### PR TITLE
Updated bufferput dependency to bitpays repository.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "classtool": "git://github.com/bitpay/classtool.git",
     "base58-native": "=0.1.3",
     "bindings": "=1.1.1",
-    "bufferput": "=0.1.1",
+    "bufferput": "git://github.com/bitpay/node-bufferput.git",
     "bignum": "=0.6.1",
     "binary": "=0.3.0",
     "step": "=0.0.4",


### PR DESCRIPTION
The referenced bufferput version is missing some important functions like "word32le".

See issue #88 for an example.

This PR changes the bufferput dependency to the bitpay repository node-bufferput used already by insight.
