### PR TITLE
Change PrivateKey.toString from WIF to hex format

### DIFF
--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -284,11 +284,20 @@ PrivateKey.isValid = function(data, network){
 };
 
 /**
+ * Will output the PublicKey encoded as hex string
+ *
+ * @returns {String}
+ */
+PrivateKey.prototype.toString = function() {
+  return this.toBuffer().toString('hex');
+}
+
+/**
  * Will output the PrivateKey to a WIF string
  *
  * @returns {String} A WIP representation of the private key
  */
-PrivateKey.prototype.toString = PrivateKey.prototype.toWIF = function() {
+PrivateKey.prototype.toWIF = function() {
   var network = this.network;
   var compressed = this.compressed;
 

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -284,7 +284,7 @@ PrivateKey.isValid = function(data, network){
 };
 
 /**
- * Will output the PublicKey encoded as hex string
+ * Will output the PrivateKey encoded as hex string
  *
  * @returns {String}
  */

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -409,8 +409,7 @@ PublicKey.prototype.toAddress = function(network) {
  * @returns {String} A DER hex encoded string
  */
 PublicKey.prototype.toString = function() {
-  var compressed = _.isUndefined(this.compressed) || this.compressed;
-  return this.toDER(compressed).toString('hex');
+  return this.toDER().toString('hex');
 };
 
 /**

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -135,7 +135,7 @@ describe('PrivateKey', function() {
 
     it('should create a livenet private key', function() {
       var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet');
-      privkey.toString().should.equal(wifLivenet);
+      privkey.toWIF().should.equal(wifLivenet);
     });
 
     it('should create a default network private key', function() {
@@ -197,7 +197,7 @@ describe('PrivateKey', function() {
 
     it('should output this address correctly', function() {
       var privkey = PrivateKey.fromWIF(wifLivenetUncompressed);
-      privkey.toString().should.equal(wifLivenetUncompressed);
+      privkey.toWIF().should.equal(wifLivenetUncompressed);
     });
 
   });
@@ -221,20 +221,20 @@ describe('PrivateKey', function() {
     it('should output known livenet address for console', function() {
       var privkey = PrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
       privkey.inspect().should.equal(
-        '<PrivateKey: L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m, network: livenet>'
+        '<PrivateKey: b9de6e778fe92aa7edb69395556f843f1dce0448350112e14906efc2a80fa61a, network: livenet>'
       );
     });
 
     it('should output known testnet address for console', function() {
       var privkey = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
       privkey.inspect().should.equal(
-        '<PrivateKey: cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq, network: testnet>'
+        '<PrivateKey: 67fd2209ce4a95f6f1d421ab3fbea47ada13df11b73b30c4d9a9f78cc80651ac, network: testnet>'
       );
     });
 
     it('outputs "uncompressed" for uncompressed imported WIFs', function() {
       var privkey = PrivateKey.fromWIF(wifLivenetUncompressed);
-      privkey.inspect().should.equal('<PrivateKey: ' + wifLivenetUncompressed + ', network: livenet, uncompressed>');
+      privkey.inspect().should.equal('<PrivateKey: 96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a, network: livenet, uncompressed>');
     });
   });
 
@@ -261,7 +261,7 @@ describe('PrivateKey', function() {
   describe('#toBuffer', function() {
     it('should output known buffer', function() {
       var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet');
-      privkey.toBuffer().toString('hex').should.equal(buf.toString('hex'));
+      privkey.toString().should.equal(buf.toString('hex'));
     });
   });
 
@@ -316,7 +316,7 @@ describe('PrivateKey', function() {
 
     it('should parse this uncompressed livenet address correctly', function() {
       var privkey = PrivateKey.fromString(wifLivenetUncompressed);
-      privkey.toString().should.equal(wifLivenetUncompressed);
+      privkey.toString().should.equal("96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a");
     });
 
   });


### PR DESCRIPTION
This way is both a PublicKey and PrivateKey implements their `toString` method as a `this.toBuffer().toString('hex');`. IMO it's clearer and removes the need for a `.toHex()` method.

Closes #876 
