### PR TITLE
paypro: expose RootCerts on PayPro.

### DIFF
--- a/lib/common/PayPro.js
+++ b/lib/common/PayPro.js
@@ -18,6 +18,8 @@ PayPro.PAYMENT_REQUEST_CONTENT_TYPE = "application/bitcoin-paymentrequest";
 PayPro.PAYMENT_CONTENT_TYPE = "application/bitcoin-payment";
 PayPro.PAYMENT_ACK_CONTENT_TYPE = "application/bitcoin-paymentack";
 
+PayPro.RootCerts = RootCerts;
+
 PayPro.proto = {};
 
 PayPro.proto.Output = "message Output {\


### PR DESCRIPTION
This will be useful for copay.
