### PR TITLE
removes buffertools dependencies in browsers Key.js

### DIFF
--- a/examples/browser/example.html
+++ b/examples/browser/example.html
@@ -44,7 +44,10 @@
       Using bitcore root module
 */
       var bitcore = require('bitcore');
+      var Key = bitcore.Key;
       var k = bitcore.Key.generateSync();
+k.private = new bitcore.Buffer('8d76eb9ddfa64fd29f4c541eac2b03ffdd1810dd19b01a10593fdb08f6be25f5','hex');
+      k.regenerateSync();
       print ('Generate Key Pair:');
       print ('Private:' + bitcore.buffertools.toHex(k.private));
       print ('Public:'  + bitcore.buffertools.toHex(k.public));

--- a/lib/browser/Key.js
+++ b/lib/browser/Key.js
@@ -1,5 +1,4 @@
 var ECKey = require('../../browser/vendor-bundle.js').ECKey;
-var buffertools = require('buffertools');
 
 var Key = function() {
   this._pub = null;
@@ -48,7 +47,7 @@ Key.prototype.regenerateSync = function() {
     throw new Error('Key does not have a private key set');
   }
 
-  var eck = new ECKey(buffertools.toHex(this.private));
+  var eck = new ECKey(this.private.toString('hex'));
   eck.setCompressed(this.compressed);
   this.public = new Buffer(eck.getPub());
   return this;
@@ -62,7 +61,7 @@ Key.prototype.signSync = function(hash) {
   if (!Buffer.isBuffer(hash) || hash.length !== 32) {
     throw new Error('Arg should be a 32 bytes hash buffer');
   }
-  var eck = new ECKey(buffertools.toHex(this.private));
+  var eck = new ECKey(this.private.toString('hex'));
   eck.setCompressed(this.compressed);
   var signature = eck.sign(bufferToArray(hash));
   // return it as a buffer to keep c++ compatibility


### PR DESCRIPTION
This removes the unnecessary dependency of 'buffertools' in the browser version of Key.js.

By doing this, browser test are fixed on Firefox (v28).
