### PR TITLE
add isCanonicalSignature check to script interpreter and tests

### DIFF
--- a/test/test.ScriptInterpreter.js
+++ b/test/test.ScriptInterpreter.js
@@ -42,6 +42,30 @@ describe('ScriptInterpreter', function() {
       );
     });
   });
+
+  var i = 0;
+  testdata.dataSigCanonical.forEach(function(datum) {
+    it('should validate valid canonical signatures', function() {
+      ScriptInterpreter.isCanonicalSignature(new Buffer(datum,'hex')).should.equal(true);
+    });
+  });
+   testdata.dataSigNonCanonical.forEach(function(datum) {
+    it('should NOT validate invalid canonical signatures', function() {
+
+      var sig;
+      var isHex;
+      //is Hex?
+      try {
+        sig =new Buffer(datum,'hex');
+        isHex=1;
+      } catch (e) { }
+
+      if (isHex)
+        ScriptInterpreter.isCanonicalSignature.bind(sig).should.throw();
+    });
+  });
+ 
+
 });
 
 

--- a/test/testdata.js
+++ b/test/testdata.js
@@ -7,6 +7,8 @@ var dataTxValid = JSON.parse(fs.readFileSync('test/data/tx_valid.json'));
 var dataTxInvalid = JSON.parse(fs.readFileSync('test/data/tx_invalid.json'));
 var dataScriptValid = JSON.parse(fs.readFileSync('test/data/script_valid.json'));
 var dataScriptInvalid = JSON.parse(fs.readFileSync('test/data/script_invalid.json'));
+var dataSigCanonical = JSON.parse(fs.readFileSync('test/data/sig_canonical.json'));
+var dataSigNonCanonical = JSON.parse(fs.readFileSync('test/data/sig_noncanonical.json'));
 
 module.exports.dataValid = dataValid;
 module.exports.dataInvalid = dataInvalid;
@@ -16,3 +18,6 @@ module.exports.dataTxInvalid = dataTxInvalid;
 module.exports.dataScriptValid = dataScriptValid;
 module.exports.dataScriptInvalid = dataScriptInvalid;
 module.exports.dataScriptAll = dataScriptValid.concat(dataScriptInvalid);
+
+module.exports.dataSigCanonical = dataSigCanonical;
+module.exports.dataSigNonCanonical = dataSigNonCanonical;


### PR DESCRIPTION
This one adds isCannonicalSignature checks for the script interpreter. Pass the original bitcoind test
