### PR TITLE
remove unused params in example

### DIFF
--- a/examples/CreateAndSignTx-PayToScriptHash.js
+++ b/examples/CreateAndSignTx-PayToScriptHash.js
@@ -41,10 +41,10 @@ var run = function() {
   });
 
   // multisig p2sh
-  var opts = {nreq:3, pubkeys:pubkeys, amount:0.05};
+  var opts = {nreq:3, pubkeys:pubkeys};
 
   // p2scriphash p2sh
-  //var opts = [{address: an_address, amount:0.05}];
+  //var opts = [{address: an_address}];
   
   var info = Builder.infoForP2sh(opts, 'testnet');
   var p2shScript = info.scriptBufHex;

--- a/test/test.TransactionBuilder.js
+++ b/test/test.TransactionBuilder.js
@@ -563,7 +563,7 @@ describe('TransactionBuilder', function() {
     };
     var data = getInfoForP2sh();
     // multisig p2sh
-    var p2shOpts = {nreq:3, pubkeys:data.pubkeys, amount:0.05};
+    var p2shOpts = {nreq:3, pubkeys:data.pubkeys};
     var info = TransactionBuilder.infoForP2sh(p2shOpts, network);
 
     var outs = outs || [{
@@ -644,7 +644,7 @@ describe('TransactionBuilder', function() {
       remainderOut: {address: 'mwZabyZXg8JzUtFX1pkGygsMJjnuqiNhgd'},
     };
     // p2hash/ p2sh
-    var p2shOpts = {address:'mgwqzy6pF5BSc72vxHBFSnnhNEBcV4TJzV', amount:0.05};
+    var p2shOpts = {address:'mgwqzy6pF5BSc72vxHBFSnnhNEBcV4TJzV'};
     var info = TransactionBuilder.infoForP2sh(p2shOpts, network);
 
     //addr: 2NAwCQ1jPYPrSsyBQvfP6AJ6d6SSxnHsZ4e


### PR DESCRIPTION
This is a small clean up in Transaction Builder examples (remove unused data).
