### PR TITLE
TxIn: add sequence to standardized object

### DIFF
--- a/Transaction.js
+++ b/Transaction.js
@@ -40,6 +40,8 @@ function TransactionIn(data) {
   this.q = data.q ? data.q : data.sequence;
 }
 
+TransactionIn.MAX_SEQUENCE = 0xffffffff;
+
 TransactionIn.prototype.getScript = function getScript() {
   return new Script(this.s);
 };


### PR DESCRIPTION
Having the sequence on the standardized transaction txins objects would simplify my code a bit. Hope it's OK to have it there. If the sequence is `0xfffffffff`, it becomes `null` on the standardised object.
