### PR TITLE
add p2sh support and test

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -490,7 +490,25 @@ Script.prototype.toHumanReadable = function() {
     }
   }
   return s;
+};
 
+Script.prototype.countMissingSignatures = function() {
+  var ret = 0;
+  if (!Buffer.isBuffer(this.chunks[0]) && this.chunks[0] ===0) {
+    // Multisig, skip first 0x0 
+    for (var i = 1; i < this.chunks.length; i++) {
+      if (this.chunks[i]===0 
+          || buffertools.compare(this.chunks[i], util.EMPTY_BUFFER) === 0){
+        ret++;
+      }
+    }
+  }
+  else {
+    if (buffertools.compare(this.getBuffer(), util.EMPTY_BUFFER) === 0) {
+      ret = 1;
+    }
+  }
+  return ret;
 };
 
 Script.stringToBuffer = function(s) {

--- a/Transaction.js
+++ b/Transaction.js
@@ -552,28 +552,28 @@ Transaction.prototype.getSize = function getHash() {
   return this.size;
 };
 
+
+Transaction.prototype.countInputMissingSignatures = function(index) {
+  var ret = 0;
+  var script = new Script(this.ins[index].s);
+  return script.countMissingSignatures();
+};
+
+
+Transaction.prototype.isInputComplete = function(index) {
+  return this.countInputMissingSignatures(index)===0;
+};
+
 Transaction.prototype.isComplete = function() {
   var ret = true;
   var l   = this.ins.length;
 
   for (var i = 0; i < l; i++) {
-    var script = new Script(this.ins[i].s);
-    // Multisig?
-    if (!Buffer.isBuffer(script.chunks[0]) && script.chunks[0] ===0) {
-      for (var i = 1; i < script.chunks.length; i++) {
-        if (buffertools.compare(script.chunks[i], util.EMPTY_BUFFER) === 0){
-          ret = false;
-          break;
-        }
-      }
+    if (!this.isInputComplete(i)){
+      ret = false;
+      break;
     }
-    else {
-      if (buffertools.compare(this.ins[i].s, util.EMPTY_BUFFER) === 0) {
-        ret = false;
-        break;
-      }
-    }
-  };
+  }
 
   return ret;
 };

--- a/examples/CreateAndSignTx-Multisig.js
+++ b/examples/CreateAndSignTx-Multisig.js
@@ -17,11 +17,11 @@ var run = function() {
   var utxos = [
     {
     address: input.addr,
-    txid: "a2a1b0bfbbe769253787d83c097adf61e6d77088e295249e9c3f1ca8a035c639",
-    vout: 0,
+    txid: "39c71ebda371f75f4b854a720eaf9898b237facf3c2b101b58cd4383a44a6adc",
+    vout: 1,
     ts: 1396288753,
     scriptPubKey: "76a914e867aad8bd361f57c50adc37a0c018692b5b0c9a88ac",
-    amount: 0.63,
+    amount: 0.4296,
     confirmations: 2
   }
   ];
@@ -50,7 +50,7 @@ var run = function() {
     .build();
   var txHex =  tx.serialize().toString('hex');
   console.log('1) SEND TO MULSISIG TX: ', txHex);
-  console.log('[this example originally generated TXID: ff5c8b4912f6d056f0cf8431ec27032a73df22c167726267dd4cc0d7817a1e7d on testnet]\n\n\thttp://test.bitcore.io/tx/ff5c8b4912f6d056f0cf8431ec27032a73df22c167726267dd4cc0d7817a1e7d\n\n');
+  console.log('[this example originally generated TXID: e4bc22d8c519d3cf848d710619f8480be56176a4a6548dfbe865ab3886b578b5 on testnet]\n\n\thttp://test.bitcore.io/tx/e4bc22d8c519d3cf848d710619f8480be56176a4a6548dfbe865ab3886b578b5\n\n');
 
 
   //save scriptPubKey
@@ -63,7 +63,7 @@ var run = function() {
   var utxos2 = [
     {
     address: input.addr,
-    txid: "ff5c8b4912f6d056f0cf8431ec27032a73df22c167726267dd4cc0d7817a1e7d",
+    txid: "e4bc22d8c519d3cf848d710619f8480be56176a4a6548dfbe865ab3886b578b5",
     vout: 0,
     ts: 1396288753,
     scriptPubKey: scriptPubKey, 
@@ -84,9 +84,9 @@ var run = function() {
 
   var txHex =  tx.serialize().toString('hex');
   console.log('2) REDEEM SCRIPT: ', txHex);
-console.log('=> Is signed status:', b.isFullySigned(), b.countInputMultiSig(0) );
+console.log('=> Is signed status:', b.isFullySigned(), tx.countInputMissingSignatures(0) );
 
-  console.log('[this example originally generated TXID: 2813c5a670d2c9d0527718f9d0ea896c78c3c8fc57b409e67308744fc7a7a98e on testnet]\n\n\thttp://test.bitcore.io/tx/2813c5a670d2c9d0527718f9d0ea896c78c3c8fc57b409e67308744fc7a7a98e');
+  console.log('[this example originally generated TXID: 1eb388977b2de99562eb0fbcc661a100eaffed99c53bfcfebe5a087002039b83 on testnet]\n\n\thttp://test.bitcore.io/tx/1eb388977b2de99562eb0fbcc661a100eaffed99c53bfcfebe5a087002039b83');
 
 };
 

--- a/examples/CreateAndSignTx-PayToScriptHash.js
+++ b/examples/CreateAndSignTx-PayToScriptHash.js
@@ -16,11 +16,11 @@ var run = function() {
   var utxos = [
     {
     address: "n2hoFVbPrYQf7RJwiRy1tkbuPPqyhAEfbp",
-    txid: "ba20653648a896ae95005b8f52847935a7313da06cd7295bb2cfc8b5c1b36c71",
+    txid: "e4bc22d8c519d3cf848d710619f8480be56176a4a6548dfbe865ab3886b578b5",
     vout: 1,
     ts: 1396290442,
     scriptPubKey: "76a914e867aad8bd361f57c50adc37a0c018692b5b0c9a88ac",
-    amount: 0.5298,
+    amount:  0.3795,
     confirmations: 7
   }
   ];
@@ -57,12 +57,13 @@ var run = function() {
     .setOutputs(outs)
     .sign([input.priv])
     .build();
+
   var txHex =  tx.serialize().toString('hex');
 
 
-  console.log('p2sh address: ' + p2shAddress); //TODO
-  console.log('1) SEND TO P2SH TX: ', txHex);
-  console.log('[this example originally generated TXID: 8675a1f7ab0c2eeec2ff2def539446d1942efffd468319107429b894e60ecac3 on testnet]\n\n\thttp://test.bitcore.io/tx/8675a1f7ab0c2eeec2ff2def539446d1942efffd468319107429b894e60ecac3\n\n');
+  console.log('## p2sh address: ' + p2shAddress); //TODO
+  console.log('\n1) SEND TO P2SH TX: ', txHex);
+  console.log('[this example originally generated TXID: c2e50d1c8c581d8c4408378b751633f7eb86687fc5f0502be7b467173f275ae7 on testnet]\n\n\thttp://test.bitcore.io/tx/c2e50d1c8c581d8c4408378b751633f7eb86687fc5f0502be7b467173f275ae7\n\n');
 
   //save scriptPubKey
   var scriptPubKey = tx.outs[0].s.toString('hex');
@@ -74,12 +75,12 @@ var run = function() {
   var utxos2 = [
     {
     address: p2shAddress,
-    txid: "ba20653648a896ae95005b8f52847935a7313da06cd7295bb2cfc8b5c1b36c71",
+    txid: "c2e50d1c8c581d8c4408378b751633f7eb86687fc5f0502be7b467173f275ae7",
     vout: 0,
-    ts: 1396288753,
-    scriptPubKey: scriptPubKey, 
+    ts: 1396375187,
+    scriptPubKey: scriptPubKey,
     amount: 0.05,
-    confirmations: 2
+    confirmations: 1
   }
   ];
 
@@ -94,17 +95,41 @@ var run = function() {
     .setOutputs(outs)
     .sign(privs);
 
-
   tx= b.build();
 
 
+console.log('Builder:');
+console.log('\tSignatures:' + tx.countInputMissingSignatures(0) );
+console.log('\t#isFullySigned:' + b.isFullySigned() );
+
+console.log('TX:');
+console.log('\t #isComplete:' + tx.isComplete() ); 
+
   var txHex =  tx.serialize().toString('hex');
   console.log('2) REDEEM SCRIPT: ', txHex);
-console.log('=> Is signed status:', b.isFullySigned(), b.countInputMultiSig(0) );
+  console.log('[this example originally generated TXID: 8284aa3b6f9c71c35ecb1d61d05ae78c8ca1f36940eaa615b50584dfc3d95cb7 on testnet]\n\n\thttp://test.bitcore.io/tx/8284aa3b6f9c71c35ecb1d61d05ae78c8ca1f36940eaa615b50584dfc3d95cb7\n\n');
 
-  console.log('[this example originally generated TXID: 2813c5a670d2c9d0527718f9d0ea896c78c3c8fc57b409e67308744fc7a7a98e on testnet]\n\n\thttp://test.bitcore.io/tx/2813c5a670d2c9d0527718f9d0ea896c78c3c8fc57b409e67308744fc7a7a98e');
+/*
+  // To send TX with RPC:
+  var RpcClient = bitcore.RpcClient;
+  var config = {
+    protocol: 'http',
+    user: 'user',
+    pass: 'pass',
+    host: '127.0.0.1',
+    port: '18332',
+  };
+  var rpc = new RpcClient(config);
+  rpc.sendRawTransaction(txHex, function(err, ret) {
+    console.log('err', err); //TODO
+    console.log('ret', ret); //TODO
+    process.exit(-1);
+  });
+};
+*/
 
 };
+
 
 // This is just for browser & mocha compatibility
 if (typeof module !== 'undefined') {
@@ -115,6 +140,3 @@ if (typeof module !== 'undefined') {
 } else {
   run();
 }
-
-////
-

--- a/examples/CreateKey.js
+++ b/examples/CreateKey.js
@@ -32,7 +32,7 @@ var run = function() {
 
   //Generate from private Key WIF. Compressed status taken from WIF.
   var wk2 = new WalletKey(opts);
-  wk2.fromObj({priv:'cS62Ej4SobZnpFQYN1PEEBr2KWf5sgRYYnELtumcG6WVCfxno39V'});
+  wk2.fromObj({priv:'cMpKwGr5oxEacN95WFKNEq6tTcvi11regFwS3muHvGYVxMPJX8JA'});
   print(wk2);
 
 

--- a/test/data/unspentSign.json
+++ b/test/data/unspentSign.json
@@ -65,7 +65,23 @@
     "cUkYub4jtFVYymHh38yMMW36nJB4pXG5Pzd5QjResq79kAndkJcg",
     "cMyBgowsyrJRufoKWob73rMQB1PBqDdwFt8z4TJ6APN2HkmX1Ttm",
     "cN9yZCom6hAZpHtCp8ovE1zFa7RqDf3Cr4W6AwH2tp59Jjh9JcXu"
+  ],
+  "unspentP2sh": [
+    {
+      "address": "2Mwswt6Eih28xH8611fexpqKqJCLJMomveK",
+      "scriptPubKey": "a91432d272ce8a9b482b363408a0b1dd28123d59c63387",
+      "txid": "2ac165fa7a3a2b535d106a0041c7568d03b531e58aeccdd3199d7289ab12cfc1",
+      "vout": 1,
+      "amount": 1,
+      "confirmations":7
+    }
+  ],
+  "keyStringsP2sh": [
+    "cMpKwGr5oxEacN95WFKNEq6tTcvi11regFwS3muHvGYVxMPJX8JA",
+    "cVf32m9MR4vxcPwKNJuPepUe8XrHD2z63eCk76d6njRGyCkXpkSM",
+    "cQ2sVRFX4jQYMLhWyzz6jTQ2xju51P36968ecXnPhRLKLH677eKR",
+    "cSw7x9ERcmeWCU3yVBT6Nz7b9JiZ5yjUB7JMhBUv9UM7rSaDpwX9",
+    "cRQBM8qM4ZXJGP1De4D5RtJm7Q6FNWQSMx7YExxzgn2ehjM3haxW"
   ]
-
 }
 


### PR DESCRIPTION
This add p2sh support. Tests and examples were added. p2sh transactions were successfully broadcasted to bitcoin testnet. 

Some small interface changes are expected on the future as we understand better the use cases.
