### PR TITLE
add regenerate to WalletKey

### DIFF
--- a/WalletKey.js
+++ b/WalletKey.js
@@ -17,6 +17,11 @@ function ClassSpec(b) {
 		this.created = timeUtil.curtime();
 	};
 
+	WalletKey.prototype.regenerate = function() {
+		this.privKey.regenerateSync();
+		this.created = timeUtil.curtime();
+	};
+
 	WalletKey.prototype.storeObj = function() {
 		var pubKey = this.privKey.public.toString('hex');
 		var pubKeyHash = coinUtil.sha256ripe160(this.privKey.public);

--- a/test/WalletKey.js
+++ b/test/WalletKey.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var WalletKey = require('../WalletKey').class();
+
+describe('WalletKey', function(){
+  describe('#regenerate', function(){
+    it('accurately update the public key to correspond to the private key', function(){
+      var wkey=new WalletKey({'network':'testnet'});
+      wkey.generate();
+      var privstr1=wkey.privKey.private.toString('hex');
+      var pubstr1=wkey.privKey.public.toString('hex');
+      wkey.generate();
+      var privstr2=wkey.privKey.private.toString('hex');
+      var pubstr2=wkey.privKey.public.toString('hex');
+      wkey.privKey.private=new Buffer(privstr1, 'hex');
+      wkey.regenerate();
+      var privstr3=wkey.privKey.private.toString('hex');
+      var pubstr3=wkey.privKey.public.toString('hex');
+      assert.equal(privstr1,privstr3);
+      assert.equal(pubstr1,pubstr3);
+      assert.notEqual(privstr1,privstr2);
+      assert.notEqual(pubstr1,pubstr2);
+    });
+  });
+});


### PR DESCRIPTION
"regenerate", available in eckey.cc, will find the public key corresponding to
a private key. By adding this to WalletKey, this will allow us to support
private key import and brain wallets.
