### PR TITLE
[#315] clean all 'eval(' from bundle.js

### DIFF
--- a/lib/Script.js
+++ b/lib/Script.js
@@ -5,8 +5,10 @@ var Opcode      = imports.Opcode || require('./Opcode');
 var buffertools = imports.buffertools || require('buffertools');
 
 // Make opcodes available as pseudo-constants
+var OP = {};
 for (var i in Opcode.map) {
-  eval(i + " = " + Opcode.map[i] + ";");
+  var name = i.split('_').pop();
+  OP["_"+name] = Opcode.map[i];
 }
 
 var util   = imports.util || require('../util/util');
@@ -51,18 +53,18 @@ Script.prototype.parse = function() {
     var opcode = parser.word8();
 
     var len, chunk;
-    if (opcode > 0 && opcode < OP_PUSHDATA1) {
+    if (opcode > 0 && opcode < OP._PUSHDATA1) {
       // Read some bytes of data, opcode value is the length of data
       this.chunks.push(parser.buffer(opcode));
-    } else if (opcode === OP_PUSHDATA1) {
+    } else if (opcode === OP._PUSHDATA1) {
       len = parser.word8();
       chunk = parser.buffer(len);
       this.chunks.push(chunk);
-    } else if (opcode === OP_PUSHDATA2) {
+    } else if (opcode === OP._PUSHDATA2) {
       len = parser.word16le();
       chunk = parser.buffer(len);
       this.chunks.push(chunk);
-    } else if (opcode === OP_PUSHDATA4) {
+    } else if (opcode === OP._PUSHDATA4) {
       len = parser.word32le();
       chunk = parser.buffer(len);
       this.chunks.push(chunk);
@@ -75,7 +77,7 @@ Script.prototype.parse = function() {
 Script.prototype.isPushOnly = function() {
   for (var i = 0; i < this.chunks.length; i++) {
     var op = this.chunks[i];
-    if (!Buffer.isBuffer(op) && op > OP_16) {
+    if (!Buffer.isBuffer(op) && op > OP._16) {
       return false;
     }
   }
@@ -85,38 +87,38 @@ Script.prototype.isPushOnly = function() {
 
 Script.prototype.isP2SH = function() {
   return (this.chunks.length == 3 &&
-    this.chunks[0] == OP_HASH160 &&
+    this.chunks[0] == OP._HASH160 &&
     Buffer.isBuffer(this.chunks[1]) &&
     this.chunks[1].length == 20 &&
-    this.chunks[2] == OP_EQUAL);
+    this.chunks[2] == OP._EQUAL);
 };
 
 Script.prototype.isPubkey = function() {
   return (this.chunks.length == 2 &&
     Buffer.isBuffer(this.chunks[0]) &&
-    this.chunks[1] == OP_CHECKSIG);
+    this.chunks[1] == OP._CHECKSIG);
 };
 
 Script.prototype.isPubkeyHash = function() {
   return (this.chunks.length == 5 &&
-    this.chunks[0] == OP_DUP &&
-    this.chunks[1] == OP_HASH160 &&
+    this.chunks[0] == OP._DUP &&
+    this.chunks[1] == OP._HASH160 &&
     Buffer.isBuffer(this.chunks[2]) &&
     this.chunks[2].length == 20 &&
-    this.chunks[3] == OP_EQUALVERIFY &&
-    this.chunks[4] == OP_CHECKSIG);
+    this.chunks[3] == OP._EQUALVERIFY &&
+    this.chunks[4] == OP._CHECKSIG);
 };
 
 function isSmallIntOp(opcode) {
-  return ((opcode == OP_0) ||
-    ((opcode >= OP_1) && (opcode <= OP_16)));
+  return ((opcode == OP._0) ||
+    ((opcode >= OP._1) && (opcode <= OP._16)));
 };
 
 Script.prototype.isMultiSig = function() {
   return (this.chunks.length > 3 &&
     isSmallIntOp(this.chunks[0]) &&
     isSmallIntOp(this.chunks[this.chunks.length - 2]) &&
-    this.chunks[this.chunks.length - 1] == OP_CHECKMULTISIG);
+    this.chunks[this.chunks.length - 1] == OP._CHECKMULTISIG);
 };
 
 Script.prototype.isP2shScriptSig = function() {
@@ -384,13 +386,13 @@ Script.prototype.writeN = function(n) {
     throw new Error("writeN: out of range value " + n);
 
   if (n == 0)
-    this.writeOp(OP_0);
+    this.writeOp(OP._0);
   else
-    this.writeOp(OP_1 + n - 1);
+    this.writeOp(OP._1 + n - 1);
 };
 
 function prefixSize(data_length) {
-  if (data_length < OP_PUSHDATA1) {
+  if (data_length < OP._PUSHDATA1) {
     return 1;
   } else if (data_length <= 0xff) {
     return 1 + 1;
@@ -403,20 +405,20 @@ function prefixSize(data_length) {
 
 function encodeLen(data_length) {
   var buf = undefined;
-  if (data_length < OP_PUSHDATA1) {
+  if (data_length < OP._PUSHDATA1) {
     buf = new Buffer(1);
     buf.writeUInt8(data_length, 0);
   } else if (data_length <= 0xff) {
     buf = new Buffer(1 + 1);
-    buf.writeUInt8(OP_PUSHDATA1, 0);
+    buf.writeUInt8(OP._PUSHDATA1, 0);
     buf.writeUInt8(data_length, 1);
   } else if (data_length <= 0xffff) {
     buf = new Buffer(1 + 2);
-    buf.writeUInt8(OP_PUSHDATA2, 0);
+    buf.writeUInt8(OP._PUSHDATA2, 0);
     buf.writeUInt16LE(data_length, 1);
   } else {
     buf = new Buffer(1 + 4);
-    buf.writeUInt8(OP_PUSHDATA4, 0);
+    buf.writeUInt8(OP._PUSHDATA4, 0);
     buf.writeUInt32LE(data_length, 1);
   }
 
@@ -469,7 +471,7 @@ Script.prototype.findAndDelete = function(chunk) {
 Script.createPubKeyOut = function(pubkey) {
   var script = new Script();
   script.writeBytes(pubkey);
-  script.writeOp(OP_CHECKSIG);
+  script.writeOp(OP._CHECKSIG);
   return script;
 };
 
@@ -478,11 +480,11 @@ Script.createPubKeyOut = function(pubkey) {
  */
 Script.createPubKeyHashOut = function(pubKeyHash) {
   var script = new Script();
-  script.writeOp(OP_DUP);
-  script.writeOp(OP_HASH160);
+  script.writeOp(OP._DUP);
+  script.writeOp(OP._HASH160);
   script.writeBytes(pubKeyHash);
-  script.writeOp(OP_EQUALVERIFY);
-  script.writeOp(OP_CHECKSIG);
+  script.writeOp(OP._EQUALVERIFY);
+  script.writeOp(OP._CHECKSIG);
   return script;
 };
 
@@ -514,15 +516,15 @@ Script.createMultisig = function(n_required, inKeys, opts) {
     script.writeBytes(key);
   });
   script.writeN(keys.length);
-  script.writeOp(OP_CHECKMULTISIG);
+  script.writeOp(OP._CHECKMULTISIG);
   return script;
 };
 
 Script.createP2SH = function(scriptHash) {
   var script = new Script();
-  script.writeOp(OP_HASH160);
+  script.writeOp(OP._HASH160);
   script.writeBytes(scriptHash);
-  script.writeOp(OP_EQUAL);
+  script.writeOp(OP._EQUAL);
   return script;
 };
 
@@ -626,16 +628,16 @@ Script.chunksToBuffer = function(chunks) {
   for (var i = 0, l = chunks.length; i < l; i++) {
     var data = chunks[i];
     if (Buffer.isBuffer(data)) {
-      if (data.length < OP_PUSHDATA1) {
+      if (data.length < OP._PUSHDATA1) {
         buf.word8(data.length);
       } else if (data.length <= 0xff) {
-        buf.word8(OP_PUSHDATA1);
+        buf.word8(OP._PUSHDATA1);
         buf.word8(data.length);
       } else if (data.length <= 0xffff) {
-        buf.word8(OP_PUSHDATA2);
+        buf.word8(OP._PUSHDATA2);
         buf.word16le(data.length);
       } else {
-        buf.word8(OP_PUSHDATA4);
+        buf.word8(OP._PUSHDATA4);
         buf.word32le(data.length);
       }
       buf.put(data);

--- a/lib/ScriptInterpreter.js
+++ b/lib/ScriptInterpreter.js
@@ -15,8 +15,10 @@ var SIGHASH_SINGLE = 3;
 var SIGHASH_ANYONECANPAY = 80;
 
 // Make opcodes available as pseudo-constants
+var OP = {};
 for (var i in Opcode.map) {
-  eval(i + " = " + Opcode.map[i] + ";");
+  var name = i.split('_').pop();
+  OP["_"+name] = Opcode.map[i];
 }
 
 var intToBufferSM = Util.intToBufferSM
@@ -28,9 +30,9 @@ function ScriptInterpreter(opts) {
   this.disableUnsafeOpcodes = true;
 };
 
-ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, callback) {
+ScriptInterpreter.prototype.evalScript = function evalScript(script, tx, inIndex, hashType, callback) {
   if ("function" !== typeof callback) {
-    throw new Error("ScriptInterpreter.eval() requires a callback");
+    throw new Error("ScriptInterpreter.evalScript() requires a callback");
   }
 
   var pc = 0;
@@ -74,101 +76,101 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
         throw new Error("Max push value size exceeded (>520)");
       }
 
-      if (opcode > OP_16 && ++opCount > 201) {
+      if (opcode > OP._16 && ++opCount > 201) {
         throw new Error("Opcode limit exceeded (>200)");
       }
 
       if (this.disableUnsafeOpcodes &&
         "number" === typeof opcode &&
-        (opcode === OP_CAT ||
-          opcode === OP_SUBSTR ||
-          opcode === OP_LEFT ||
-          opcode === OP_RIGHT ||
-          opcode === OP_INVERT ||
-          opcode === OP_AND ||
-          opcode === OP_OR ||
-          opcode === OP_XOR ||
-          opcode === OP_2MUL ||
-          opcode === OP_2DIV ||
-          opcode === OP_MUL ||
-          opcode === OP_DIV ||
-          opcode === OP_MOD ||
-          opcode === OP_LSHIFT ||
-          opcode === OP_RSHIFT)) {
+        (opcode === OP._CAT ||
+          opcode === OP._SUBSTR ||
+          opcode === OP._LEFT ||
+          opcode === OP._RIGHT ||
+          opcode === OP._INVERT ||
+          opcode === OP._AND ||
+          opcode === OP._OR ||
+          opcode === OP._XOR ||
+          opcode === OP._2MUL ||
+          opcode === OP._2DIV ||
+          opcode === OP._MUL ||
+          opcode === OP._DIV ||
+          opcode === OP._MOD ||
+          opcode === OP._LSHIFT ||
+          opcode === OP._RSHIFT)) {
         throw new Error("Encountered a disabled opcode");
       }
 
       if (exec && Buffer.isBuffer(opcode)) {
         this.stack.push(opcode);
-      } else if (exec || (OP_IF <= opcode && opcode <= OP_ENDIF))
+      } else if (exec || (OP._IF <= opcode && opcode <= OP._ENDIF))
         switch (opcode) {
-          case OP_0:
+          case OP._0:
             this.stack.push(new Buffer([]));
             break;
 
-          case OP_1NEGATE:
-          case OP_1:
-          case OP_2:
-          case OP_3:
-          case OP_4:
-          case OP_5:
-          case OP_6:
-          case OP_7:
-          case OP_8:
-          case OP_9:
-          case OP_10:
-          case OP_11:
-          case OP_12:
-          case OP_13:
-          case OP_14:
-          case OP_15:
-          case OP_16:
-            var opint = opcode - OP_1 + 1;
+          case OP._1NEGATE:
+          case OP._1:
+          case OP._2:
+          case OP._3:
+          case OP._4:
+          case OP._5:
+          case OP._6:
+          case OP._7:
+          case OP._8:
+          case OP._9:
+          case OP._10:
+          case OP._11:
+          case OP._12:
+          case OP._13:
+          case OP._14:
+          case OP._15:
+          case OP._16:
+            var opint = opcode - OP._1 + 1;
             var opbuf = intToBufferSM(opint);
             this.stack.push(opbuf);
             break;
 
-          case OP_NOP:
-          case OP_NOP1:
-          case OP_NOP2:
-          case OP_NOP3:
-          case OP_NOP4:
-          case OP_NOP5:
-          case OP_NOP6:
-          case OP_NOP7:
-          case OP_NOP8:
-          case OP_NOP9:
-          case OP_NOP10:
+          case OP._NOP:
+          case OP._NOP1:
+          case OP._NOP2:
+          case OP._NOP3:
+          case OP._NOP4:
+          case OP._NOP5:
+          case OP._NOP6:
+          case OP._NOP7:
+          case OP._NOP8:
+          case OP._NOP9:
+          case OP._NOP10:
             break;
 
-          case OP_IF:
-          case OP_NOTIF:
+          case OP._IF:
+          case OP._NOTIF:
             // <expression> if [statements] [else [statements]] endif
             var value = false;
             if (exec) {
               value = castBool(this.stackPop());
-              if (opcode === OP_NOTIF) {
+              if (opcode === OP._NOTIF) {
                 value = !value;
               }
             }
             execStack.push(value);
             break;
 
-          case OP_ELSE:
+          case OP._ELSE:
             if (execStack.length < 1) {
               throw new Error("Unmatched OP_ELSE");
             }
             execStack[execStack.length - 1] = !execStack[execStack.length - 1];
             break;
 
-          case OP_ENDIF:
+          case OP._ENDIF:
             if (execStack.length < 1) {
               throw new Error("Unmatched OP_ENDIF");
             }
             execStack.pop();
             break;
 
-          case OP_VERIFY:
+          case OP._VERIFY:
             var value = castBool(this.stackTop());
             if (value) {
               this.stackPop();
@@ -177,27 +179,27 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             }
             break;
 
-          case OP_RETURN:
+          case OP._RETURN:
             throw new Error("OP_RETURN");
 
-          case OP_TOALTSTACK:
+          case OP._TOALTSTACK:
             altStack.push(this.stackPop());
             break;
 
-          case OP_FROMALTSTACK:
+          case OP._FROMALTSTACK:
             if (altStack.length < 1) {
               throw new Error("OP_FROMALTSTACK with alt stack empty");
             }
             this.stack.push(altStack.pop());
             break;
 
-          case OP_2DROP:
+          case OP._2DROP:
             // (x1 x2 -- )
             this.stackPop();
             this.stackPop();
             break;
 
-          case OP_2DUP:
+          case OP._2DUP:
             // (x1 x2 -- x1 x2 x1 x2)
             var v1 = this.stackTop(2);
             var v2 = this.stackTop(1);
@@ -205,7 +207,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(v2);
             break;
 
-          case OP_3DUP:
+          case OP._3DUP:
             // (x1 x2 -- x1 x2 x1 x2)
             var v1 = this.stackTop(3);
             var v2 = this.stackTop(2);
@@ -215,7 +217,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(v3);
             break;
 
-          case OP_2OVER:
+          case OP._2OVER:
             // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
             var v1 = this.stackTop(4);
             var v2 = this.stackTop(3);
@@ -223,7 +225,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(v2);
             break;
 
-          case OP_2ROT:
+          case OP._2ROT:
             // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
             var v1 = this.stackTop(6);
             var v2 = this.stackTop(5);
@@ -232,13 +234,13 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(v2);
             break;
 
-          case OP_2SWAP:
+          case OP._2SWAP:
             // (x1 x2 x3 x4 -- x3 x4 x1 x2)
             this.stackSwap(4, 2);
             this.stackSwap(3, 1);
             break;
 
-          case OP_IFDUP:
+          case OP._IFDUP:
             // (x - 0 | x x)
             var value = this.stackTop();
             if (castBool(value)) {
@@ -246,23 +248,23 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             }
             break;
 
-          case OP_DEPTH:
+          case OP._DEPTH:
             // -- stacksize
             var value = bignum(this.stack.length);
             this.stack.push(intToBufferSM(value));
             break;
 
-          case OP_DROP:
+          case OP._DROP:
             // (x -- )
             this.stackPop();
             break;
 
-          case OP_DUP:
+          case OP._DUP:
             // (x -- x x)
             this.stack.push(this.stackTop());
             break;
 
-          case OP_NIP:
+          case OP._NIP:
             // (x1 x2 -- x2)
             if (this.stack.length < 2) {
               throw new Error("OP_NIP insufficient stack size");
@@ -270,13 +272,13 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.splice(this.stack.length - 2, 1);
             break;
 
-          case OP_OVER:
+          case OP._OVER:
             // (x1 x2 -- x1 x2 x1)
             this.stack.push(this.stackTop(2));
             break;
 
-          case OP_PICK:
-          case OP_ROLL:
+          case OP._PICK:
+          case OP._ROLL:
             // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
             // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
             var n = castInt(this.stackPop());
@@ -284,13 +286,13 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
               throw new Error("OP_PICK/OP_ROLL insufficient stack size");
             }
             var value = this.stackTop(n + 1);
-            if (opcode === OP_ROLL) {
+            if (opcode === OP._ROLL) {
               this.stack.splice(this.stack.length - n - 1, 1);
             }
             this.stack.push(value);
             break;
 
-          case OP_ROT:
+          case OP._ROT:
             // (x1 x2 x3 -- x2 x3 x1)
             //  x2 x1 x3  after first swap
             //  x2 x3 x1  after second swap
@@ -298,12 +300,12 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stackSwap(2, 1);
             break;
 
-          case OP_SWAP:
+          case OP._SWAP:
             // (x1 x2 -- x2 x1)
             this.stackSwap(2, 1);
             break;
 
-          case OP_TUCK:
+          case OP._TUCK:
             // (x1 x2 -- x2 x1 x2)
             if (this.stack.length < 2) {
               throw new Error("OP_TUCK insufficient stack size");
@@ -311,7 +313,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.splice(this.stack.length - 2, 0, this.stackTop());
             break;
 
-          case OP_CAT:
+          case OP._CAT:
             // (x1 x2 -- out)
             var v1 = this.stackTop(2);
             var v2 = this.stackTop(1);
@@ -320,7 +322,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(Buffer.concat([v1, v2]));
             break;
 
-          case OP_SUBSTR:
+          case OP._SUBSTR:
             // (in begin size -- out)
             var buf = this.stackTop(3);
             var start = castInt(this.stackTop(2));
@@ -336,8 +338,8 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack[this.stack.length - 1] = buf.slice(start, start + len);
             break;
 
-          case OP_LEFT:
-          case OP_RIGHT:
+          case OP._LEFT:
+          case OP._RIGHT:
             // (in size -- out)
             var buf = this.stackTop(2);
             var size = castInt(this.stackTop(1));
@@ -348,20 +350,20 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
               size = buf.length;
             }
             this.stackPop();
-            if (opcode === OP_LEFT) {
+            if (opcode === OP._LEFT) {
               this.stack[this.stack.length - 1] = buf.slice(0, size);
             } else {
               this.stack[this.stack.length - 1] = buf.slice(buf.length - size);
             }
             break;
 
-          case OP_SIZE:
+          case OP._SIZE:
             // (in -- in size)
             var value = bignum(this.stackTop().length);
             this.stack.push(intToBufferSM(value));
             break;
 
-          case OP_INVERT:
+          case OP._INVERT:
             // (in - out)
             var buf = this.stackTop();
             for (var i = 0, l = buf.length; i < l; i++) {
@@ -369,24 +371,24 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             }
             break;
 
-          case OP_AND:
-          case OP_OR:
-          case OP_XOR:
+          case OP._AND:
+          case OP._OR:
+          case OP._XOR:
             // (x1 x2 - out)
             var v1 = this.stackTop(2);
             var v2 = this.stackTop(1);
             this.stackPop();
             this.stackPop();
             var out = new Buffer(Math.max(v1.length, v2.length));
-            if (opcode === OP_AND) {
+            if (opcode === OP._AND) {
               for (var i = 0, l = out.length; i < l; i++) {
                 out[i] = v1[i] & v2[i];
               }
-            } else if (opcode === OP_OR) {
+            } else if (opcode === OP._OR) {
               for (var i = 0, l = out.length; i < l; i++) {
                 out[i] = v1[i] | v2[i];
               }
-            } else if (opcode === OP_XOR) {
+            } else if (opcode === OP._XOR) {
               for (var i = 0, l = out.length; i < l; i++) {
                 out[i] = v1[i] ^ v2[i];
               }
@@ -394,9 +396,9 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(out);
             break;
 
-          case OP_EQUAL:
-          case OP_EQUALVERIFY:
-            //case OP_NOTEQUAL: // use OP_NUMNOTEQUAL
+          case OP._EQUAL:
+          case OP._EQUALVERIFY:
+            //case OP._NOTEQUAL: // use OP_NUMNOTEQUAL
             // (x1 x2 - bool)
             var v1 = this.stackTop(2);
             var v2 = this.stackTop(1);
@@ -406,13 +408,13 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             // OP_NOTEQUAL is disabled because it would be too easy to say
             // something like n != 1 and have some wiseguy pass in 1 with extra
             // zero bytes after it (numerically, 0x01 == 0x0001 == 0x000001)
-            //if (opcode == OP_NOTEQUAL)
+            //if (opcode == OP._NOTEQUAL)
             //    fEqual = !fEqual;
 
             this.stackPop();
             this.stackPop();
             this.stack.push(new Buffer([value ? 1 : 0]));
-            if (opcode === OP_EQUALVERIFY) {
+            if (opcode === OP._EQUALVERIFY) {
               if (value) {
                 this.stackPop();
               } else {
@@ -421,136 +423,136 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             }
             break;
 
-          case OP_1ADD:
-          case OP_1SUB:
-          case OP_2MUL:
-          case OP_2DIV:
-          case OP_NEGATE:
-          case OP_ABS:
-          case OP_NOT:
-          case OP_0NOTEQUAL:
+          case OP._1ADD:
+          case OP._1SUB:
+          case OP._2MUL:
+          case OP._2DIV:
+          case OP._NEGATE:
+          case OP._ABS:
+          case OP._NOT:
+          case OP._0NOTEQUAL:
             // (in -- out)
             var num = bufferSMToInt(this.stackTop());
             switch (opcode) {
-              case OP_1ADD:
+              case OP._1ADD:
                 num = num.add(bignum(1));
                 break;
-              case OP_1SUB:
+              case OP._1SUB:
                 num = num.sub(bignum(1));
                 break;
-              case OP_2MUL:
+              case OP._2MUL:
                 num = num.mul(bignum(2));
                 break;
-              case OP_2DIV:
+              case OP._2DIV:
                 num = num.div(bignum(2));
                 break;
-              case OP_NEGATE:
+              case OP._NEGATE:
                 num = num.neg();
                 break;
-              case OP_ABS:
+              case OP._ABS:
                 num = num.abs();
                 break;
-              case OP_NOT:
+              case OP._NOT:
                 num = bignum(num.cmp(0) == 0 ? 1 : 0);
                 break;
-              case OP_0NOTEQUAL:
+              case OP._0NOTEQUAL:
                 num = bignum(num.cmp(0) == 0 ? 0 : 1);
                 break;
             }
             this.stack[this.stack.length - 1] = intToBufferSM(num);
             break;
 
-          case OP_ADD:
-          case OP_SUB:
-          case OP_MUL:
-          case OP_DIV:
-          case OP_MOD:
-          case OP_LSHIFT:
-          case OP_RSHIFT:
-          case OP_BOOLAND:
-          case OP_BOOLOR:
-          case OP_NUMEQUAL:
-          case OP_NUMEQUALVERIFY:
-          case OP_NUMNOTEQUAL:
-          case OP_LESSTHAN:
-          case OP_GREATERTHAN:
-          case OP_LESSTHANOREQUAL:
-          case OP_GREATERTHANOREQUAL:
-          case OP_MIN:
-          case OP_MAX:
+          case OP._ADD:
+          case OP._SUB:
+          case OP._MUL:
+          case OP._DIV:
+          case OP._MOD:
+          case OP._LSHIFT:
+          case OP._RSHIFT:
+          case OP._BOOLAND:
+          case OP._BOOLOR:
+          case OP._NUMEQUAL:
+          case OP._NUMEQUALVERIFY:
+          case OP._NUMNOTEQUAL:
+          case OP._LESSTHAN:
+          case OP._GREATERTHAN:
+          case OP._LESSTHANOREQUAL:
+          case OP._GREATERTHANOREQUAL:
+          case OP._MIN:
+          case OP._MAX:
             // (x1 x2 -- out)
             var v1 = bufferSMToInt(this.stackTop(2));
             var v2 = bufferSMToInt(this.stackTop(1));
             var num;
             switch (opcode) {
-              case OP_ADD:
+              case OP._ADD:
                 num = v1.add(v2);
                 break;
-              case OP_SUB:
+              case OP._SUB:
                 num = v1.sub(v2);
                 break;
-              case OP_MUL:
+              case OP._MUL:
                 num = v1.mul(v2);
                 break;
-              case OP_DIV:
+              case OP._DIV:
                 num = v1.div(v2);
                 break;
-              case OP_MOD:
+              case OP._MOD:
                 num = v1.mod(v2);
                 break;
 
-              case OP_LSHIFT:
+              case OP._LSHIFT:
                 if (v2.cmp(0) < 0 || v2.cmp(2048) > 0) {
                   throw new Error("OP_LSHIFT parameter out of bounds");
                 }
                 num = v1.shiftLeft(v2);
                 break;
 
-              case OP_RSHIFT:
+              case OP._RSHIFT:
                 if (v2.cmp(0) < 0 || v2.cmp(2048) > 0) {
                   throw new Error("OP_RSHIFT parameter out of bounds");
                 }
                 num = v1.shiftRight(v2);
                 break;
 
-              case OP_BOOLAND:
+              case OP._BOOLAND:
                 num = bignum((v1.cmp(0) != 0 && v2.cmp(0) != 0) ? 1 : 0);
                 break;
 
-              case OP_BOOLOR:
+              case OP._BOOLOR:
                 num = bignum((v1.cmp(0) != 0 || v2.cmp(0) != 0) ? 1 : 0);
                 break;
 
-              case OP_NUMEQUAL:
-              case OP_NUMEQUALVERIFY:
+              case OP._NUMEQUAL:
+              case OP._NUMEQUALVERIFY:
                 num = bignum(v1.cmp(v2) == 0 ? 1 : 0);
                 break;
 
-              case OP_NUMNOTEQUAL:
+              case OP._NUMNOTEQUAL:
                 ;
                 num = bignum(v1.cmp(v2) != 0 ? 1 : 0);
                 break;
 
-              case OP_LESSTHAN:
+              case OP._LESSTHAN:
                 num = bignum(v1.lt(v2) ? 1 : 0);
                 break;
 
-              case OP_GREATERTHAN:
+              case OP._GREATERTHAN:
                 num = bignum(v1.gt(v2) ? 1 : 0);
                 break;
 
-              case OP_LESSTHANOREQUAL:
+              case OP._LESSTHANOREQUAL:
                 num = bignum(v1.gt(v2) ? 0 : 1);
                 break;
 
-              case OP_GREATERTHANOREQUAL:
+              case OP._GREATERTHANOREQUAL:
                 num = bignum(v1.lt(v2) ? 0 : 1);
                 break;
 
-              case OP_MIN:
+              case OP._MIN:
                 num = (v1.lt(v2) ? v1 : v2);
                 break;
-              case OP_MAX:
+              case OP._MAX:
                 num = (v1.gt(v2) ? v1 : v2);
                 break;
             }
@@ -558,7 +560,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stackPop();
             this.stack.push(intToBufferSM(num));
 
-            if (opcode === OP_NUMEQUALVERIFY) {
+            if (opcode === OP._NUMEQUALVERIFY) {
               if (castBool(this.stackTop())) {
                 this.stackPop();
               } else {
@@ -567,7 +569,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             }
             break;
 
-          case OP_WITHIN:
+          case OP._WITHIN:
             // (x min max -- out)
             var v1 = bufferSMToInt(this.stackTop(3));
             var v2 = bufferSMToInt(this.stackTop(2));
@@ -579,35 +581,35 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             this.stack.push(intToBufferSM(value ? 1 : 0));
             break;
 
-          case OP_RIPEMD160:
-          case OP_SHA1:
-          case OP_SHA256:
-          case OP_HASH160:
-          case OP_HASH256:
+          case OP._RIPEMD160:
+          case OP._SHA1:
+          case OP._SHA256:
+          case OP._HASH160:
+          case OP._HASH256:
             // (in -- hash)
             var value = this.stackPop();
             var hash;
-            if (opcode === OP_RIPEMD160) {
+            if (opcode === OP._RIPEMD160) {
               hash = Util.ripe160(value);
-            } else if (opcode === OP_SHA1) {
+            } else if (opcode === OP._SHA1) {
               hash = Util.sha1(value);
-            } else if (opcode === OP_SHA256) {
+            } else if (opcode === OP._SHA256) {
               hash = Util.sha256(value);
-            } else if (opcode === OP_HASH160) {
+            } else if (opcode === OP._HASH160) {
               hash = Util.sha256ripe160(value);
-            } else if (opcode === OP_HASH256) {
+            } else if (opcode === OP._HASH256) {
               hash = Util.twoSha256(value);
             }
             this.stack.push(hash);
             break;
 
-          case OP_CODESEPARATOR:
+          case OP._CODESEPARATOR:
             // Hash starts after the code separator
             hashStart = pc;
             break;
 
-          case OP_CHECKSIG:
-          case OP_CHECKSIGVERIFY:
+          case OP._CHECKSIG:
+          case OP._CHECKSIGVERIFY:
             // (sig pubkey -- bool)
             var sig = this.stackTop(2);
             var pubkey = this.stackTop(1);
@@ -640,7 +642,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
               this.stackPop();
               this.stackPop();
               this.stack.push(new Buffer([success ? 1 : 0]));
-              if (opcode === OP_CHECKSIGVERIFY) {
+              if (opcode === OP._CHECKSIGVERIFY) {
                 if (success) {
                   this.stackPop();
                 } else {
@@ -656,8 +658,8 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
             // the next opcode from being executed.
             return;
 
-          case OP_CHECKMULTISIG:
-          case OP_CHECKMULTISIGVERIFY:
+          case OP._CHECKMULTISIG:
+          case OP._CHECKMULTISIGVERIFY:
             // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
             var keysCount = castInt(this.stackPop());
             if (keysCount < 0 || keysCount > 20) {
@@ -729,7 +731,7 @@ ScriptInterpreter.prototype.eval = function eval(script, tx, inIndex, hashType, 
                 }.bind(this));
               } else {
                 this.stack.push(new Buffer([success ? 1 : 0]));
-                if (opcode === OP_CHECKMULTISIGVERIFY) {
+                if (opcode === OP._CHECKMULTISIGVERIFY) {
                   if (success) {
                     this.stackPop();
                   } else {
@@ -774,13 +776,13 @@ ScriptInterpreter.prototype.evalTwo =
   function evalTwo(scriptSig, scriptPubkey, tx, n, hashType, callback) {
     var self = this;
 
-    self.eval(scriptSig, tx, n, hashType, function(e) {
+    self.evalScript(scriptSig, tx, n, hashType, function(e) {
       if (e) {
         callback(e)
         return;
       }
 
-      self.eval(scriptPubkey, tx, n, hashType, callback);
+      self.evalScript(scriptPubkey, tx, n, hashType, callback);
     });
 };
 
@@ -946,7 +948,7 @@ ScriptInterpreter.prototype.verifyStep3 = function(scriptSig,
   var subscript = new Script(siCopy.stackPop());
   var that = this;
   // evaluate the P2SH subscript
-  siCopy.eval(subscript, tx, nIn, hashType, function(err) {
+  siCopy.evalScript(subscript, tx, nIn, hashType, function(err) {
     if (err) return callback(err);
     that.verifyStep4(callback, siCopy);
   });
@@ -964,7 +966,7 @@ ScriptInterpreter.prototype.verifyStep2 = function(scriptSig, scriptPubKey,
 
   var that = this;
   // 2nd step, evaluate scriptPubKey
-  this.eval(scriptPubKey, tx, nIn, hashType, function(err) {
+  this.evalScript(scriptPubKey, tx, nIn, hashType, function(err) {
     if (err) return callback(err);
     that.verifyStep3(scriptSig, scriptPubKey, tx, nIn,
       hashType, callback, siCopy);
@@ -976,7 +978,7 @@ ScriptInterpreter.prototype.verifyFull = function(scriptSig, scriptPubKey,
   var that = this;
 
   // 1st step, evaluate scriptSig
-  this.eval(scriptSig, tx, nIn, hashType, function(err) {
+  this.evalScript(scriptSig, tx, nIn, hashType, function(err) {
     if (err) return callback(err);
     that.verifyStep2(scriptSig, scriptPubKey, tx, nIn,
       hashType, callback);

--- a/lib/browser/Point.js
+++ b/lib/browser/Point.js
@@ -8,7 +8,6 @@ var ECPointFp = require('../../browser/vendor-bundle.js').ECPointFp;
 var ECFieldElementFp = require('../../browser/vendor-bundle.js').ECFieldElementFp;
 var getSECCurveByName = require('../../browser/vendor-bundle.js').getSECCurveByName;
 var BigInteger = require('../../browser/vendor-bundle.js').BigInteger;
-var should = require('chai').should();
 
 //a point on the secp256k1 curve
 //x and y are bignums

--- a/test/test.Opcode.js
+++ b/test/test.Opcode.js
@@ -20,18 +20,6 @@ describe('Opcode', function() {
     var oc = new Opcode(81);
     should.exist(oc);
   });
-  it('should be able to create some constants', function() {
-    // TODO: test works in node but not in browser
-    for (var i in Opcode.map) {
-      eval('var ' + i + ' = ' + Opcode.map[i] + ';');
-    }
-    should.exist(OP_VER);
-    should.exist(OP_HASH160);
-    should.exist(OP_RETURN);
-    should.exist(OP_EQUALVERIFY);
-    should.exist(OP_CHECKSIG);
-    should.exist(OP_CHECKMULTISIG);
-  });
   it('#asList should work', function() {
     var list = Opcode.asList();
     (typeof(list[0])).should.equal('string');


### PR DESCRIPTION
- Global variable are also 'evil'.
- ScriptInterpreter.eval replaced by ScriptInterpreter.evalScript
- chaï use eval() and not used in Point.js (was included in bundle.js)
- no need to test if eval() works
