### PR TITLE
build browser/bundle.js in prepublish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "install": "node-gyp rebuild",
     "test": "mocha test -R spec",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter spec test",
-    "postinstall": "node browser/build.js -a"
+    "prepublish": "node browser/build.js -a"
   },
   "dependencies": {
     "jssha": "=1.5.0",


### PR DESCRIPTION
Doing stuff in `postinstall` for modules is frowned upon by many in the node community (doing it for applications is another thing)

Building `browser/bundle.js` in the `postinstall` step, means everyone has to build it when bitcore is installed. It's much better to do this in the `prepublish` step since we can build the bundle _once_ and be done with it. Technically this also means we could move `browserify` to devDependencies (unless something else has to use it in production).

Note that `prepublish` and `postinstall` are both fired when doing a local `npm install`, so if you're developing on bitcore, the bundle is created for you without you having to type `npm run-script prepublish`.

More info [here](https://www.npmjs.org/doc/misc/npm-scripts.html)

Note: This needs to be tested by someone that has access to your npm account :)

Cheers
