### PR TITLE
fix bug - 0 fee is not working!

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -109,10 +109,8 @@ function TransactionBuilder(opts) {
   this.lockTime = opts.lockTime || 0;
   this.spendUnconfirmed = opts.spendUnconfirmed || false;
 
-  if (opts.fee || opts.feeSat) {
-    this.givenFeeSat = opts.fee ? opts.fee * util.COIN : opts.feeSat;
-  }
-  if (opts.fee == 0 || opts.feeSat == 0) this.givenFeeSat = 0;
+  this.givenFeeSat = typeof(opts.fee) !== 'undefined' ? opts.fee * util.COIN : opts.feeSat;
+  
   this.remainderOut = opts.remainderOut;
   this.signhash = opts.signhash || Transaction.SIGHASH_ALL;
 
@@ -359,8 +357,7 @@ TransactionBuilder.prototype._setFeeAndRemainder = function(txobj) {
     /* based on https://en.bitcoin.it/wiki/Transaction_fees */
     maxSizeK = parseInt(size / 1000) + 1;
 
-    var feeSat = this.givenFeeSat || this.givenFeeSat == 0  ?
-      this.givenFeeSat : maxSizeK * FEE_PER_1000B_SAT;
+    var feeSat = typeof(this.givenFeeSat) !== 'undefined' ? this.givenFeeSat : maxSizeK * FEE_PER_1000B_SAT;
 
     var neededAmountSat = this.valueOutSat.add(feeSat);
 


### PR DESCRIPTION
if the user pass 0 fee (in fee or feeSat arguments) - there's a bug in the program that will add fee even if specified 0 fee:
- in case fee or feeSat is 0 the if statement `if (opts.fee || opts.feeSat)` will be false.
  from some reason `0 || undefined` in js returns `undefined` and in case a user set the fee to 0 in options this condition will not happen. 
- second fix: `var feeSat = this.givenFeeSat ? ...` fixed since if `this.givenFeeSat` is 0 the condition will return false (and we want true in this case) since `0 ? true : false` will return `false` in js language.
