### PR TITLE
fix browser tests for Point and Key

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -28,6 +28,7 @@
     <script src="test.Opcode.js"></script>
     <script src="test.Peer.js"></script>
     <script src="test.PeerManager.js"></script>
+    <script src="test.Point.js"></script>
     <script src="test.PrivateKey.js"></script>
     <script src="test.RpcClient.js"></script>
     <script src="test.Script.js"></script>

--- a/test/test.Key.js
+++ b/test/test.Key.js
@@ -1,12 +1,11 @@
-'use strict';
 
-var assert = require('assert');
 var chai = chai || require('chai');
 var bitcore = bitcore || require('../bitcore');
-var coinUtil = coinUtil || require('../util/util');
+var coinUtil = coinUtil || bitcore.util;
 var buffertools = require('buffertools');
 
 var should = chai.should();
+var assert = chai.assert;
 
 var Key = bitcore.Key;
 describe('Key', function() {
@@ -115,52 +114,57 @@ describe('Key', function() {
     ret.should.equal(false);
   });
 
-  describe('#addUncompressed', function() {
-    it('should exist', function() {
-      should.exist(Key.addUncompressed);
-    });
 
-    it('should add two uncompressed public keys', function() {
-      var key1 = Key.generateSync();
-      key1.compressed = false;
-      var key2 = Key.generateSync();
-      key2.compressed = false;
-      var pubkey1 = key1.public;
-      var pubkey2 = key2.public;
-      var pubkey = Key.addUncompressed(pubkey1, pubkey2);
-      pubkey.length.should.equal(65);
-    });
+  //node tests only
+  //addUncompressed is a node-only interface feature
+  if (typeof process !== 'undefined' && process.versions) {
+    describe('#addUncompressed', function() {
+      it('should exist', function() {
+        should.exist(Key.addUncompressed);
+      });
 
-    it('a + b should equal b + a', function() {
-      var key1 = Key.generateSync();
-      key1.compressed = false;
-      var key2 = Key.generateSync();
-      key2.compressed = false;
-      var pubkey1 = key1.public;
-      var pubkey2 = key2.public;
-      var r1 = Key.addUncompressed(pubkey1, pubkey2);
-      var r2 = Key.addUncompressed(pubkey2, pubkey1);
-      r1.toString('hex').should.equal(r2.toString('hex'));
-    });
+      it('should add two uncompressed public keys', function() {
+        var key1 = Key.generateSync();
+        key1.compressed = false;
+        var key2 = Key.generateSync();
+        key2.compressed = false;
+        var pubkey1 = key1.public;
+        var pubkey2 = key2.public;
+        var pubkey = Key.addUncompressed(pubkey1, pubkey2);
+        pubkey.length.should.equal(65);
+      });
 
-    it('should be able to add these two public keys without error', function() {
-      var key1 = new Key();
-      key1.private = coinUtil.sha256("first " + 3);
-      key1.compressed = false;
-      key1.regenerateSync();
-      var key2 = new Key();
-      key2.private = coinUtil.sha256("second " + 3);
-      key2.compressed = false;
-      key2.regenerateSync();
-      var pubkey1 = key1.public;
-      var pubkey2 = key2.public;
-      var pubkey = Key.addUncompressed(pubkey1, pubkey2);
-      pubkey.length.should.equal(65);
-      var key = new Key();
-      key.public = pubkey;
-      assert(key.public !== null);
-    });
+      it('a + b should equal b + a', function() {
+        var key1 = Key.generateSync();
+        key1.compressed = false;
+        var key2 = Key.generateSync();
+        key2.compressed = false;
+        var pubkey1 = key1.public;
+        var pubkey2 = key2.public;
+        var r1 = Key.addUncompressed(pubkey1, pubkey2);
+        var r2 = Key.addUncompressed(pubkey2, pubkey1);
+        r1.toString('hex').should.equal(r2.toString('hex'));
+      });
 
-  });
+      it('should be able to add these two public keys without error', function() {
+        var key1 = new Key();
+        key1.private = coinUtil.sha256("first " + 3);
+        key1.compressed = false;
+        key1.regenerateSync();
+        var key2 = new Key();
+        key2.private = coinUtil.sha256("second " + 3);
+        key2.compressed = false;
+        key2.regenerateSync();
+        var pubkey1 = key1.public;
+        var pubkey2 = key2.public;
+        var pubkey = Key.addUncompressed(pubkey1, pubkey2);
+        pubkey.length.should.equal(65);
+        var key = new Key();
+        key.public = pubkey;
+        assert(key.public !== null);
+      });
+
+    });
+  }
 
 });

--- a/test/test.Point.js
+++ b/test/test.Point.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var assert = require('assert');
 var chai = chai || require('chai');
 var bitcore = bitcore || require('../bitcore');
-var coinUtil = coinUtil || require('../util/util');
+var coinUtil = coinUtil || bitcore.util;
 var buffertools = require('buffertools');
 var bignum = require('bignum');
 
 var should = chai.should();
+var assert = chai.assert;
 
 var Point = bitcore.Point;
 var Key = bitcore.Key;


### PR DESCRIPTION
The addUncompressed function is for node-only, and is a temporary workaround
until we expose a better crypto interface in both node and the browser. I wrote
tests for this function that were node-only, but were broken in the browser.  I
also wrote tests for the Point class that should have worked in both node and
the browser, and did, but I was using the wrong module such that it worked only
in node.  This update makes the tests work in the browser by using the correct
module.
