### PR TITLE
Move input to subfolder before refactor

### DIFF
--- a/lib/transaction/input/index.js
+++ b/lib/transaction/input/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var Input = require('./input');
+
+module.exports = Input;

--- a/lib/transaction/input/input.js
+++ b/lib/transaction/input/input.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var _ = require('lodash');
-var BufferWriter = require('../encoding/bufferwriter');
+var BufferWriter = require('../../encoding/bufferwriter');
 var buffer = require('buffer');
-var bufferUtil = require('../util/buffer');
-var jsUtil = require('../util/js');
-var Script = require('../script');
+var bufferUtil = require('../../util/buffer');
+var jsUtil = require('../../util/js');
+var Script = require('../../script');
 
 function Input(params) {
   if (!(this instanceof Input)) {


### PR DESCRIPTION
Gonna inherit from it on two subclasses: "P2SH Input" and "P2PKH Input"

They'll have a `addSignature` method, to deal with new signatures, a `clearSignatures`, in case the outputs change and the signatures get invalidated, `countMissingSignatures`, and a reference to the UTXO they'll be spending, so all logic regarding "p2sh mapping" (redeem script info) gets to be in here and the Transaction class is not polluted.
