### PR TITLE
Fixes unhandled exceptions in Transaction

### DIFF
--- a/lib/Address.js
+++ b/lib/Address.js
@@ -189,7 +189,13 @@ Address.fromPubkeyHashScriptSig = function(scriptSig, network) {
 //extract an address from scriptSig
 Address.fromScriptSig = function(scriptSig, network) {
   if (typeof scriptSig === 'string') {
-    scriptSig = new Script(new Buffer(scriptSig, 'hex'));
+    try {
+      var scriptSigBuf = new Buffer(scriptSig, 'hex')
+    } catch(err) {
+      // Error: Invalid public key
+      return null;
+    }
+    scriptSig = new Script(scriptSigBuf);
   }
   if (!network)
     network = 'livenet';

--- a/lib/Transaction.js
+++ b/lib/Transaction.js
@@ -633,19 +633,19 @@ Transaction.prototype.getReceivingAddresses = function(networkName) {
   ret = [];
   for (var i = 0; i<this.outs.length; i++) {
     var o = this.outs[i];
-    var tmp = Address.fromScriptPubKey(o.getScript(), networkName);
-    if (typeof tmp[0] !== 'undefined') {
-      var addr = tmp[0].toString();
-      ret.push(addr);
+    var addrs = Address.fromScriptPubKey(o.getScript(), networkName);
+    if (typeof addrs[0] !== 'undefined') {
+      ret.push(addrs[0].toString());
     } else {
       ret.push(null);
     }
   }
   return ret;
 };
+
 Transaction.prototype.getSendingAddresses = function(networkName) {
-  var ret = [];
   if (!networkName) networkName = 'livenet';
+  var ret = [];
   for (var i = 0; i<this.ins.length; i++) {
     var input = this.ins[i];
     var scriptSig = input.getScript();
@@ -653,13 +653,8 @@ Transaction.prototype.getSendingAddresses = function(networkName) {
       ret.push(null);
       continue;
     }
-    try {
-      var addr = Address.fromScriptSig(scriptSig, networkName);
-      ret.push(addr?addr.toString():null);
-    } catch(err) {
-      // Error: Invalid public key
-      ret.push(null);
-    }
+    var addr = Address.fromScriptSig(scriptSig, networkName);
+    ret.push(addr?addr.toString():null);
   }
   return ret;
 };


### PR DESCRIPTION
This fixes issue #468 handling 2 errors:
- Uncaught exception "Invalid public key" in `Transaction.getSendingAddresses()`, thrown inside `Address.fromScriptSig()`
- Correctly handles `undefined` in `Transaction.getReceivingAddresses()`, returned from `Address.fromScriptPubKey()`. This was causing `TypeError: Cannot call method 'toString' of undefined` as reported on #468

I didn't know how to create test transactions to write tests for it, if you could give some directions, I'd be happy to write some.
