### PR TITLE
add try-catch in each script processing in getStandarizedObject

### DIFF
--- a/Transaction.js
+++ b/Transaction.js
@@ -577,7 +577,12 @@ Transaction.prototype.getStandardizedObject = function getStandardizedObject() {
     if (txin.isCoinBase()) {
       txinObj.coinbase = txin.s.toString('hex');
     } else {
-      txinObj.scriptSig = new Script(txin.s).getStringContent(false, 0);
+
+      try {
+        txinObj.scriptSig = new Script(txin.s).getStringContent(false, 0);
+      } catch (e) {
+        log.warn(e.msg);     /* log the error, and continue */
+      }
     }
     totalSize += 36 + util.getVarIntSize(txin.s.length) +
       txin.s.length + 4; // outpoint + script_len + script + sequence
@@ -588,9 +593,17 @@ Transaction.prototype.getStandardizedObject = function getStandardizedObject() {
   var outs = this.outs.map(function (txout) {
     totalSize += util.getVarIntSize(txout.s.length) +
       txout.s.length + 8; // script_len + script + value
+
+    var s;
+    try {
+      s = new Script(txout.s).getStringContent(false, 0);
+    } catch (e) {
+      log.warn(e.msg);     /* log the error, and continue */
+    }
+
     return {
       value: util.formatValue(txout.v),
-      scriptPubKey: new Script(txout.s).getStringContent(false, 0)
+      scriptPubKey: s,
     };
   });
 


### PR DESCRIPTION
This add a try-catch block when processing scripts within a transaction in getStandarizedObject.

This prevents getStandarizedObject to stop if it found a broken / malformed / unknown script with in a TX. Needed for insight and blockchain processing. Related to https://github.com/bitpay/bitcore/issues/180

Just for reference, This error appear ~ 15 times in the testnet as it is today.
