### PR TITLE
Fix to check for zero s value in sign function

### DIFF
--- a/lib/browser/Key.js
+++ b/lib/browser/Key.js
@@ -120,9 +120,8 @@ Key.prototype.signSync = function(hash) {
       var G = ecparams.getG();
       var Q = G.multiply(k);
       var r = Q.getX().toBigInteger().mod(n);
-    } while (r.compareTo(BigInteger.ZERO) <= 0);
-
-    var s = k.modInverse(n).multiply(e.add(d.multiply(r))).mod(n);
+      var s = k.modInverse(n).multiply(e.add(d.multiply(r))).mod(n);
+    } while (r.compareTo(BigInteger.ZERO) <= 0 || s.compareTo(BigInteger.ZERO) <= 0);
 
     return serializeSig(r, s);
   };


### PR DESCRIPTION
If r OR s are zero then recalculate both r and s until they are both non-zero values.
