### PR TITLE
WIP: Add and expose SJCL and replace all browser crypto with SJCL

### DIFF
--- a/bitcore.js
+++ b/bitcore.js
@@ -60,5 +60,6 @@ requireWhenAccessed('WalletKey', './lib/WalletKey');
 requireWhenAccessed('PeerManager', './lib/PeerManager');
 requireWhenAccessed('Message', './lib/Message');
 requireWhenAccessed('Electrum', './lib/Electrum');
+requireWhenAccessed('sjcl', 'sjcl');
 module.exports.Buffer = Buffer;
 

--- a/browser/build.js
+++ b/browser/build.js
@@ -104,6 +104,9 @@ var createBitcore = function(opts) {
   b.require(opts.dir + 'buffers', {
     expose: 'buffers'
   });
+  b.require(opts.dir + 'sjcl', {
+    expose: 'sjcl'
+  });
   b.require('./' + opts.dir + 'bitcore', {
     expose: 'bitcore'
   });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "postinstall": "node browser/build.js -a"
   },
   "dependencies": {
+    "sjcl": "=1.0.1",
     "jssha": "=1.5.0",
     "soop": "=0.1.5",
     "bindings": "=1.1.1",


### PR DESCRIPTION
Bitcore exposes very little cryptography, which makes it difficult to develop new advanced features that depend on low-level crypto, especially elliptic curves. After investigating various crypto libraries, the SJCL seems like a very solid library that does everything we need and more. The idea of this PR is to add SJCL, expose it, and then update all the browser crypto to use SJCL instead of vendor-bundle.

Ultimately the idea here is to use SJCL in the browser, and OpenSSL in node, and develop a thorough crypto interface that works the same way in the browser and node along the way. This is the SJCL half of this project.

This is a WIP and all browser crypto has not yet been updated to use SJCL. I've merely added SJCL and exposed it (you can access it with bitcore.sjcl).

SJCL does not consume much filesize. Adding SJCL and then removing all the vendor-bundle files reduces the minified filesize of bitcore by about 20KB. Removing the browser/bignum.js file and using SJCL's bignum library would reduce the filesize even more.
