### PR TITLE
Fix loosing signatures after from-toObj roundtrip

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -445,7 +445,7 @@ TransactionBuilder._mapKeys = function(keys) {
     }
     var addr = wk.storeObj().addr;
     walletKeyMap[addr] = wk;
-    
+
   }
   return walletKeyMap;
 };
@@ -766,7 +766,7 @@ TransactionBuilder.prototype.sign = function(keys) {
     ins = tx.ins,
     l = ins.length,
     walletKeyMap = TransactionBuilder._mapKeys(keys);
-  
+
 
   for (var i = 0; i < l; i++) {
     var input = this.inputMap[i];
@@ -834,6 +834,17 @@ TransactionBuilder.prototype.toObj = function() {
   return ret;
 };
 
+TransactionBuilder.prototype._setScriptSig = function(inScriptSig) {
+  this.vanilla.scriptSig = inScriptSig;
+
+  for (var i in inScriptSig) {
+    this.tx.ins[i].s = new Buffer(inScriptSig[i], 'hex');
+    var scriptSig = new Script(this.tx.ins[i].s);
+    if (scriptSig.finishedMultiSig() !== false)
+      this.inputsSigned++;
+  }
+};
+
 // fromObj
 // -------
 // Returns a TransactionBuilder instance given
@@ -855,12 +866,8 @@ TransactionBuilder.fromObj = function(data) {
     if (data.outs) {
       b.setOutputs(data.outs);
 
-      for (var i in data.scriptSig) {
-        b.tx.ins[i].s = new Buffer(data.scriptSig[i], 'hex');
-
-        var scriptSig = new Script(b.tx.ins[i].s);
-        if (scriptSig.finishedMultiSig() !== false)
-          b.inputsSigned++;
+      if (data.scriptSig) {
+        b._setScriptSig(data.scriptSig);
       }
     }
   }

--- a/test/test.TransactionBuilder.js
+++ b/test/test.TransactionBuilder.js
@@ -919,6 +919,15 @@ describe('TransactionBuilder', function() {
       util.valueToBigInt(tx.outs[1].v).cmp(2990000).should.equal(0);
     });
 
+    it('#clone roundtrip, signed', function() {
+      var b = getBuilder3();
+      b.sign(testdata.dataUnspentSign.keyStrings);
+      b.isFullySigned().should.equal(true);
+
+      var b2 = b.clone().clone().clone();
+      b2.isFullySigned().should.equal(true);
+    });
+
     it('#toObj #fromObj roundtrip, step signatures p2sh/p2pubkeyhash', function() {
       var b = getP2shBuilder(1);
 
@@ -1204,8 +1213,5 @@ describe('TransactionBuilder', function() {
         b2.merge(b)
       }).should.throw('incompatible');
     });
-
-
-
   });
 });


### PR DESCRIPTION
- fromObj was not storing vanilla signatures to later serialization, therefore the roundtrip use to loose the transaction signatures.
