### PR TITLE
allowing sign keys to be strings

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -744,8 +744,9 @@ fnToSign[Script.TX_SCRIPTHASH] = TransactionBuilder.prototype._signScriptHash;
 // sign
 // ----
 // Signs a transaction. 
-// `keys`: an array of strings representing private keys to sign the 
-// transaction in WIF private key format OR bitcore's `WalletKey` objects
+// `keys`: an array of strings representing private keys to sign the transaction in WIF private key format 
+// OR bitcore's `WalletKey` objects 
+// OR string representing private keys to sign the transaction in WIF private key format separated by commas
 //
 // If multiple keys are given, each will be tested against the transaction's 
 // scriptPubKeys. Only the valid private keys will be used to sign.
@@ -756,6 +757,7 @@ fnToSign[Script.TX_SCRIPTHASH] = TransactionBuilder.prototype._signScriptHash;
 //
 //
 TransactionBuilder.prototype.sign = function(keys) {
+  if (typeof keys === "string") keys = keys.split(',');
   if (!(keys instanceof Array))
     throw new Error('parameter should be an array');
 

--- a/test/test.TransactionBuilder.js
+++ b/test/test.TransactionBuilder.js
@@ -935,7 +935,7 @@ describe('TransactionBuilder', function() {
     var b = getP2shBuilder(1);
     (function() {
       b.sign(testdata.dataUnspentSign.keyStringsP2sh[0])
-    }).should.throw('array');
+    }).should.not.throw('array');
   });
 
 


### PR DESCRIPTION
Same PR as https://github.com/bitpay/bitcore/pull/499, but with test fixed

no need to pass array of one element to sign a transaction, you can simply pass the private key string (one or more separated by commas) and convert it to array. make user's life easier :)
