### PR TITLE
Make Facebook sharing prettier by using image.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     <title> Bitcore </title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href='http://fonts.googleapis.com/css?family=Ubuntu+Mono|Ubuntu:300,400,500,700,400italic' rel='stylesheet' type='text/css'>
+    <meta property="og:image" content="/images/bitcore-core.png">
+    <link href="http://fonts.googleapis.com/css?family=Ubuntu+Mono|Ubuntu:300,400,500,700,400italic" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="css/normalize.css">
     <link href="css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="css/common.css">


### PR DESCRIPTION
This made me sad: 
![screenshot 2014-02-09 19 40 03](https://f.cloud.github.com/assets/129761/2122141/13824d28-9205-11e3-8dfb-7207331f0bd4.png)

So this should fix it, based on the [OGP specs](http://ogp.me/).  This might need to be an absolute URI, as opposed to the current relative one.
