### PR TITLE
Remove compressed argument from PrivateKey and PublicKey constructors

### DIFF
--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -29,18 +29,17 @@ var Random = require('./crypto/random');
  *
  * @param {String} data - The encoded data in various formats
  * @param {String} [network] - Either "livenet" or "testnet"
- * @param {Boolean} [compressed] - If the key is in compressed format
  * @returns {PrivateKey} A new valid instance of an PrivateKey
  * @constructor
  */
-var PrivateKey = function PrivateKey(data, network, compressed) {
+var PrivateKey = function PrivateKey(data, network) {
 
   if (!(this instanceof PrivateKey)) {
-    return new PrivateKey(data, network, compressed);
+    return new PrivateKey(data, network);
   }
 
   var info = {
-    compressed: typeof(compressed) !== 'undefined' ? compressed : true,
+    compressed: true,
     network: network ? Networks.get(network) : Networks.defaultNetwork
   };
 
@@ -50,12 +49,14 @@ var PrivateKey = function PrivateKey(data, network, compressed) {
   } else if (data instanceof BN) {
     info.bn = data;
   } else if (data instanceof Buffer || data instanceof Uint8Array) {
-    info = PrivateKey._transformBuffer(data, network, compressed);
+    info = PrivateKey._transformBuffer(data, network);
+  } else if (PrivateKey._isJSON(data)){
+    info = PrivateKey._transformJSON(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
       info.bn = BN(new Buffer(data, 'hex'));
     } else {
-      info = PrivateKey._transformWIF(data, network, compressed);
+      info = PrivateKey._transformWIF(data, network);
     }
   } else {
     throw new TypeError('First argument is an unrecognized data type.');
@@ -70,9 +71,6 @@ var PrivateKey = function PrivateKey(data, network, compressed) {
   }
   if (typeof(info.network) === 'undefined') {
     throw new TypeError('Must specify the network ("livenet" or "testnet")');
-  }
-  if (typeof(info.compressed) !== 'boolean') {
-    throw new TypeError('Must specify whether the corresponding public key is compressed or not (true or false)');
   }
 
   Object.defineProperty(this, 'bn', {
@@ -92,12 +90,7 @@ var PrivateKey = function PrivateKey(data, network, compressed) {
 
   Object.defineProperty(this, 'publicKey', {
     configurable: false,
-    get: function() {
-      if (!info.publicKey) {
-        info.publicKey = this.toPublicKey();
-      }
-      return info.publicKey;
-    }
+    get: this.toPublicKey.bind(this)
   });
 
   return this;
@@ -122,15 +115,25 @@ PrivateKey._getRandomBN = function(){
 };
 
 /**
+ * Internal function to detect if a param is a JSON string or plain object
+ *
+ * @param {*} param - value to test
+ * @returns {boolean}
+ * @private
+ */
+PrivateKey._isJSON = function(json) {
+  return JSUtil.isValidJSON(json) || (json.bn && json.network && json.compressed);
+};
+
+/**
  * Internal function to transform a WIF Buffer into a private key
  *
  * @param {Buffer} buf - An WIF string
  * @param {String} [network] - Either "livenet" or "testnet"
- * @param {String} [compressed] - If the private key is compressed
  * @returns {Object} An object with keys: bn, network and compressed
  * @private
  */
-PrivateKey._transformBuffer = function(buf, network, compressed) {
+PrivateKey._transformBuffer = function(buf, network) {
 
   var info = {};
 
@@ -154,10 +157,6 @@ PrivateKey._transformBuffer = function(buf, network, compressed) {
     throw TypeError('Private key network mismatch');
   }
 
-  if (typeof(compressed) !== 'undefined' && info.compressed !== compressed){
-    throw TypeError('Private key compression mismatch');
-  }
-
   info.bn = BN.fromBuffer(buf.slice(1, 32 + 1));
 
   return info;
@@ -171,19 +170,8 @@ PrivateKey._transformBuffer = function(buf, network, compressed) {
  * @returns {Object} An object with keys: bn, network and compressed
  * @private
  */
-PrivateKey._transformWIF = function(str, network, compressed) {
-  return PrivateKey._transformBuffer(base58check.decode(str), network, compressed);
-};
-
-/**
- * Instantiate a PrivateKey from a WIF string
- *
- * @param {String} str - The WIF encoded private key string
- * @returns {PrivateKey} A new valid instance of PrivateKey
- */
-PrivateKey.fromWIF = function(str) {
-  var info = PrivateKey._transformWIF(str);
-  return new PrivateKey(info.bn, info.network, info.compressed);
+PrivateKey._transformWIF = function(str, network) {
+  return PrivateKey._transformBuffer(base58check.decode(str), network);
 };
 
 /**
@@ -193,23 +181,31 @@ PrivateKey.fromWIF = function(str) {
  * @returns {PrivateKey} A new valid instance of PrivateKey
  */
 PrivateKey.fromJSON = function(json) {
+  if (!PrivateKey._isJSON(json)) {
+    throw new TypeError('Must be a valid JSON string or plain object');
+  }
+
+  return new PrivateKey(json);
+};
+
+
+/**
+ * Internal function to transform a JSON string on plain object into a private key
+ *
+ * @param {String} json - A JSON string or plain object
+ * @returns {Object} An object with keys: bn, network and compressed
+ * @private
+ */
+PrivateKey._transformJSON = function(json) {
   if (JSUtil.isValidJSON(json)) {
     json = JSON.parse(json);
   }
   var bn = BN(json.bn, 'hex');
-  return new PrivateKey(bn, json.network, json.compressed);
-};
-
-/**
- * Instantiate a PrivateKey from random bytes
- *
- * @param {String} [network] - Either "livenet" or "testnet"
- * @param {String} [compressed] - If the private key is compressed
- * @returns {PrivateKey} A new valid instance of PrivateKey
- */
-PrivateKey.fromRandom = function(network, compressed) {
-  var bn = PrivateKey._getRandomBN();
-  return new PrivateKey(bn, network, compressed);
+  return {
+    bn: bn,
+    network: json.network,
+    compressed: json.compressed
+  }
 };
 
 /**
@@ -218,9 +214,19 @@ PrivateKey.fromRandom = function(network, compressed) {
  * @param {String} str - The WIF encoded private key string
  * @returns {PrivateKey} A new valid instance of PrivateKey
  */
-PrivateKey.fromString = function(str) {
-  var info = PrivateKey._transformWIF(str);
-  return new PrivateKey(info.bn, info.network, info.compressed);
+PrivateKey.fromString = PrivateKey.fromWIF = function(str) {
+  return new PrivateKey(str);
+};
+
+/**
+ * Instantiate a PrivateKey from random bytes
+ *
+ * @param {String} [network] - Either "livenet" or "testnet"
+ * @returns {PrivateKey} A new valid instance of PrivateKey
+ */
+PrivateKey.fromRandom = function(network) {
+  var bn = PrivateKey._getRandomBN();
+  return new PrivateKey(bn, network);
 };
 
 /**
@@ -228,14 +234,13 @@ PrivateKey.fromString = function(str) {
  *
  * @param {String} data - The encoded data in various formats
  * @param {String} [network] - Either "livenet" or "testnet"
- * @param {String} [compressed] - If the private key is compressed
  * @returns {null|Error} An error if exists
  */
 
-PrivateKey.getValidationError = function(data, network, compressed) {
+PrivateKey.getValidationError = function(data, network) {
   var error;
   try {
-    new PrivateKey(data, network, compressed);
+    new PrivateKey(data, network);
   } catch (e) {
     error = e;
   }
@@ -247,11 +252,10 @@ PrivateKey.getValidationError = function(data, network, compressed) {
  *
  * @param {String} data - The encoded data in various formats
  * @param {String} [network] - Either "livenet" or "testnet"
- * @param {String} [compressed] - If the private key is compressed
  * @returns {Boolean} If the private key is would be valid
  */
-PrivateKey.isValid = function(data, network, compressed){
-  return !PrivateKey.getValidationError(data, network, compressed);
+PrivateKey.isValid = function(data, network){
+  return !PrivateKey.getValidationError(data, network);
 };
 
 /**
@@ -259,7 +263,7 @@ PrivateKey.isValid = function(data, network, compressed){
  *
  * @returns {String} A WIP representation of the private key
  */
-PrivateKey.prototype.toWIF = function() {
+PrivateKey.prototype.toString = PrivateKey.prototype.toWIF = function() {
   var network = this.network;
   var compressed = this.compressed;
 
@@ -300,7 +304,10 @@ PrivateKey.prototype.toBuffer = function(){
  * @returns {PublicKey} A public key generated from the private key
  */
 PrivateKey.prototype.toPublicKey = function(){
-  return PublicKey.fromPrivateKey(this);
+  if (!this._pubkey) {
+    this._pubkey = PublicKey.fromPrivateKey(this);
+  }
+  return this._pubkey;
 };
 
 /**
@@ -329,21 +336,13 @@ PrivateKey.prototype.toJSON = function toJSON() {
 };
 
 /**
- * Will output the PrivateKey to a WIF string
- *
- * @returns {String} A WIF representation of the private key
- */
-PrivateKey.prototype.toString = function() {
-  return this.toWIF();
-};
-
-/**
  * Will return a string formatted for the console
  *
  * @returns {String} Private key
  */
 PrivateKey.prototype.inspect = function() {
-  return '<PrivateKey: ' + this.toString() + ', compressed: '+this.compressed+', network: '+this.network+'>';
+  var uncompressed = !this.compressed ? ', uncompressed' : '';
+  return '<PrivateKey: ' + this.toString() + ', network: ' + this.network + uncompressed + '>';
 };
 
 module.exports = PrivateKey;

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -20,14 +20,13 @@ var JSUtil = require('./util/js');
  * var imported = PublicKey.fromString(exported);
  *
  * @param {String} data - The encoded data in various formats
- * @param {String} [compressed] - If the public key is compressed
  * @returns {PublicKey} A new valid instance of an PublicKey
  * @constructor
  */
-var PublicKey = function PublicKey(data, compressed) {
+var PublicKey = function PublicKey(data) {
 
   if (!(this instanceof PublicKey)) {
-    return new PublicKey(data, compressed);
+    return new PublicKey(data);
   }
 
   if (!data) {
@@ -39,18 +38,19 @@ var PublicKey = function PublicKey(data, compressed) {
   }
 
   var info = {
-    compressed: typeof(compressed) !== 'undefined' ? compressed : true
+    compressed: true
   };
 
   // detect type of data
   if (data instanceof Point) {
     info.point = data;
-  } else if (typeof(data) === 'string'){
+  } else if (PublicKey._isJSON(data)) {
+    info = PublicKey._transformJSON(data);
+  } else if (typeof(data) === 'string') {
     info = PublicKey._transformDER(new Buffer(data, 'hex'));
-  } else if (data instanceof Buffer || data instanceof Uint8Array){
+  } else if (PublicKey._isBuffer(data)) {
     info = PublicKey._transformDER(data);
-  } else if (data.constructor && (data.constructor.name &&
-                                  data.constructor.name === 'PrivateKey')) {
+  } else if (PublicKey._isPrivateKey(data)) {
     info = PublicKey._transformPrivateKey(data);
   } else {
     throw new TypeError('First argument is an unrecognized data format.');
@@ -69,8 +69,47 @@ var PublicKey = function PublicKey(data, compressed) {
     value: info.compressed
   });
 
+  Object.defineProperty(this, 'address', {
+    configurable: false,
+    get: this.toAddress.bind(this)
+  });
+
   return this;
 
+};
+
+/**
+ * Internal function to detect if an object is a PrivateKey
+ *
+ * @param {*} param - object to test
+ * @returns {boolean}
+ * @private
+ */
+PublicKey._isPrivateKey = function(param) {
+  return param && param.constructor && param.constructor.name
+      && param.constructor.name === 'PrivateKey';
+};
+
+/**
+ * Internal function to detect if an object is a Buffer
+ *
+ * @param {*} param - object to test
+ * @returns {boolean}
+ * @private
+ */
+PublicKey._isBuffer = function(param) {
+  return (param instanceof Buffer) || (param instanceof Uint8Array);
+};
+
+/**
+ * Internal function to detect if a param is a JSON string or plain object
+ *
+ * @param {*} param - value to test
+ * @returns {boolean}
+ * @private
+ */
+PublicKey._isJSON = function(json) {
+  return JSUtil.isValidJSON(json) || (json.x && json.y);
 };
 
 /**
@@ -82,8 +121,7 @@ var PublicKey = function PublicKey(data, compressed) {
  */
 PublicKey._transformPrivateKey = function(privkey) {
   var info = {};
-  if (!privkey.constructor ||
-      (privkey.constructor.name && privkey.constructor.name !== 'PrivateKey')) {
+  if (!PublicKey._isPrivateKey(privkey)) {
     throw new TypeError('Must be an instance of PrivateKey');
   }
   info.point = Point.getG().mul(privkey.bn);
@@ -100,7 +138,7 @@ PublicKey._transformPrivateKey = function(privkey) {
  */
 PublicKey._transformDER = function(buf){
   var info = {};
-  if (!(buf instanceof Buffer) && !(buf instanceof Uint8Array)){
+  if (!PublicKey._isBuffer(buf)) {
     throw new TypeError('Must be a hex buffer of DER encoded public key');
   }
 
@@ -159,13 +197,31 @@ PublicKey._transformX = function(odd, x){
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromJSON = function(json) {
+  if (!PublicKey._isJSON(json)) {
+    throw new TypeError('Must be a valid JSON string or plain object');
+  }
+
+  return new PublicKey(json);
+};
+
+/**
+ * Internal function to transform a JSON into a public key point
+ *
+ * @param {Buffer} buf - a JSON string or plain object
+ * @returns {Object} An object with keys: point and compressed
+ * @private
+ */
+PublicKey._transformJSON = function(json) {
   if (JSUtil.isValidJSON(json)) {
     json = JSON.parse(json);
   }
   var x = BN(json.x, 'hex');
   var y = BN(json.y, 'hex');
-  var point = new Point(x, y);
-  return new PublicKey(point, json.compressed);
+
+  return {
+    point: Point(x, y),
+    compressed: json.compressed
+  };
 };
 
 /**
@@ -175,19 +231,23 @@ PublicKey.fromJSON = function(json) {
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromPrivateKey = function(privkey) {
-  var info = PublicKey._transformPrivateKey(privkey);
-  return new PublicKey(info.point, info.compressed);
+  if (!PublicKey._isPrivateKey(privkey)) {
+    throw new TypeError('Must be an instance of PrivateKey');
+  }
+  return new PublicKey(privkey);
 };
 
 /**
  * Instantiate a PublicKey from a Buffer
  *
- * @param {Buffer} buf - A DER hex buffer
+ * @param {Buffer} buf - A DER buffer
  * @returns {PublicKey} A new valid instance of PublicKey
  */
-PublicKey.fromBuffer = function(buf) {
-  var info = PublicKey._transformDER(buf);
-  return new PublicKey(info.point, info.compressed);
+PublicKey.fromDER = PublicKey.fromBuffer = function(buf) {
+  if (!PublicKey._isBuffer(buf)) {
+    throw new TypeError('Must be a hex buffer of DER encoded public key');
+  }
+  return new PublicKey(buf);
 };
 
 /**
@@ -196,26 +256,15 @@ PublicKey.fromBuffer = function(buf) {
  * @param {Point} point - A Point instance
  * @returns {PublicKey} A new valid instance of PublicKey
  */
-PublicKey.fromPoint = function(point, compressed){
+PublicKey.fromPoint = function(point){
   if (!(point instanceof Point)) {
     throw new TypeError('First argument must be an instance of Point.');
   }
-  return new PublicKey(point, compressed);
+  return new PublicKey(point);
 };
 
 /**
  * Instantiate a PublicKey from a DER Buffer
- *
- * @param {Buffer} buf - A DER Buffer
- * @returns {PublicKey} A new valid instance of PublicKey
- */
-PublicKey.fromDER = function(buf) {
-  var info = PublicKey._transformDER(buf);
-  return new PublicKey(info.point, info.compressed);
-};
-
-/**
- * Instantiate a PublicKey from a DER hex encoded string
  *
  * @param {String} str - A DER hex string
  * @param {String} [encoding] - The type of string encoding
@@ -223,8 +272,7 @@ PublicKey.fromDER = function(buf) {
  */
 PublicKey.fromString = function(str, encoding) {
   var buf = new Buffer(str, encoding || 'hex');
-  var info = PublicKey._transformDER(buf);
-  return new PublicKey(info.point, info.compressed);
+  return new PublicKey(buf);
 };
 
 /**
@@ -236,9 +284,8 @@ PublicKey.fromString = function(str, encoding) {
  */
 PublicKey.fromX = function(odd, x) {
   var info = PublicKey._transformX(odd, x);
-  return new PublicKey(info.point, info.compressed);
+  return new PublicKey(info.point);
 };
-
 
 /**
  * Check if there would be any errors when initializing a PublicKey
@@ -284,26 +331,11 @@ PublicKey.prototype.toJSON = function toJSON(){
 };
 
 /**
- * Will output the PublicKey to a Buffer
- *
- * @returns {Buffer} A DER hex encoded buffer
- */
-PublicKey.prototype.toBuffer = function() {
-  var compressed = typeof this.compressed === 'undefined' ? true : this.compressed;
-  return this.toDER(compressed);
-};
-
-/**
  * Will output the PublicKey to a DER Buffer
  *
  * @returns {Buffer} A DER hex encoded buffer
  */
-PublicKey.prototype.toDER = function(compressed) {
-  compressed = typeof(compressed) !== 'undefined' ? compressed : this.compressed;
-  if (typeof compressed !== 'boolean') {
-    throw new TypeError('Must specify whether the public key is compressed or not (true or false)');
-  }
-
+PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
   var x = this.point.getX();
   var y = this.point.getY();
 
@@ -311,7 +343,7 @@ PublicKey.prototype.toDER = function(compressed) {
   var ybuf = y.toBuffer({size: 32});
 
   var prefix;
-  if (!compressed) {
+  if (!this.compressed) {
     prefix = new Buffer([0x04]);
     return Buffer.concat([prefix, xbuf, ybuf]);
   } else {
@@ -340,8 +372,7 @@ PublicKey.prototype.toAddress = function(network) {
  * @returns {String} A DER hex encoded string
  */
 PublicKey.prototype.toString = function() {
-  var compressed = typeof this.compressed === 'undefined' ? true : this.compressed;
-  return this.toDER(compressed).toString('hex');
+  return this.toDER().toString('hex');
 };
 
 /**
@@ -350,7 +381,8 @@ PublicKey.prototype.toString = function() {
  * @returns {String} Public key
  */
 PublicKey.prototype.inspect = function() {
-  return '<PublicKey: ' + this.toString() + ', compressed: '+this.compressed+'>';
+  var uncompressed = !this.compressed ? ', uncompressed' : '';
+  return '<PublicKey: ' + this.toString() + uncompressed + '>';
 };
 
 module.exports = PublicKey;

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -79,12 +79,6 @@ describe('PrivateKey', function() {
     }).to.throw('Private key network mismatch');
   });
 
-  it('should not be able to instantiate private key because of compression mismatch', function() {
-    expect(function() {
-      var a = new PrivateKey('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m', 'livenet', false);
-    }).to.throw('Private key compression mismatch');
-  });
-
   it('should not be able to instantiate private key WIF is too long', function() {
     expect(function() {
       var buf = base58check.decode('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
@@ -108,12 +102,6 @@ describe('PrivateKey', function() {
     privkey.publicKey.toString().should.equal(pubhex);
   });
 
-  it('should not be able to instantiate because compressed is non-boolean', function() {
-    expect(function() {
-      var a = new PrivateKey(BN(2), 'testnet', 'compressed');
-    }).to.throw('Must specify whether the corresponding public key is compressed or not (true or false)');
-  });
-
   it('should not be able to instantiate because of unrecognized data', function() {
     expect(function() {
       var a = new PrivateKey(new Error());
@@ -134,7 +122,7 @@ describe('PrivateKey', function() {
   });
 
   it('should create a livenet private key', function() {
-    var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet', true);
+    var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet');
     privkey.toString().should.equal(enclivenet);
   });
 
@@ -147,16 +135,6 @@ describe('PrivateKey', function() {
     b.network.should.equal(Networks.testnet);
     // restore the default
     Networks.defaultNetwork = Networks.livenet;
-  });
-
-  it('should create an uncompressed testnet private key', function() {
-    var privkey = new PrivateKey(BN.fromBuffer(buf), 'testnet', false);
-    privkey.toString().should.equal(enctu);
-  });
-
-  it('should create an uncompressed livenet private key', function() {
-    var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet', false);
-    privkey.toString().should.equal(encmu);
   });
 
   describe('#json', function() {
@@ -199,12 +177,12 @@ describe('PrivateKey', function() {
   describe('#inspect', function() {
     it('should output known livenet address for console', function() {
       var privkey = PrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
-      privkey.inspect().should.equal('<PrivateKey: L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m, compressed: true, network: livenet>');
+      privkey.inspect().should.equal('<PrivateKey: L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m, network: livenet>');
     });
 
     it('should output known testnet address for console', function() {
       var privkey = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
-      privkey.inspect().should.equal('<PrivateKey: cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq, compressed: true, network: testnet>');
+      privkey.inspect().should.equal('<PrivateKey: cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq, network: testnet>');
     });
 
   });
@@ -231,7 +209,7 @@ describe('PrivateKey', function() {
 
   describe('#toBuffer', function() {
     it('should output known buffer', function() {
-      var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet', true);
+      var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet');
       var b = privkey.toBuffer().toString('hex').should.equal(buf.toString('hex'));
     });
   });
@@ -239,7 +217,7 @@ describe('PrivateKey', function() {
   describe('#toBigNumber', function() {
     it('should output known BN', function() {
       var a = BN.fromBuffer(buf);
-      var privkey = new PrivateKey(a, 'livenet', true);
+      var privkey = new PrivateKey(a, 'livenet');
       var b = privkey.toBigNumber();
       b.toString('hex').should.equal(a.toString('hex'));
     });
@@ -310,15 +288,15 @@ describe('PrivateKey', function() {
     });
 
     it('should convert this known PrivateKey to known PublicKey and preserve compressed=true', function() {
-      var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
-      var privkey = new PrivateKey(BN(new Buffer(privhex, 'hex')), 'livenet', true);
+      var privwif = 'L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m';
+      var privkey = new PrivateKey(privwif, 'livenet');
       var pubkey = privkey.toPublicKey();
       pubkey.compressed.should.equal(true);
     });
 
-    it('should convert this known PrivateKey to known PublicKey and preserve compressed=true', function() {
-      var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
-      var privkey = new PrivateKey(BN(new Buffer(privhex, 'hex')), 'livenet', false);
+    it('should convert this known PrivateKey to known PublicKey and preserve compressed=false', function() {
+      var privwif = '92jJzK4tbURm1C7udQXxeCBvXHoHJstDXRxAMouPG1k1XUaXdsu';
+      var privkey = new PrivateKey(privwif, 'testnet');
       var pubkey = privkey.toPublicKey();
       pubkey.compressed.should.equal(false);
     });

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -241,6 +241,12 @@ describe('PublicKey', function() {
       pk.toBuffer().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });
 
+    it('should return this uncompressed DER format', function() {
+      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
+      var pk = PublicKey.fromX(true, x);
+      pk.toBuffer().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
+    });
+
   });
 
   describe('#toDER', function() {
@@ -248,23 +254,13 @@ describe('PublicKey', function() {
     it('should return this compressed DER format', function() {
       var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
       var pk = PublicKey.fromX(true, x);
-      pk.toDER(true).toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
+      pk.toDER().toString('hex').should.equal('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
     });
 
     it('should return this uncompressed DER format', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
-      var pk = PublicKey.fromX(true, x);
-      pk.toDER(false).toString('hex').should.equal('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
+      var pk = PublicKey.fromString('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
+      pk.toDER().toString('hex').should.equal('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
     });
-
-    it('should error because compressed param is invalid', function() {
-      var x = BN.fromBuffer(new Buffer('1ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a', 'hex'));
-      var pk = PublicKey.fromX(true, x);
-      (function() {
-        pk.toDER('false'); //string not boolean
-      }).should.throw('Must specify whether the public key is compressed or not (true or false)');
-    });
-
   });
 
   describe('#toAddress', function() {
@@ -296,12 +292,12 @@ describe('PublicKey', function() {
   describe('#inspect', function() {
     it('should output known uncompressed pubkey for console', function() {
       var pubkey = PublicKey.fromString('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
-      pubkey.inspect().should.equal('<PublicKey: 041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341, compressed: false>');
+      pubkey.inspect().should.equal('<PublicKey: 041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341, uncompressed>');
     });
 
     it('should output known compressed pubkey for console', function() {
       var pubkey = PublicKey.fromString('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
-      pubkey.inspect().should.equal('<PublicKey: 031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a, compressed: true>');
+      pubkey.inspect().should.equal('<PublicKey: 031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a>');
     });
 
   });


### PR DESCRIPTION
Rationale:
- Bitcore v0.8 goal is to simplify interfaces and reduce the knowledge required by the user-developer.
- The `compressed` format is the standard way to represent a private/public key.
- If a new key is generated it should be using the standard format.
- Allowing the user-developer to create new random keys using the uncompressed format adds unnecessary complexity.
- Creating a key from an `uncompressed` format must work though.
