### PR TITLE
Idiomatic address use

### DIFF
--- a/Address.js
+++ b/Address.js
@@ -9,12 +9,16 @@ function Address() {
 Address.parent = parent;
 parent.applyEncodingsTo(Address);
 
+
 Address.prototype.validate = function() {
-  var answer;
   this.doAsBinary(function() {
     Address.super(this, 'validate', arguments);
-    answer = (this.data.length === 21);
+    if(this.data.length !== 21) throw new Error('invalid data length');
   });
+};
+
+Address.prototype.isValid = function() {
+  var answer = Address.super(this, 'isValid', arguments);
   return answer;
 };
 

--- a/README.md
+++ b/README.md
@@ -31,26 +31,19 @@ Validating a Bitcoin address:
 ```js
 var Address = require('bitcore/Address');
 
-var addrStrings = [
-  "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
-  "1A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx",
-  "A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx",
-  "1600 Pennsylvania Ave NW",
+var addrs = [
+  '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+  '1A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx',
+  'A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+  '1600 Pennsylvania Ave NW',
 ].map(function(addr) {
   return new Address(addr);
 });
 
-addrStrings.forEach(function(addr) {
-
-  try {
-    addr.validate();
-    console.log(addr.data + ": is valid");
-  } catch(e) {
-    console.log(addr.data + ": is not a valid address. " + e);
-  }
-
+addrs.forEach(function(addr) {
+  var valid = addr.isValid();
+  console.log(addr.data + ' is ' + (valid ? '' : 'not ') + 'valid');
 });
-
 ```
 ## Monitoring Blocks and Transactions
 For this example you need a running bitcoind instance with RPC enabled. 

--- a/examples/Address.js
+++ b/examples/Address.js
@@ -4,22 +4,16 @@
 
 var Address = require('../Address');
 
-var addrStrings = [
-  "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
-  "1A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx",
-  "A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx",
-  "1600 Pennsylvania Ave NW",
+var addrs = [
+  '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+  '1A1zP1eP5QGefi2DMPTfTL5SLmv7Dixxxx',
+  'A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+  '1600 Pennsylvania Ave NW',
 ].map(function(addr) {
   return new Address(addr);
 });
 
-addrStrings.forEach(function(addr) {
-
-  try {
-    addr.validate();
-    console.log(addr.data + ": is valid");
-  } catch(e) {
-    console.log(addr.data + ": is not a valid address. " + e);
-  }
-
+addrs.forEach(function(addr) {
+  var valid = addr.isValid();
+  console.log(addr.data + ' is ' + (valid ? '' : 'not ') + 'valid');
 });

--- a/test/test.Address.js
+++ b/test/test.Address.js
@@ -20,21 +20,31 @@ describe('Address', function() {
     var a = new Address('1KfyjCgBSMsLqiCbakfSdeoBUqMqLUiu3T');
     should.exist(a);
   });
-  it('should validate correctly', function() {
-    var a = new Address('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
-    var m = new Address('32QBdjycLwbDTuGafUwaU5p5GxzSLPYoF6');
-    var b = new Address('11111111111111111111111111122222234');
-    a.validate.bind(a).should.not.throw(Error);
-    m.validate.bind(m).should.not.throw(Error);
-    b.validate.bind(b).should.not.throw(Error);
+  var data = [
+    ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', true],
+    ['11111111111111111111111111122222234', false], // totally invalid
+    ['32QBdjycLwbDTuGafUwaU5p5GxzSLPYoF6', true],
+    ['1Q1pE5vPGEEMqRcVRMbtBK842Y6Pzo6nK9', true],
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i', true],
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW600', false],  // bad checksum
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW620', false],  // bad checksum
+    ['1ANNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i', false],  // data changed, original checksum.
+    ['1A Na15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i', false],  // invalid chars
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62j', false],  // checksums don't match.
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62!', false],  // bad char (!)
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62iz', false], // too long Bitcoin address
+    ['1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62izz', false],// too long Bitcoin address
+    ['2cFupjhnEsSn59qHXstmK2ffpLv2', false],        // valid base58 invalid data
+  ];
+  data.forEach(function(datum) {
+    var address = datum[0];
+    var result = datum[1];
+    it('should validate correctly ' + address, function() {
+      var a = new Address(address);
+      var s = a.toString();
 
-    a.validate().should.equal(true);
-    m.validate().should.equal(true);
-    b.validate().should.equal(false);
+      a.isValid().should.equal(result);
+      s.should.equal(a.toString()); // check that validation doesn't change data
+    });
   });
 });
-
-
-
-
-


### PR DESCRIPTION
Various community members expressed (https://github.com/bitpay/bitcore/issues/104, https://github.com/bitpay/bitcore/issues/84) the need to have a simpler way of validating Address objects in bitcore. The current validate() method throwed exceptions when encountering an invalid address, which is not the easiest way to access the functionality and adds extra lines of code.

This adds an isValid method and tests for it. The default way of validating addresses should be via this method (examples updated). 
