### PR TITLE
Change `new Address` to `Address.new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var addrStrings = [
   "A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx",
   "1600 Pennsylvania Ave NW",
 ].map(function(addr) {
-  return new Address(addr);
+  return Address.new(addr);
 });
 
 addrStrings.forEach(function(addr) {
@@ -144,7 +144,7 @@ var createTx = function() {
   txin.o = Buffer.concat([hash, voutBuf]);
   txobj.ins.push(txin);
 
-  var addr     = new Address(ADDR);
+  var addr     = Address.new(ADDR);
   var script   = Script.createPubKeyHashOut(addr.payload());
   var valueNum = coinUtil.parseValue(VAL);
   var value    = coinUtil.bigIntToValue(valueNum);
@@ -226,21 +226,21 @@ Gets an address strings from a  ScriptPubKey Buffer
     switch (type) {
       case Script.TX_PUBKEY:
         var chunk = s.captureOne();
-        addr = new Address(network.addressPubkey, coinUtil.sha256ripe160(chunk));
+        addr = Address.new(network.addressPubkey, coinUtil.sha256ripe160(chunk));
         addrStrs.push(addr.toString());
         break;
       case Script.TX_PUBKEYHASH:
-        addr = new Address(network.addressPubkey, s.captureOne());
+        addr = Address.new(network.addressPubkey, s.captureOne());
         addrStrs.push(addr.toString());
         break;
       case Script.TX_SCRIPTHASH:
-        addr = new Address(network.addressScript, s.captureOne());
+        addr = Address.new(network.addressScript, s.captureOne());
         addrStrs.push(addr.toString());
         break;
       case Script.TX_MULTISIG:
         var chunks = s.capture();
         chunks.forEach(function(chunk) {
-          var a = new Address(network.addressPubkey, coinUtil.sha256ripe160(chunk));
+          var a = Address.new(network.addressPubkey, coinUtil.sha256ripe160(chunk));
           addrStrs.push(a.toString());
         });
         break;


### PR DESCRIPTION
Documentation says `new Address(...)` but following the examples produces

```
  return new Address(addr);
         ^
TypeError: object is not a function
    at /Users/johnbackus/bitcore-testing/validate-example-broken.js:9:10
    at Array.map (native)
    at Object.<anonymous> (/Users/johnbackus/bitcore-testing/validate-example-broken.js:8:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:901:3
```

Changing `new Address` to `Address.new` fixes this.  From the "Validating an address" example:

``` shell
    $ node validate-example-broken.js

    /Users/johnbackus/bitcore-testing/validate-example-broken.js:9
      return new Address(addr);
             ^
    TypeError: object is not a function
        at /Users/johnbackus/bitcore-testing/validate-example-broken.js:9:10
        at Array.map (native)
        at Object.<anonymous> (/Users/johnbackus/bitcore-testing/validate-example-broken.js:8:3)
        at Module._compile (module.js:456:26)
        at Object.Module._extensions..js (module.js:474:10)
        at Module.load (module.js:356:32)
        at Function.Module._load (module.js:312:12)
        at Function.Module.runMain (module.js:497:10)
        at startup (node.js:119:16)
        at node.js:901:3

    $ node validate-example-fix.js
    1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa: is valid
    1A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx: is not a valid address. Error: checksum mismatch
    A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx: is not a valid address. Error: checksum mismatch
    1600 Pennsylvania Ave NW: is not a valid address. TypeError: Unspecified operation for type undefined for add

    $ diff validate-example-broken.js validate-example-fix.js
    9c9
    <   return new Address(addr);
    ---
    >   return Address.new(addr);
```
