### PR TITLE
add index.js for node requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-bitcore.js

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "currency",
     "virtual"
   ],
+  "main": "bitcore.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/bitpay/bitcore.git"


### PR DESCRIPTION
adding a index.js files allows to require like this (in node):

```
var bitcore = require('bitcore');
var addr     = new bitcore.Address('xx');
```

instead of:

```
var bitcore = require('bitcore/bitcore');
var addr     = new bitcore.Address('xx');
```

from projects outside bitcore itself.
