### PR TITLE
Exporting a constant on TransactionBuilder for use on Copay

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -114,6 +114,8 @@ function TransactionBuilder(opts) {
   return this;
 }
 
+TransactionBuilder.FEE_PER_1000B_SAT = FEE_PER_1000B_SAT;
+
 /*
  * scriptForAddress
  *

--- a/test/test.TransactionBuilder.js
+++ b/test/test.TransactionBuilder.js
@@ -19,8 +19,6 @@ var vopts =  {
   dontVerifyStrictEnc: true
 };
 
-
-
 describe('TransactionBuilder', function() {
   it('should initialze the main object', function() {
     should.exist(TransactionBuilder);
@@ -40,6 +38,10 @@ describe('TransactionBuilder', function() {
     t.lockTime.should.equal(10);
   });
 
+  it('should be a fee in satoshi', function() {
+    var satoshi = TransactionBuilder.FEE_PER_1000B_SAT;
+    satoshi.should.equal(10000);
+  });
 
   var getBuilder = function (spendUnconfirmed) {
     var t = new TransactionBuilder({spendUnconfirmed: spendUnconfirmed})


### PR DESCRIPTION
In this PR:
- I Exported a constant for use out the file (TransactionBuilder). (For example on Copay, this is for check available funds to spend with fee included). 
- A simple test for this.
