### PR TITLE
syntax fix - typeof is not a function, it's  an operator

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -109,7 +109,7 @@ function TransactionBuilder(opts) {
   this.lockTime = opts.lockTime || 0;
   this.spendUnconfirmed = opts.spendUnconfirmed || false;
 
-  this.givenFeeSat = typeof(opts.fee) !== 'undefined' ? opts.fee * util.COIN : opts.feeSat;
+  this.givenFeeSat = typeof opts.fee !== 'undefined' ? opts.fee * util.COIN : opts.feeSat;
   
   this.remainderOut = opts.remainderOut;
   this.signhash = opts.signhash || Transaction.SIGHASH_ALL;
@@ -357,7 +357,7 @@ TransactionBuilder.prototype._setFeeAndRemainder = function(txobj) {
     /* based on https://en.bitcoin.it/wiki/Transaction_fees */
     maxSizeK = parseInt(size / 1000) + 1;
 
-    var feeSat = typeof(this.givenFeeSat) !== 'undefined' ? this.givenFeeSat : maxSizeK * FEE_PER_1000B_SAT;
+    var feeSat = typeof this.givenFeeSat !== 'undefined' ? this.givenFeeSat : maxSizeK * FEE_PER_1000B_SAT;
 
     var neededAmountSat = this.valueOutSat.add(feeSat);
 


### PR DESCRIPTION
following the comment of @shesek here: https://github.com/bitpay/bitcore/pull/500/files#r16642032
`typeof(foo)` should be `typeof foo`
