### PR TITLE
Fix exec syntax in browser/build.js, fixes error on windows

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -63,7 +63,10 @@ var createBitcore = function(opts) {
   opts.dir = opts.dir || '';
 
   // concat browser vendor files
-  exec('cd ' + opts.dir + 'browser & sh concat.sh', puts);
+  var cwd = process.cwd();
+  process.chdir(opts.dir + 'browser');
+  exec('sh concat.sh', puts);
+  process.chdir(cwd);
 
   if (!opts.includeall && (!opts.submodules || opts.submodules.length === 0)) {
     if (!opts.stdout) console.log('Must use either -s or -a option. For more info use the --help option');


### PR DESCRIPTION
This fixes #222 
[Source of syntax](http://stackoverflow.com/questions/14427075/how-do-i-make-node-child-process-exec-continuously/14435103#14435103)
~~This has not yet been tested on a *nix system!~~
Tested on osx.
