### PR TITLE
Script is not used in this example

### DIFF
--- a/examples/CreateAndSignTx-Multisig.js
+++ b/examples/CreateAndSignTx-Multisig.js
@@ -3,7 +3,6 @@ var run = function() {
   bitcore = typeof (bitcore) === 'undefined' ? require('../bitcore') : bitcore;
   var networks = require('../networks');
   var WalletKey = bitcore.WalletKey;
-  var Script = bitcore.Script;
   var Builder = bitcore.TransactionBuilder;
   var opts = {network: networks.testnet};
 


### PR DESCRIPTION
Removed the `Script` assignment as it doesn't seem it's used in the `CreateAndSignTx-Multisig` example.
