### PR TITLE
Solved: test vector that passes in node, but fails in browser/sjcl

### DIFF
--- a/lib/browser/ECIES.js
+++ b/lib/browser/ECIES.js
@@ -9,18 +9,10 @@ ECIES.symmetricEncrypt = function(key, iv, message) {
   var smessage = sjcl.codec.hex.toBits(message.toString('hex'));
 
   sjcl.beware["CBC mode is dangerous because it doesn't protect message integrity."]();
-  var params = {
-    iv: siv,
-    ks: 256,
-    ts: 128,
-    iter: 1000,
-    mode: 'cbc'
-  };
-  var encrypted = sjcl.encrypt(skey, smessage, params);
-  var enchex = sjcl.codec.hex.fromBits(sjcl.codec.base64.toBits(JSON.parse(encrypted).ct));
 
-  var encbuf = new Buffer(enchex, 'hex');
-
+  var cipher = new sjcl.cipher.aes(skey);
+  var encrypted = sjcl.mode.cbc.encrypt(cipher, smessage, siv);
+  var encbuf = new Buffer(sjcl.codec.hex.fromBits(encrypted), 'hex');
   var r = Buffer.concat([iv, encbuf]);
 
   return r;
@@ -31,25 +23,13 @@ ECIES.symmetricDecrypt = function(key, encrypted) {
   var iv = encrypted.slice(0, 16);
   var todecrypt = encrypted.slice(16, encrypted.length);
 
-  var siv = sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(iv.toString('hex')));
-  var sct = sjcl.codec.base64.fromBits(sjcl.codec.hex.toBits(todecrypt.toString('hex')));
-
   sjcl.beware["CBC mode is dangerous because it doesn't protect message integrity."]();
-  var obj = {
-    iv: siv,
-    v: 1,
-    iter: 1000,
-    ks: 256,
-    ts: 128,
-    mode: 'cbc',
-    adata: '',
-    cipher: 'aes',
-    ct: sct
-  };
-  var str = JSON.stringify(obj);
 
-  var decrypted = sjcl.decrypt(skey, str);
-  var decbuf = new Buffer(decrypted);
+  var encbits = sjcl.codec.hex.toBits(todecrypt.toString('hex'));
+  var ivbits = sjcl.codec.hex.toBits(iv.toString('hex'));
+  var cipher = new sjcl.cipher.aes(skey);
+  var decrypted = sjcl.mode.cbc.decrypt(cipher, encbits, ivbits);
+  var decbuf = new Buffer(sjcl.codec.hex.fromBits(decrypted), 'hex');
 
   return decbuf;
 };

--- a/test/test.ECIES.js
+++ b/test/test.ECIES.js
@@ -75,6 +75,48 @@ describe('ECIES', function() {
       decrypted.toString().should.equal('this is my message');
     });
 
+    it('should encrypt and decrypt 0x80 correctly, the first bad byte', function() {
+      var privhex = 'e0224327f5e4a9daea6c7b996cb013775f90821d15d7d0d25db517c7cd0c1a8e';
+      var key = new bitcore.Key();
+      key.private = new Buffer(privhex, 'hex');
+      key.regenerateSync();
+
+      var data = new Buffer([0x80]);
+      var encrypted = bitcore.ECIES.encrypt(key.public, data);
+      var decrypted = bitcore.ECIES.decrypt(key.private, encrypted);
+      decrypted.toString('hex').should.equal('80');
+      decrypted.toString('hex').should.not.equal('c280');
+    });
+
+    it('should encrypt and decrypt this known problematic encrypted message', function() {
+      var privhex = 'e0224327f5e4a9daea6c7b996cb013775f90821d15d7d0d25db517c7cd0c1a8e';
+      var key = new bitcore.Key();
+      key.private = new Buffer(privhex, 'hex');
+      key.regenerateSync();
+
+      var data = new Buffer('010053bdae9b000000017b2274797065223a2268656c6c6f222c22636f70617965724964223a22303237323735366234366561386564313763376166613934303861306161333535616266326432623263353134373637343766353135326332623535653163656230227d', 'hex');
+      var data = new Buffer('53bdae00', 'hex');
+
+      var encrypted = bitcore.ECIES.encrypt(key.public, data);
+      var decrypted = bitcore.ECIES.decrypt(key.private, encrypted);
+      decrypted.toString('hex').should.not.equal('53c2bdc2ae00');
+      decrypted.toString('hex').should.equal('53bdae00');
+
+    });
+
+    it('should encrypt and decrypt this known problematic encrypted message', function() {
+      var privhex = 'e0224327f5e4a9daea6c7b996cb013775f90821d15d7d0d25db517c7cd0c1a8e';
+      var key = new bitcore.Key();
+      key.private = new Buffer(privhex, 'hex');
+      key.regenerateSync();
+
+      var data = new Buffer('010053bdae9b000000017b2274797065223a2268656c6c6f222c22636f70617965724964223a22303237323735366234366561386564313763376166613934303861306161333535616266326432623263353134373637343766353135326332623535653163656230227d', 'hex');
+      var encrypted = bitcore.ECIES.encrypt(key.public, data);
+      var decrypted = bitcore.ECIES.decrypt(key.private, encrypted);
+      decrypted.toString('hex').should.equal('010053bdae9b000000017b2274797065223a2268656c6c6f222c22636f70617965724964223a22303237323735366234366561386564313763376166613934303861306161333535616266326432623263353134373637343766353135326332623535653163656230227d');
+
+    });
+
     it('should decrypt this known problematic encrypted message', function() {
       var privhex = 'e0224327f5e4a9daea6c7b996cb013775f90821d15d7d0d25db517c7cd0c1a8e';
       var key = new bitcore.Key();


### PR DESCRIPTION
There is some kind of problem either in bitcore or sjcl involving the
decodeURIComponent function. I discovered this issue while working on the
network protocol for Copay.  Decrypting binary data in sjcl produces problems
due to the way sjcl is interpreting data as strings. I will have to investigate
further tomorrow. For now I am producing this test vector to demonstrate the
issue. This test passes in mocha node, but fails in mocha browser.
