### PR TITLE
Allow stringToBuffer to parse hex without preceding length byte

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -496,8 +496,16 @@ Script.stringToBuffer = function(s) {
     if (word === '') continue;
     if (word.length > 2 && word.substring(0, 2) === '0x') {
       // raw hex value
-      //console.log('hex value');
-      buf.put(new Buffer(word.substring(2, word.length), 'hex'));
+      var wordBuf = new Buffer(word.substring(2, word.length), 'hex');
+      var lenBuf = encodeLen(wordBuf.length);
+
+      // if the string being parsed is an output of toHumanReadble,
+      // it will already have a length byte. don't push it twice
+      if (split[i - 1] && split[i - 1] !== '0x' + lenBuf.toString('hex')) {
+        buf.put(lenBuf);
+      }
+
+      buf.put(wordBuf);
     } else {
       var opcode = Opcode.map['OP_' + word];
       if (typeof opcode !== 'undefined') {


### PR DESCRIPTION
Script.stringToBuffer, given the following script

```
DUP HASH160 0x8f90da6b92b76c353cec6b8876d1bc004b6f1fd9 EQUALVERIFY CHECKSIG
```

would erroneously parse it as

```
{ buffer: <Buffer 76 a9 8f 90 da 6b 92 b7 6c 35 3c ec 6b 88 76 d1 bc 00 4b 6f 1f d9 88 ac>,
  chunks:
   [ 118,
     169,
     143,
     144,
     218,
     107,
     146,
     183,
     108,
     <Buffer 3c ec 6b 88 76 d1 bc 00 4b 6f 1f d9 88 ac> ] }
```

or as the output of toHumanReadable,

```
DUP HASH160 NEGATE ABS 0xda TOALTSTACK 0NOTEQUAL NOP8 FROMALTSTACK 0x0e 0x3cec6b8876d1bc004b6f1fd988ac
```

It was assuming that because there was an `0x` in front of the string it was an output of toHumanReadable and there would be a preceding length chunk. My change pushes the length chunk if it isn't already there.

My database currently has scripts in the form of my input example <sup>which I know I shouldn't be doing</sup> and this change was easier than running a query over gigabytes of data to remove `0x`. I suppose it isn't an important change for the project - no worries if you don't want to merge.

I would have written tests, but you guys don't have any docs and I'm eating pizza.
