### PR TITLE
fix bignum issue

### DIFF
--- a/bitcore.js
+++ b/bitcore.js
@@ -62,8 +62,3 @@ requireWhenAccessed('Message', './lib/Message');
 requireWhenAccessed('Electrum', './lib/Electrum');
 module.exports.Buffer = Buffer;
 
-if (typeof process.versions === 'undefined') {
-  // Browser specific
-  module.exports.Bignum.config({EXPONENTIAL_AT: 9999999, DECIMAL_PLACES: 0, ROUNDING_MODE: 1});
-}
-

--- a/lib/browser/Bignum.js
+++ b/lib/browser/Bignum.js
@@ -2118,4 +2118,6 @@ P['valueOf'] = function () {
 
 
 // EXPORT
+BigNumber.config({EXPONENTIAL_AT: 9999999, DECIMAL_PLACES: 0, ROUNDING_MODE: 1});
 module.exports = BigNumber;
+

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,9 @@
     <script src="adapter.js"></script>
 
     <script src="test.Address.js"></script>
+    <script src="test.Base58.js"></script>
     <script src="test.basic.js"></script>
+    <script src="test.Bignum.browser.js"></script>
     <script src="test.BIP32.js"></script>
     <script src="test.Block.js"></script>
     <script src="test.Bloom.js"></script>

--- a/test/test.Base58.js
+++ b/test/test.Base58.js
@@ -1,6 +1,8 @@
-var assert = require('assert');
-var base58 = require('../lib/Base58').base58;
-var base58Check = require('../lib/Base58').base58Check;
+var chai = chai || require('chai');
+var assert = chai.assert;
+var bitcore = bitcore || require('../bitcore');
+var base58 = bitcore.Base58.base58;
+var base58Check = bitcore.Base58.base58Check;
 
 var testData = [
   ["61", "2g", "C2dGTwc"],
@@ -19,31 +21,33 @@ var testData = [
 
 //suite('basic');
 
-test('allData', function() {
-  base58.encodeTest = function(raw, b58str) {
-    assert.equal(base58.encode(raw), b58str);
-  };
+describe('Base58', function() {
+  it('should pass these tests', function() {
+    base58.encodeTest = function(raw, b58str) {
+      assert.equal(base58.encode(raw), b58str);
+    };
 
-  base58.decodeTest = function(raw, b58str) {
-    assert.equal(raw.toString('hex'), base58.decode(b58str).toString('hex'));
-  };
+    base58.decodeTest = function(raw, b58str) {
+      assert.equal(raw.toString('hex'), base58.decode(b58str).toString('hex'));
+    };
 
-  base58Check.encodeTest = function(raw, b58str) {
-    assert.equal(base58Check.encode(raw), b58str);
-  };
+    base58Check.encodeTest = function(raw, b58str) {
+      assert.equal(base58Check.encode(raw), b58str);
+    };
 
-  base58Check.decodeTest = function(raw, b58str) {
-    assert.equal(raw.toString('hex'), base58Check.decode(b58str).toString('hex'));
-  };
+    base58Check.decodeTest = function(raw, b58str) {
+      assert.equal(raw.toString('hex'), base58Check.decode(b58str).toString('hex'));
+    };
 
-  testData.forEach(function(datum) {
-    var raw = new Buffer(datum[0], 'hex');
-    var b58 = datum[1];
-    var b58Check = datum[2];
+    testData.forEach(function(datum) {
+      var raw = new Buffer(datum[0], 'hex');
+      var b58 = datum[1];
+      var b58Check = datum[2];
 
-    base58.encodeTest(raw, b58);
-    base58.decodeTest(raw, b58);
-    base58Check.encodeTest(raw, b58Check);
-    base58Check.decodeTest(raw, b58Check);
+      base58.encodeTest(raw, b58);
+      base58.decodeTest(raw, b58);
+      base58Check.encodeTest(raw, b58Check);
+      base58Check.decodeTest(raw, b58Check);
+    });
   });
 });

--- a/test/test.Bignum.browser.js
+++ b/test/test.Bignum.browser.js
@@ -1,0 +1,18 @@
+var chai = chai || require('chai');
+var bitcore = bitcore || require('../bitcore');
+var coinUtil = coinUtil || bitcore.util;
+var should = chai.should();
+var assert = chai.assert;
+
+var Bignum = bitcore.Bignum;
+
+if (typeof process == 'undefined' || typeof process.versions == 'undefined') {
+  describe('#Bignum.browser', function() {
+    it('should have proper config settings', function() {
+      bitcore.Bignum.config().EXPONENTIAL_AT[0].should.equal(-9999999);
+      bitcore.Bignum.config().EXPONENTIAL_AT[1].should.equal(9999999);
+      bitcore.Bignum.config().DECIMAL_PLACES.should.equal(0);
+      bitcore.Bignum.config().ROUNDING_MODE.should.equal(1);
+    });
+  });
+}


### PR DESCRIPTION
In the browser, sometimes the config for bignum wasn't being set up if (somehow
... still not sure how this is possible) you use bitcore without using
require('bitcore'). This would by pass the code that set the config for bignum.
Solution is to put the config for bignum in bignum itself (in the browser).

This fixes, in particular, an issue with base58 where it was depending on
bignum having the proper config.

Also I add the base58 tests to run in the browser which they weren't
previously.

And finally I add a small test for Bignum in the browser that makes sure the
config is set properly.
