### PR TITLE
make default bundle have all submodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "install": "node-gyp rebuild",
     "test": "node browser/build.js -a && node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --reporter spec test",
-    "prepublish": "node browser/build.js -m"
+    "prepublish": "node browser/build.js -a"
   },
   "dependencies": {
     "grunt-browserify": "~2.0.0",


### PR DESCRIPTION
The default browser build should contain all modules. If not, tests won't pass by default (you have to run `grunt` to make them work). 
