### PR TITLE
remove network stuff from main browser build

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -76,8 +76,11 @@ var createBitcore = function(opts) {
     submodules.splice(submodules.indexOf('lib/BIP39'), 1);
     submodules.splice(submodules.indexOf('lib/BIP39WordlistEn'), 1);
     submodules.splice(submodules.indexOf('lib/PayPro'), 1);
+    submodules.splice(submodules.indexOf('lib/Connection'), 1);
+    submodules.splice(submodules.indexOf('lib/Peer'), 1);
+    submodules.splice(submodules.indexOf('lib/PeerManager'), 1);
     var assert = require('assert');
-    assert(submodules.length == modules.length - 3);
+    assert(submodules.length == modules.length - 6);
   }
 
   if (opts.submodules) {


### PR DESCRIPTION
The network classes Connection, Peer and PeerManager are not useful from the browser, so I have removed them from the main browser bundle by default.  This saves several tens of kilobytes from the browser bundle (since not only are these files not included, but their dependencies are not included either).

Unfortunately the recently included cryptography change did not decrease the size of the bundle like I thought, but actually increased it. After reviewing the stuff that's in the bundle, I think almost everyone who uses bitcore will only use a small fraction of the available code. We should move away from having a bundle at all, and make bitcore more browserify-friendly by being pure javascript first, as mentioned in this issue: https://github.com/bitpay/bitcore/issues/420
