### PR TITLE
update version to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitcore",
   "description": "Bitcoin Library",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {
     "name": "Stephen Pair",
     "email": "stephen@bitpay.com"


### PR DESCRIPTION
Changes since version 0.1.7
- Key interface is now bitcore.Key, not bitcore.KeyModule.Key
  *\* bitcore.KeyModule is deprecated
- Examples of signing transactions
- Refactor browser building
- Bug fixes
