### PR TITLE
Remove dead code in Script.js

### DIFF
--- a/lib/Script.js
+++ b/lib/Script.js
@@ -602,10 +602,6 @@ Script.stringToBuffer = function(s) {
           // string
           //console.log('string');
           word = word.substring(1, word.length - 1);
-          var hexString = '';
-          for (var c = 0; c < word.length; c++) {
-            hexString += '' + word.charCodeAt(c).toString(16);
-          }
           buf.put(Script.chunksToBuffer([new Buffer(word)]));
         } else {
           throw new Error('Could not parse word "' + word + '" from script "' + s + '"');


### PR DESCRIPTION
The `hexString` variable isn't used anywhere. By searching the git history it seems that it was there from the beginning.
