### PR TITLE
paypro: example - add another higher output to the server outputs.

### DIFF
--- a/examples/PayPro/server.js
+++ b/examples/PayPro/server.js
@@ -129,7 +129,7 @@ app.post('/-/request', function(req, res, next) {
 
   var outputs = [];
 
-  [2000, 1000].forEach(function(value) {
+  [2000, 1000, 10000].forEach(function(value) {
     var po = new PayPro();
     po = po.makeOutput();
     // number of satoshis to be paid


### PR DESCRIPTION
Right now the server outputs are asking for less than dust. This fixes that.
