### PR TITLE
remove deprecated chai uses

### DIFF
--- a/test/test.Transaction.js
+++ b/test/test.Transaction.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var chai = chai || require('chai');
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 var bitcore = bitcore || require('../bitcore');
 
 var should = chai.should();

--- a/test/test.TransactionBuilder.js
+++ b/test/test.TransactionBuilder.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var chai = chai || require('chai');
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 var bitcore = bitcore || require('../bitcore');
 
 var should = chai.should();


### PR DESCRIPTION
This fixes a small deprecation message that you got when running tests with the latest version of chai.
