### PR TITLE
default BIP32 to livenet

### DIFF
--- a/lib/BIP32.js
+++ b/lib/BIP32.js
@@ -11,12 +11,14 @@ var secp256k1_n = new bignum("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBF
 var secp256k1_Gx = new bignum("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798", 16);
 
 var BIP32 = function(bytes) {
-  if (bytes == 'mainnet' || bytes == 'livenet')
+  if (typeof bytes == 'undefined' || bytes == 'mainnet' || bytes == 'livenet') {
+    bytes = 'livenet';
     this.version = networks['livenet'].bip32privateVersion;
+  }
   else if (bytes == 'testnet')
     this.version = networks['testnet'].bip32privateVersion;
 
-  if (bytes == 'mainnet' || bytes == 'livenet' || bytes == 'testnet') {
+  if (bytes == 'livenet' || bytes == 'testnet') {
     this.depth = 0x00;
     this.parentFingerprint = new Buffer([0, 0, 0, 0]);
     this.childIndex = new Buffer([0, 0, 0, 0]);


### PR DESCRIPTION
If you run "new BIP32" it generates a blank BIP32. This changes it so by default it generates a livenet BIP32. Livenet is already the default for other methods in bitcore, like Address.fromPubKey
