### PR TITLE
serialize only the list of selected utxos, if available

### DIFF
--- a/lib/TransactionBuilder.js
+++ b/lib/TransactionBuilder.js
@@ -821,10 +821,12 @@ TransactionBuilder.prototype.build = function() {
 //
 TransactionBuilder.prototype.toObj = function() {
 
+  var utxos = this.selectedUtxos && this.selectedUtxos[0] ? this.selectedUtxos : JSON.parse(this.vanilla.utxos);
+
   var ret = {
     version: TOOBJ_VERSION,
     outs: JSON.parse(this.vanilla.outs),
-    utxos: JSON.parse(this.vanilla.utxos),
+    utxos: utxos,
     opts: JSON.parse(this.vanilla.opts),
     scriptSig: this.vanilla.scriptSig,
   };


### PR DESCRIPTION
- This PR  change the serialization of TX builder to only include selectedUTXOS (if they exists) and not old the given list of utxos. The resulting output is therefore smaller. 

Sending the entire UTXOs list don't have advantages from a security perspective.
