### PR TITLE
BIP32 speed improvement

### DIFF
--- a/lib/BIP32.js
+++ b/lib/BIP32.js
@@ -281,12 +281,12 @@ BIP32.prototype.deriveChild = function(i) {
   } else {
     var data = Buffer.concat([this.eckey.public, ib]);
     var hash = coinUtil.sha512hmac(data, this.chainCode);
-    var il = bignum.fromBuffer(hash.slice(0, 32), {size: 32});
+    var il = hash.slice(0, 32);
     var ir = hash.slice(32, 64);
 
     // Ki = (IL + kpar)*G = IL*G + Kpar
     var ilGkey = new Key();
-    ilGkey.private = il.toBuffer({size: 32});
+    ilGkey.private = il;
     ilGkey.regenerateSync();
     var ilG = Point.fromKey(ilGkey);
     var oldkey = new Key();


### PR DESCRIPTION
- remove multiple concats with one, more efficient, concat
- allow generating blank BIP32 for internal use
- other minor improvements

Speed test:

```
var d1 = new Date();
for (var i = 0; i <= 10000; i++) {
  var bip32 = new bitcore.BIP32();
  var bip32b = bip32.derive('m/5');
  console.log(i);
}
var d2 = new Date();
console.log(d2-d1);
```

This code took 32 seconds on master, and 20 seconds on this new branch on my machine (in node). So things are about 30% faster.
