### PR TITLE
Got rid of evil eval

### DIFF
--- a/lib/Opcode.js
+++ b/lib/Opcode.js
@@ -165,4 +165,18 @@ Opcode.asList = function() {
   return keys;
 };
 
+Opcode.registerGlobally = function () {
+  var globalobj;
+  try { globalobj = window; } catch (e) { globalobj = global; }
+
+  if (globalobj['bitcore_opcodes_registered']) return;
+
+  for (var k in Opcode.map) {
+    if(Opcode.map.hasOwnProperty(k)) {
+      globalobj[k] = Opcode.map[k];
+    }
+  }
+  globalobj['bitcore_opcodes_registered'] = true;
+};
+
 module.exports = require('soop')(Opcode);

--- a/lib/Script.js
+++ b/lib/Script.js
@@ -5,9 +5,7 @@ var Opcode      = imports.Opcode || require('./Opcode');
 var buffertools = imports.buffertools || require('buffertools');
 
 // Make opcodes available as pseudo-constants
-for (var i in Opcode.map) {
-  eval(i + " = " + Opcode.map[i] + ";");
-}
+Opcode.registerGlobally();
 
 var util   = imports.util || require('../util/util');
 var Parser = imports.Parser || require('../util/BinaryParser');

--- a/lib/ScriptInterpreter.js
+++ b/lib/ScriptInterpreter.js
@@ -15,9 +15,7 @@ var SIGHASH_SINGLE = 3;
 var SIGHASH_ANYONECANPAY = 80;
 
 // Make opcodes available as pseudo-constants
-for (var i in Opcode.map) {
-  eval(i + " = " + Opcode.map[i] + ";");
-}
+Opcode.registerGlobally();
 
 var intToBufferSM = Util.intToBufferSM
 var bufferSMToInt = Util.bufferSMToInt;


### PR DESCRIPTION
Got rid of evil eval in favor of writing to the evil global scope. Haven't tested in browser.

See issue #315
