### PR TITLE
soop may not be in the bitcore directory

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -40,7 +40,9 @@ if (!program.includeall && (!program.submodules || program.submodules.length ===
 }
 
 var pack = function (params) {
-  var preludePath  = 'node_modules/soop/example/custom_prelude.js';
+  var file = require.resolve('soop');
+  var dir = file.substr(0, file.length - String('soop.js').length);
+  var preludePath = dir + 'example/custom_prelude.js';
   params.raw = true;
   params.sourceMapPrefix = '//#';
   params.prelude = fs.readFileSync(preludePath, 'utf8');


### PR DESCRIPTION
If bitcore is being built inside of another project that uses soop, soop may
not be in the bitcore directory. We need to find the location of soop and then
find the custom_prelude script relative to that.
