### PR TITLE
fix key tests for browser

### DIFF
--- a/test/test.Key.js
+++ b/test/test.Key.js
@@ -16,21 +16,6 @@ describe('Key', function() {
     var k = new Key();
     should.exist(k);
   });
-  it('should not fail when called as Key() without "new"', function() {
-    var key = Key();
-    should.exist(key);
-  });
-  it('should not fail when called as Key() without "new" with some args', function() {
-    var key = Key(1, 2, 3, 4, 5);
-    should.exist(key);
-  });
-  it('should have correct properties when called with Key() without "new"', function() {
-    var key = Key();
-    key.compressed.should.equal(true);
-    should.not.exist(key.public);
-    should.not.exist(key.private);
-    should.exist(key);
-  });
   it('should be able to generateSync instance', function() {
     var k = Key.generateSync();
     should.exist(k);
@@ -177,6 +162,25 @@ describe('Key', function() {
         var key = new Key();
         key.public = pubkey;
         assert(key.public !== null);
+      });
+
+    });
+
+    describe('node only Key functionality', function() {
+      it('should not fail when called as Key() without "new"', function() {
+        var key = Key();
+        should.exist(key);
+      });
+      it('should not fail when called as Key() without "new" with some args', function() {
+        var key = Key(1, 2, 3, 4, 5);
+        should.exist(key);
+      });
+      it('should have correct properties when called with Key() without "new"', function() {
+        var key = Key();
+        key.compressed.should.equal(true);
+        should.not.exist(key.public);
+        should.not.exist(key.private);
+        should.exist(key);
       });
 
     });


### PR DESCRIPTION
Some tests that were intended for node only were running the browser. This
update removes those tests from the browser.
