### PR TITLE
peerDiscovery: add peerLimit - default: 32.

### DIFF
--- a/lib/PeerManager.js
+++ b/lib/PeerManager.js
@@ -26,7 +26,8 @@ function PeerManager(config) {
   this.pool = [];
   this.connections = [];
   this.isConnected = false;
-  this.peerDiscovery = false;
+  this.peerDiscovery = config.peerDiscovery || false;
+  this.peerLimit = config.peerLimit || 32;
 
   // Move these to the Node's settings object
   this.interval = 5000;
@@ -143,9 +144,11 @@ PeerManager.prototype.handleVersion = function(e) {
   if (!e.conn.inbound) {
     // TODO: Advertise our address (if listening)
   }
+
   // Get recent addresses
-  if (this.peerDiscovery &&
-    (e.message.version >= 31402 || this.peers.length < 1000)) {
+  if (this.peerDiscovery
+      && e.message.version >= 31402
+      && this.peers.length < this.peerLimit) {
     e.conn.sendGetAddr();
     e.conn.getaddr = true;
   }
@@ -187,7 +190,7 @@ PeerManager.prototype.handleAddr = function(e) {
       log.warn("Invalid addr received: " + e.message);
     }
   }.bind(this));
-  if (e.message.addrs.length < 1000) {
+  if (e.message.addrs.length < this.peerLimit) {
     e.conn.getaddr = false;
   }
 };


### PR DESCRIPTION
Add a peer limit to peer discovery. Having it hardcoded at 1000 hits the ulimit in most OS's and is generally unnecessary. 32 is a reasonable default.
