### PR TITLE
fix: typo - s/Payment/PaymentACK/

### DIFF
--- a/lib/common/PayPro.js
+++ b/lib/common/PayPro.js
@@ -105,7 +105,7 @@ PayPro.prototype.makePayment = function(obj) {
 };
 
 PayPro.prototype.makePaymentACK = function(obj) {
-  this.messageType = 'Payment';
+  this.messageType = 'PaymentACK';
   this.message = new PayPro.PaymentACK();
   this.setObj(obj);
   return this;


### PR DESCRIPTION
Fixes a typo with PaymentACK messsages.
