### PR TITLE
Allow SSL connections to bitcoind

### DIFF
--- a/lib/RpcClient.js
+++ b/lib/RpcClient.js
@@ -15,6 +15,7 @@ function RpcClient(opts) {
   this.protocol = (opts.protocol == 'http') ? http : https;
   this.batchedCalls = null;
   this.disableAgent = opts.disableAgent || false;
+  this.rejectUnauthorized = opts.rejectUnauthorized || false;
 }
 
 RpcClient.prototype.batch = function(batchCallback, resultCallback) {
@@ -163,7 +164,7 @@ function rpc(request, callback) {
     path: '/',
     method: 'POST',
     port: self.port,
-    rejectUnauthorized: false,
+    rejectUnauthorized: self.rejectUnauthorized,
     agent: self.disableAgent ? false : undefined,
   };
   if (self.httpOptions) {


### PR DESCRIPTION
This is required as, by default, self-signed certificates are rejected. Most users of bitcoin use self-signed certificates. This was commented upon in #436
