### PR TITLE
allowing sign keys to be strings

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -746,8 +746,9 @@ fnToSign[Script.TX_SCRIPTHASH] = TransactionBuilder.prototype._signScriptHash;
 // sign
 // ----
 // Signs a transaction. 
-// `keys`: an array of strings representing private keys to sign the 
-// transaction in WIF private key format OR bitcore's `WalletKey` objects
+// `keys`: an array of strings representing private keys to sign the transaction in WIF private key format 
+// OR bitcore's `WalletKey` objects 
+// OR string representing private keys to sign the transaction in WIF private key format separated by commas
 //
 // If multiple keys are given, each will be tested against the transaction's 
 // scriptPubKeys. Only the valid private keys will be used to sign.
@@ -758,6 +759,7 @@ fnToSign[Script.TX_SCRIPTHASH] = TransactionBuilder.prototype._signScriptHash;
 //
 //
 TransactionBuilder.prototype.sign = function(keys) {
+  if (typeof keys === "string") keys = keys.split(',');
   if (!(keys instanceof Array))
     throw new Error('parameter should be an array');
 


### PR DESCRIPTION
no need to pass array of one element to sign a transaction, you can simply pass the private key string (one or more separated by commas) and convert it to array. make user's life easier :)
