### PR TITLE
fix .load

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@ console.log(addr.isValid());
 var bitcore = require('bitcore');
 var networks = bitcore.networks;
 var Peer = bitcore.Peer;
-var PeerManager = require('soop').load('./node_modules/bitcore/PeerManager', {
+var PeerManager = require('soop').load('bitcore/PeerManager', {
   network: networks.testnet
 });
 
@@ -154,7 +154,7 @@ var Transaction = bitcore.Transaction;
 var Address = bitcore.Address;
 var Script = bitcore.Script;
 var coinUtil = bitcore.util;
-var PeerManager = require('soop').load('./node_modules/bitcore/PeerManager', {
+var PeerManager = require('soop').load('bitcore/PeerManager', {
   network: networks.testnet
 });
 


### PR DESCRIPTION
Incorrect file name corrected. This makes the examples using PeerManager work, assuming you run them from a directory where node_modules/bitcore exists.
