### PR TITLE
k should be 32 bytes, not 8 bytes

### DIFF
--- a/lib/common/Key.js
+++ b/lib/common/Key.js
@@ -159,7 +159,8 @@ Key.calcPubKeyRecoveryParam = function(e, r, s, Q) {
 
 Key.genk = function() {
   //TODO: account for when >= n
-  return new bignum(SecureRandom.getRandomBuffer(8));
+  var k = new bignum(SecureRandom.getRandomBuffer(32))
+  return k;
 };
 
 module.exports = Key;


### PR DESCRIPTION
This is a bug with security implications. It is much easier to guess the value
of k within a 64 bit range. This would lead to compromised private keys.

The cryptography interface of bitcore is extremely poor. I recommend:
- Get rid of the C++ code, since it makes everything more difficult with little benefit
- Refactor all crypto, and have easily auditable bignum, point, ecdsa, and key classes
- Then actually audit the crypto
