### PR TITLE
remove CNAME due to build error

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-bitcore.io


### PR DESCRIPTION
"CNAME already taken: bitcore.io"
