### PR TITLE
paypro: example - sign customer transaction after output scripts are altered

### DIFF
--- a/examples/PayPro/customer.js
+++ b/examples/PayPro/customer.js
@@ -382,8 +382,7 @@ function createTX(outputs) {
 
   var b = new bitcore.TransactionBuilder(opts)
     .setUnspent(unspent)
-    .setOutputs(outs)
-    .sign(keys);
+    .setOutputs(outs);
 
   outputs.forEach(function(output, i) {
     var script = {
@@ -395,6 +394,8 @@ function createTX(outputs) {
     var s = script.buffer.slice(script.offset, script.limit);
     b.tx.outs[i].s = s;
   });
+
+  b = b.sign(keys);
 
   var tx = b.build();
 


### PR DESCRIPTION
Didn't notice this at first because it didn't really make a difference: the transaction signatures were still valid because the outputs didn't change at all. Everything still worked perfectly because of this. This fixes customer tx signing for the example.
