### PR TITLE
add require('bignum') in key

### DIFF
--- a/lib/browser/Key.js
+++ b/lib/browser/Key.js
@@ -1,6 +1,7 @@
 var ECKey = require('../../browser/vendor-bundle.js').ECKey;
 var SecureRandom = require('../SecureRandom');
 var Curve = require('../Curve');
+var bignum = require('bignum');
 
 var Key = function() {
   this._pub = null;


### PR DESCRIPTION
Necessary for using bignum in Key. Tests pass without this being present, but using the Key class still fails. Possibly because the tests include bignum on their own.
