### PR TITLE
new convenient interface for creating addresses

### DIFF
--- a/Address.js
+++ b/Address.js
@@ -27,7 +27,7 @@ Address.fromPubKey = function(pubKey, network) {
 };
 
 //create a p2sh m-of-n multisig address
-Address.fromPubKeys = function(mReq, pubKeys, network) {
+Address.fromPubKeys = function(mReq, pubKeys, network, opts) {
   if (!network)
     network = 'livenet';
 
@@ -37,12 +37,9 @@ Address.fromPubKeys = function(mReq, pubKeys, network) {
       throw new Error('Invalid public key');
   }
 
-  var version = networks[network].P2SHVersion;
-  var script = Script.createMultisig(mReq, pubKeys);
-  var buf = script.getBuffer();
-  var hash = coinUtil.sha256ripe160(buf)
+  var script = Script.createMultisig(mReq, pubKeys, opts);
 
-  return new Address(version, hash);
+  return Address.fromScript(script, network);
 };
 
 //create a p2sh address from redeemScript

--- a/test/test.Address.js
+++ b/test/test.Address.js
@@ -120,6 +120,22 @@ describe('Address', function() {
       var addr2 = Address.fromPubKeys(mReq, pubKeys);
       addr.toString().should.equal(addr2.toString());
     });
+
+    it('it should make this hand-crafted address', function() {
+      var pubkey1 = new Buffer('03e0973263b4e0d5f5f56d25d430e777ab3838ff644db972c0bf32c31da5686c27', 'hex');
+      var pubkey2 = new Buffer('0371f94c57cc013507101e30794161f4e6b9efd58a9ea68838daf429b7feac8cb2', 'hex');
+      var pubkey3 = new Buffer('032c0d2e394541e2efdc7ac3500e16e7e69df541f38670402e95aa477202fa06bb', 'hex');
+      var pubKeys = [pubkey1, pubkey2, pubkey3];
+      var mReq = 2;
+      var script = bitcore.Script.createMultisig(mReq, pubKeys);
+      var addr = Address.fromScript(script);
+      
+      var hash = bitcore.util.sha256ripe160(script.getBuffer());
+      var version = bitcore.networks['livenet'].P2SHVersion;
+      var addr2 = new Address(version, hash);
+
+      addr.toString().should.equal(addr2.toString());
+    });
   });
  
 });


### PR DESCRIPTION
To create an address from a public key or script, you used to have to do the
hashing yourself, and find the version yourself. For example:

var hash = bitcore.util.sha256ripe160(pubkey);
var version = bitcore.networks['livenet'].addressVersion;
var addr = new Address(version, hash);

But with this interface, things are much simpler:

var addr = Address.fromPubKey(pubkey);

The new convenience methods are:

Address.fromPubKey (for regular pubkeyhash addresses)
Address.fromPubKeys (for p2sh multisig addresses)
Address.fromScript (for any p2sh address)
