### PR TITLE
Add remote ref to modified template

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,12 +99,13 @@
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
     "gulp-shell": "^0.2.10",
-    "mocha": "~2.0.1",
-    "run-sequence": "^1.0.2",
-    "sinon": "^1.12.2",
+    "ink-docstrap": "git://github.com/eordano/bitcore-template.git",
     "karma": "^0.12.28",
     "karma-firefox-launcher": "^0.1.3",
-    "karma-mocha": "^0.1.9"
+    "karma-mocha": "^0.1.9",
+    "mocha": "~2.0.1",
+    "run-sequence": "^1.0.2",
+    "sinon": "^1.12.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
So, I couldn't figure out a way to modify `docstrap` templates, so I propose we reference a fork of it. For now, I will host it on my github, but we should move it to `bitpay`'s account after due approval.
