### PR TITLE
Signature and Private Key sanity tests

### DIFF
--- a/test/test.Key.js
+++ b/test/test.Key.js
@@ -130,7 +130,25 @@ describe('Key', function() {
     ret.should.equal(false);
   });
 
+  describe('generateSync', function() {
+    it('should not generate the same key twice in a row', function() {
+      var key1 = Key.generateSync();
+      var key2 = Key.generateSync();
+      key1.private.toString('hex').should.not.equal(key2.private.toString('hex'));
+    });
+  });
+
   describe('signSync', function() {
+    it('should not generate the same signature twice in a row', function() {
+      var hash = coinUtil.sha256('my data');
+      var key = new Key();
+      key.private = coinUtil.sha256('a fake private key');
+      key.regenerateSync();
+      var sig1 = key.signSync(hash);
+      var sig2 = key.signSync(hash);
+      sig1.toString('hex').should.not.equal(sig2.toString('hex'));
+    });
+
     it('should sign 10 times and have a different signature each time', function() {
       var key = new Key();
       key.private = coinUtil.sha256('my fake private key');

--- a/test/test.Message.js
+++ b/test/test.Message.js
@@ -13,6 +13,15 @@ describe('Message', function() {
       var sig = Message.sign('my message', key);
       sig.length.should.be.greaterThan(0);
     });
+
+    it('should not sign a message the same way twice', function() {
+      var key = new bitcore.Key();
+      key.private = coinUtil.sha256('a fake private key');
+      key.regenerateSync();
+      var sig1 = Message.sign('my message', key);
+      var sig2 = Message.sign('my message', key);
+      sig1.toString('hex').should.not.equal(sig2.toString('hex'));
+    });
   });
 
   describe('verifyWithPubKey', function() {


### PR DESCRIPTION
Signing a message with ECDSA involves using a random number, and this means
that two signatures should never be the same. This commit adds some basic tests
to Key.signSync and Message.sign to make sure this is the case. Also, a new
bitcore.Key should never have the same private key twice. This commit also adds
a basic test to make sure that is the case.
