### PR TITLE
remove classtool from Address, VersionedData, EncodedData

### DIFF
--- a/Address.js
+++ b/Address.js
@@ -1,22 +1,17 @@
-require('classtool');
+var superclass = require('./util/VersionedData');
+var EncodedData = require('./util/EncodedData');
 
-function ClassSpec(b) {
-  var superclass = b.superclass || require('./util/VersionedData').class();
-
-  function Address() {
-    Address.super(this, arguments);
-  }
-
-  Address.superclass = superclass;
-  superclass.applyEncodingsTo(Address);
-
-  Address.prototype.validate = function() {
-    this.doAsBinary(function() {
-      Address.super(this, 'validate', arguments);
-      if(this.data.length !== 21) throw new Error('invalid data length');
-    });
-  };
-
-  return Address;
+function Address() {
+  superclass.apply(this, arguments);
 }
-module.defineClass(ClassSpec);
+Address.prototype = new superclass();
+EncodedData.applyEncodingsTo(Address);
+
+Address.prototype.validate = function() {
+  this.doAsBinary(function() {
+    (new EncodedData()).validate.apply(this, arguments);
+    if(this.data.length !== 21) throw new Error('invalid data length');
+  });
+};
+
+module.exports = Address;

--- a/PrivateKey.js
+++ b/PrivateKey.js
@@ -1,7 +1,7 @@
 require('classtool');
 
 function ClassSpec(b) {
-  var superclass = b.superclass || require('./util/VersionedData').class();
+  var superclass = b.superclass || require('./util/VersionedData');
 
   //compressed is true if public key is compressed; false otherwise
   function PrivateKey(version, buf, compressed) {

--- a/SIN.js
+++ b/SIN.js
@@ -1,7 +1,7 @@
 require('classtool');
 
 function ClassSpec(b) {
-  var superclass = b.superclass || require('./util/VersionedData').class();
+  var superclass = b.superclass || require('./util/VersionedData');
 
 
   function SIN(type, payload) {

--- a/Transaction.js
+++ b/Transaction.js
@@ -3,7 +3,7 @@ require('classtool');
 function spec(b) {
   var config = b.config || require('./config');
   var log = b.log || require('./util/log');
-  var Address = b.Address || require('./Address').class();
+  var Address = b.Address || require('./Address');
   var Script = b.Script || require('./Script').class();
   var ScriptInterpreter = b.ScriptInterpreter || require('./ScriptInterpreter').class();
   var util = b.util || require('./util/util');

--- a/Wallet.js
+++ b/Wallet.js
@@ -4,7 +4,7 @@ var hex = function(hex) {return new Buffer(hex, 'hex');};
 function ClassSpec(b) {
   var fs = require('fs');
   var EncFile = require('./util/EncFile');
-  var Address = require('./Address').class();
+  var Address = require('./Address');
   var networks = require('./networks');
     var util = b.util || require('./util/util');
   var ENC_METHOD = 'aes-256-cbc';

--- a/WalletKey.js
+++ b/WalletKey.js
@@ -5,7 +5,7 @@ function ClassSpec(b) {
   var timeUtil = require('./util/time');
   var KeyModule = require('./Key');
   var PrivateKey = require('./PrivateKey').class();
-  var Address = require('./Address').class();
+  var Address = require('./Address');
 
   function WalletKey(cfg) {
     if (!cfg) cfg = {};

--- a/test/test.Address.js
+++ b/test/test.Address.js
@@ -6,14 +6,14 @@ var bitcore = require('../bitcore');
 var should = chai.should();
 
 var AddressModule = bitcore.Address;
-var Address;
+var Address = AddressModule;
 
 describe('Address', function() {
   it('should initialze the main object', function() {
     should.exist(AddressModule);
   });
   it('should be able to create class', function() {
-    Address = AddressModule.class();
+    Address = AddressModule;
     should.exist(Address);
   });
   it('should be able to create instance', function() {
@@ -24,6 +24,7 @@ describe('Address', function() {
     var a = new Address('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
     var m = new Address('32QBdjycLwbDTuGafUwaU5p5GxzSLPYoF6');
     var b = new Address('11111111111111111111111111122222234');
+    a.validate();
     a.validate.bind(a).should.not.throw(Error);
     m.validate.bind(m).should.not.throw(Error);
     b.validate.bind(b).should.throw(Error);

--- a/test/test.EncodedData.js
+++ b/test/test.EncodedData.js
@@ -5,15 +5,14 @@ var bitcore = require('../bitcore');
 
 var should = chai.should();
 
-var EncodedDataModule = bitcore.EncodedData;
-var EncodedData;
+var EncodedData = bitcore.EncodedData;
 
 describe('EncodedData', function() {
   it('should initialze the main object', function() {
-    should.exist(EncodedDataModule);
+    should.exist(EncodedData);
   });
   it('should be able to create class', function() {
-    EncodedData = EncodedDataModule.class();
+    EncodedData = EncodedData;
     should.exist(EncodedData);
   });
   it('should be able to create an instance', function() {

--- a/test/test.Script.js
+++ b/test/test.Script.js
@@ -6,7 +6,7 @@ var bitcore = require('../bitcore');
 var should = chai.should();
 
 var ScriptModule = bitcore.Script;
-var Address = bitcore.Address.class();
+var Address = bitcore.Address;
 var networks = bitcore.networks;
 var Script;
 

--- a/test/test.VersionedData.js
+++ b/test/test.VersionedData.js
@@ -13,7 +13,7 @@ describe('VersionedData', function() {
     should.exist(VersionedDataModule);
   });
   it('should be able to create class', function() {
-    VersionedData = VersionedDataModule.class();
+    VersionedData = VersionedDataModule;
     should.exist(VersionedData);
   });
   it('should be able to create an instance', function() {

--- a/test/test.basic.js
+++ b/test/test.basic.js
@@ -4,7 +4,7 @@ var chai = require('chai');
 var bitcore = require('../bitcore');
 var should = chai.should();
 
-var Address = bitcore.Address.class();
+var Address = bitcore.Address;
 var PrivateKey = bitcore.PrivateKey.class();
 var networks = bitcore.networks;
 var KeyModule = bitcore.KeyModule;

--- a/util/EncodedData.js
+++ b/util/EncodedData.js
@@ -1,159 +1,155 @@
-require('classtool');
+var base58 = require('base58-native').base58Check;
 
-function ClassSpec(b) {
-  var base58 = b.base58 || require('base58-native').base58Check;
-
-  // Constructor.  Takes the following forms:
-  //   new EncodedData(<base58_address_string>)
-  //   new EncodedData(<binary_buffer>)
-  //   new EncodedData(<data>, <encoding>)
-  //   new EncodedData(<version>, <20-byte-hash>)
-  function EncodedData(data, encoding) {
-    this.data = data;
-    if(!encoding && (typeof data == 'string')) {
-      this.__proto__ = this.encodings['base58'];
-    } else {
-      this.__proto__ = this.encodings[encoding || 'binary'];
-    }
-  };
-
-  // get or set the encoding used (transforms data)
-  EncodedData.prototype.encoding = function(encoding) {
-    if(encoding && (encoding != this._encoding)) {
-      this.data = this.as(encoding);
-      this.__proto__ = this.encodings[encoding];
-    }
-    return this._encoding;
-  };
-
-  // answer a new instance having the given encoding
-  EncodedData.prototype.withEncoding = function(encoding) {
-    return new EncodedData(this.as(encoding), encoding);
-  };
-
-  // answer the data in the given encoding
-  EncodedData.prototype.as = function(encoding) {
-    if(!encodings[encoding]) throw new Error('invalid encoding');
-    return this.converters[encoding].call(this);
-  };
-
-  // validate that we can convert to binary
-  EncodedData.prototype._validate = function() {
-    this.withEncoding('binary');
-  };
-
-  // Boolean protocol for testing if valid
-  EncodedData.prototype.isValid = function() {
-    try {
-      this.validate();
-      return true;
-    } catch(e) {
-      return false;
-    }
-  };
-
-  // subclasses can override to do more stuff
-  EncodedData.prototype.validate = function() {
-    this._validate();
-  };
-
-  // Boolean protocol for testing if valid
-  EncodedData.prototype.isValid = function() {
-    try {
-      this.validate();
-      return true;
-    } catch(e) {
-      return false;
-    }
-  };
-
-  // convert to a string (in base58 form)
-  EncodedData.prototype.toString = function() {
-    return this.as('base58');
-  };
-
-  // utility
-  EncodedData.prototype.doAsBinary = function(callback) {
-    var oldEncoding = this.encoding();
-    this.encoding('binary');
-    callback.apply(this);
-    this.encoding(oldEncoding);
-  };
-
-  // Setup support for various address encodings.  The object for
-  // each encoding inherits from the EncodedData prototype.  This
-  // allows any encoding to override any method...changing the encoding
-  // for an instance will change the encoding it inherits from.  Note,
-  // this will present some problems for anyone wanting to inherit from
-  // EncodedData (we'll deal with that when needed).
-  var encodings = {
-    'binary': {
-      converters: {
-        'binary': function() {
-          var answer = new Buffer(this.data.length);
-          this.data.copy(answer);
-          return answer;
-        },
-        'base58': function() {
-          return base58.encode(this.data);
-        },
-        'hex': function() {
-          return this.data.toString('hex');
-        },
-      },
-
-      _validate: function() {
-        //nothing to do here...we make no assumptions about the data
-      },
-    },
-
-    'base58': {
-      converters: {
-        'binary': function() {
-          return base58.decode(this.data);
-        },
-        'hex': function() {
-          return this.withEncoding('binary').as('hex');
-        },
-      },
-    },
-
-    'hex': {
-      converters: {
-        'binary': function() {
-          return new Buffer(this.data, 'hex');
-        },
-        'base58': function() {
-          return this.withEncoding('binary').as('base58');
-        },
-      },
-    },
-  };
-
-  var no_conversion = function() {return this.data;};
-  for(var k in encodings) {
-    if(encodings.hasOwnProperty(k)){
-      if(!encodings[k].converters[k])
-        encodings[k].converters[k] = no_conversion;
-      encodings[k]._encoding = k;
-    }
+// Constructor.  Takes the following forms:
+//   new EncodedData(<base58_address_string>)
+//   new EncodedData(<binary_buffer>)
+//   new EncodedData(<data>, <encoding>)
+//   new EncodedData(<version>, <20-byte-hash>)
+function EncodedData(data, encoding) {
+  this.data = data;
+  if(!encoding && (typeof data == 'string')) {
+    this.__proto__ = this.encodings['base58'];
+  } else {
+    this.__proto__ = this.encodings[encoding || 'binary'];
   }
+};
 
-  EncodedData.applyEncodingsTo = function(aClass) {
-    var tmp = {};
-    for(var k in encodings) {
-      var enc = encodings[k];
-      var obj = {};
-      for(var j in enc) {
-        obj[j] = enc[j];
-      }
-      obj.__proto__ = aClass.prototype;
-      tmp[k] = obj;
-    }
-    aClass.prototype.encodings = tmp;
-  };
+// get or set the encoding used (transforms data)
+EncodedData.prototype.encoding = function(encoding) {
+  if(encoding && (encoding != this._encoding)) {
+    this.data = this.as(encoding);
+    this.__proto__ = this.encodings[encoding];
+  }
+  return this._encoding;
+};
 
-  EncodedData.applyEncodingsTo(EncodedData);
-  return EncodedData;
+// answer a new instance having the given encoding
+EncodedData.prototype.withEncoding = function(encoding) {
+  return new EncodedData(this.as(encoding), encoding);
+};
+
+// answer the data in the given encoding
+EncodedData.prototype.as = function(encoding) {
+  if(!encodings[encoding]) throw new Error('invalid encoding');
+  return this.converters[encoding].call(this);
+};
+
+// validate that we can convert to binary
+EncodedData.prototype._validate = function() {
+  this.withEncoding('binary');
+};
+
+// Boolean protocol for testing if valid
+EncodedData.prototype.isValid = function() {
+  try {
+    this.validate();
+    return true;
+  } catch(e) {
+    return false;
+  }
+};
+
+// subclasses can override to do more stuff
+EncodedData.prototype.validate = function() {
+  this._validate();
+};
+
+// Boolean protocol for testing if valid
+EncodedData.prototype.isValid = function() {
+  try {
+    this.validate();
+    return true;
+  } catch(e) {
+    return false;
+  }
+};
+
+// convert to a string (in base58 form)
+EncodedData.prototype.toString = function() {
+  return this.as('base58');
+};
+
+// utility
+EncodedData.prototype.doAsBinary = function(callback) {
+  var oldEncoding = this.encoding();
+  this.encoding('binary');
+  callback.apply(this);
+  this.encoding(oldEncoding);
+};
+
+// Setup support for various address encodings.  The object for
+// each encoding inherits from the EncodedData prototype.  This
+// allows any encoding to override any method...changing the encoding
+// for an instance will change the encoding it inherits from.  Note,
+// this will present some problems for anyone wanting to inherit from
+// EncodedData (we'll deal with that when needed).
+var encodings = {
+  'binary': {
+    converters: {
+      'binary': function() {
+        var answer = new Buffer(this.data.length);
+        this.data.copy(answer);
+        return answer;
+      },
+      'base58': function() {
+        return base58.encode(this.data);
+      },
+      'hex': function() {
+        return this.data.toString('hex');
+      },
+    },
+
+    _validate: function() {
+      //nothing to do here...we make no assumptions about the data
+    },
+  },
+
+  'base58': {
+    converters: {
+      'binary': function() {
+        return base58.decode(this.data);
+      },
+      'hex': function() {
+        return this.withEncoding('binary').as('hex');
+      },
+    },
+  },
+
+  'hex': {
+    converters: {
+      'binary': function() {
+        return new Buffer(this.data, 'hex');
+      },
+      'base58': function() {
+        return this.withEncoding('binary').as('base58');
+      },
+    },
+  },
+};
+
+var no_conversion = function() {return this.data;};
+for(var k in encodings) {
+  if(encodings.hasOwnProperty(k)){
+    if(!encodings[k].converters[k])
+      encodings[k].converters[k] = no_conversion;
+    encodings[k]._encoding = k;
+  }
 }
-module.defineClass(ClassSpec);
+
+EncodedData.applyEncodingsTo = function(aClass) {
+  var tmp = {};
+  for(var k in encodings) {
+    var enc = encodings[k];
+    var obj = {};
+    for(var j in enc) {
+      obj[j] = enc[j];
+    }
+    obj.__proto__ = aClass.prototype;
+    tmp[k] = obj;
+  }
+  aClass.prototype.encodings = tmp;
+};
+
+EncodedData.applyEncodingsTo(EncodedData);
+
+module.exports = EncodedData;

--- a/util/VersionedData.js
+++ b/util/VersionedData.js
@@ -1,39 +1,36 @@
-require('classtool');
+var superclass = require('./EncodedData');
 
-function ClassSpec(b) {
-  var superclass = b.superclass || require('./EncodedData').class();
-
-  function VersionedData(version, payload) {
-    if(typeof version != 'number') {
-      VersionedData.super(this, arguments);
-      return;
-    };
-    this.data = new Buffer(payload.length + 1);
-    this.__proto__ = this.encodings['binary'];
-    this.version(version);
-    this.payload(payload);
+function VersionedData(version, payload) {
+  if(typeof version != 'number') {
+    superclass.apply(this, arguments);
+    return;
   };
-  VersionedData.superclass = superclass;
-  superclass.applyEncodingsTo(VersionedData);
-
-  // get or set the version data (the first byte of the address)
-  VersionedData.prototype.version = function(num) {
-    if(num || (num === 0)) {
-      this.doAsBinary(function() {this.data.writeUInt8(num, 0);});
-      return num;
-    }
-    return this.as('binary').readUInt8(0);
-  };
-
-  // get or set the payload data (as a Buffer object)
-  VersionedData.prototype.payload = function(data) {
-    if(data) {
-      this.doAsBinary(function() {data.copy(this.data,1);});
-      return data;
-    }
-    return this.as('binary').slice(1);
-  };
-
-  return VersionedData;
+  this.data = new Buffer(payload.length + 1);
+  this.__proto__ = this.encodings['binary'];
+  this.version(version);
+  this.payload(payload);
 };
-module.defineClass(ClassSpec);
+VersionedData.prototype = new superclass();
+VersionedData.applyEncodingsTo = superclass.applyEncodingsTo;
+superclass.applyEncodingsTo(VersionedData);
+
+// get or set the version data (the first byte of the address)
+VersionedData.prototype.version = function(num) {
+  if(num || (num === 0)) {
+    this.doAsBinary(function() {this.data.writeUInt8(num, 0);});
+    return num;
+  }
+  return this.as('binary').readUInt8(0);
+};
+
+// get or set the payload data (as a Buffer object)
+VersionedData.prototype.payload = function(data) {
+  if(data) {
+    this.doAsBinary(function() {data.copy(this.data,1);});
+    return data;
+  }
+  return this.as('binary').slice(1);
+};
+
+module.exports = VersionedData;
+


### PR DESCRIPTION
Classtool provides two particularly useful features: 1) allowing to overload dependencies in a class, 2) allowing a default instance of a class. However, it is unfriendly to new developers. One solution to this is to make classtool itself a little bit friendlier, as in @gasteve's soop. Another solution, explored here, is to remove classtool and rely on more traditional solutions to the same problems that do not require any dependencies at all.

In this PR I have removed classtool from Address, VersionedData, and EncodedData, which are all related classes. I have also updated the code to fix all tests. I have not removed classtool from other classes. The purpose of this PR is to demonstrate the feasibility of removing classtool and spark a discussion about removing classtool in the interests of making bitcore more friendly to new developers. This PR should not actually be pulled in unless we can all agree that removing classtool is the best option, and in that case the entire codebase should be updated to remove the classtool dependency.

For the record, here is an example of code that overloads dependencies of a class in a way that does not require classtool and is familiar to all javascript developers. The dependency being overloaded here is the database, which is replaced with a mockup database for the purpose of a test:

```
var sinon = require('sinon')
var assert = require('assert')

var Database = function() {
}

Database.prototype.query = function() {
  return 'herp'
}

var Person = function() {
  this.database = new Database()
}

Person.prototype.getName = function() {
  return this.database.query()
}

it("returns the return value from the original function", function () {
  var person = new Person()
  var database = {};

  database.query = function() {
    return 'derp';
  };
  person.database = database;

  assert.equal('derp', person.getName())
})

it("returns the return value from the original function", function () {
  var person = new Person()
  assert.equal('herp', person.getName())
})
```

Hat tip to @kyledrake for suggesting this option and writing some proof-of-concept code.
