### PR TITLE
fix: this fixes a failing test in copay.

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -357,7 +357,7 @@ TransactionBuilder.prototype._setFeeAndRemainder = function(txobj) {
     /* based on https://en.bitcoin.it/wiki/Transaction_fees */
     maxSizeK = parseInt(size / 1000) + 1;
 
-    var feeSat = this.givenFeeSat != null ?
+    var feeSat = this.givenFeeSat ?
       this.givenFeeSat : maxSizeK * FEE_PER_1000B_SAT;
 
     var neededAmountSat = this.valueOutSat.add(feeSat);


### PR DESCRIPTION
Reverting this change that occurred between v0.1.35->v0.1.36 fixes a failing copay test in test.Wallet.
