### PR TITLE
Fixed tests to handle a `defaultNetwork` change. Closes #890

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -244,7 +244,7 @@ Address._transformScript = function(script, network){
     info.hashBuffer = Hash.sha256ripemd160(script.toBuffer());
     info.type = Address.PayToScriptHash;
   }
-  info.network = network || Networks.defaultNetwork;
+  info.network = Networks.get(network) || Networks.defaultNetwork;
   return info;
 };
 
@@ -370,7 +370,7 @@ Address.fromJSON = function fromJSON(json) {
     json = JSON.parse(json);
   }
   $.checkState(
-    JSUtil.isHexa(json.hash), 
+    JSUtil.isHexa(json.hash),
     'Unexpected hash property, "' + json.hash + '", expected to be hex.'
   );
   var hashBuffer = new Buffer(json.hash, 'hex');

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -194,8 +194,8 @@ HDPublicKey.getSerializedError = function (data, network) {
       return error;
     }
   }
-  network = Network.get(network) || Network.defaultNetwork;
-  if (BufferUtil.integerFromBuffer(data.slice(0, 4)) === network.xprivkey) {
+  var version = BufferUtil.integerFromBuffer(data.slice(0, 4));
+  if (version === Network.livenet.xprivkey || version === Network.testnet.xprivkey ) {
     return new hdErrors.ArgumentIsPrivateExtended();
   }
   return null;

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -419,8 +419,7 @@ PublicKey.prototype.toString = function() {
  */
 PublicKey.prototype.inspect = function() {
   return '<PublicKey: ' + this.toString() +
-    (this.compressed ? '' : ', uncompressed') +
-    (this.network ? ', network: ' + this.network.name : '') + '>';
+    (this.compressed ? '' : ', uncompressed') + '>';
 };
 
 

--- a/test/address.js
+++ b/test/address.js
@@ -280,15 +280,19 @@ describe('Address', function() {
 
     it('should make an address from a pubkey hash buffer', function() {
       var hash = pubkeyhash; //use the same hash
-      Address.fromPublicKeyHash(hash).toString().should.equal(str);
+      var a = Address.fromPublicKeyHash(hash, 'livenet');
+      a.network.should.equal(Networks.livenet);
+      a.toString().should.equal(str);
       var b = Address.fromPublicKeyHash(hash, 'testnet');
       b.network.should.equal(Networks.testnet);
       b.type.should.equal('pubkeyhash');
-      new Address(hash).toString().should.equal(str);
+      new Address(hash, 'livenet').toString().should.equal(str);
     });
 
     it('should make an address using the default network', function() {
       var hash = pubkeyhash; //use the same hash
+      var network = Networks.defaultNetwork;
+      Networks.defaultNetwork = Networks.livenet;
       var a = Address.fromPublicKeyHash(hash);
       a.network.should.equal(Networks.livenet);
       // change the default
@@ -296,7 +300,7 @@ describe('Address', function() {
       var b = Address.fromPublicKeyHash(hash);
       b.network.should.equal(Networks.testnet);
       // restore the default
-      Networks.defaultNetwork = Networks.livenet;
+      Networks.defaultNetwork = network;
     });
 
     it('should throw an error for invalid length hashBuffer', function() {
@@ -307,7 +311,7 @@ describe('Address', function() {
 
     it('should make this address from a compressed pubkey', function() {
       var pubkey = new PublicKey('0285e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b004');
-      var address = Address.fromPublicKey(pubkey);
+      var address = Address.fromPublicKey(pubkey, 'livenet');
       address.toString().should.equal('19gH5uhqY6DKrtkU66PsZPUZdzTd11Y7ke');
     });
 
@@ -324,19 +328,19 @@ describe('Address', function() {
       it('should make this address from a script', function() {
         var s = Script.fromString('OP_CHECKMULTISIG');
         var buf = s.toBuffer();
-        var a = Address.fromScript(s);
+        var a = Address.fromScript(s, 'livenet');
         a.toString().should.equal('3BYmEwgV2vANrmfRymr1mFnHXgLjD6gAWm');
-        var b = new Address(s);
+        var b = new Address(s, 'livenet');
         b.toString().should.equal('3BYmEwgV2vANrmfRymr1mFnHXgLjD6gAWm');
-        var c = Address.fromScriptHash(bitcore.crypto.Hash.sha256ripemd160(buf));
+        var c = Address.fromScriptHash(bitcore.crypto.Hash.sha256ripemd160(buf), 'livenet');
         c.toString().should.equal('3BYmEwgV2vANrmfRymr1mFnHXgLjD6gAWm');
       });
 
       it('should make this address from other script', function() {
         var s = Script.fromString('OP_CHECKSIG OP_HASH160');
-        var a = Address.fromScript(s);
+        var a = Address.fromScript(s, 'livenet');
         a.toString().should.equal('347iRqVwks5r493N1rsLN4k9J7Ljg488W7');
-        var b = new Address(s);
+        var b = new Address(s, 'livenet');
         b.toString().should.equal('347iRqVwks5r493N1rsLN4k9J7Ljg488W7');
       });
 
@@ -460,12 +464,12 @@ describe('Address', function() {
     var publics = [public1, public2, public3];
 
     it('can create an address from a set of public keys', function() {
-      var address = new Address(publics, 2);
+      var address = Address.createMultisig(publics, 2, Networks.livenet);
       address.toString().should.equal('3FtqPRirhPvrf7mVUSkygyZ5UuoAYrTW3y');
     });
 
     it('works on testnet also', function() {
-      var address = new Address(publics, 2, Networks.testnet);
+      var address = Address.createMultisig(publics, 2, Networks.testnet);
       address.toString().should.equal('2N7T3TAetJrSCruQ39aNrJvYLhG1LJosujf');
     });
 

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -12,6 +12,7 @@
 
 var should = require('chai').should();
 var bitcore = require('..');
+var Networks = bitcore.Networks;
 var HDPrivateKey = bitcore.HDPrivateKey;
 var HDPublicKey = bitcore.HDPublicKey;
 
@@ -188,13 +189,13 @@ describe('BIP32 compliance', function() {
   describe('seed', function() {
 
     it('should initialize a new BIP32 correctly from test vector 1 seed', function() {
-      var seededKey = HDPrivateKey.fromSeed(vector1_master);
+      var seededKey = HDPrivateKey.fromSeed(vector1_master, Networks.livenet);
       seededKey.xprivkey.should.equal(vector1_m_private);
       seededKey.xpubkey.should.equal(vector1_m_public);
     });
 
     it('should initialize a new BIP32 correctly from test vector 2 seed', function() {
-      var seededKey = HDPrivateKey.fromSeed(vector2_master);
+      var seededKey = HDPrivateKey.fromSeed(vector2_master, Networks.livenet);
       seededKey.xprivkey.should.equal(vector2_m_private);
       seededKey.xpubkey.should.equal(vector2_m_public);
     });

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -146,6 +146,9 @@ describe('PrivateKey', function() {
     });
 
     it('should create a default network private key', function() {
+      // keep the original
+      var network = Networks.defaultNetwork;
+      Networks.defaultNetwork = Networks.livenet;
       var a = new PrivateKey(BN.fromBuffer(buf));
       a.network.should.equal(Networks.livenet);
       // change the default
@@ -153,7 +156,7 @@ describe('PrivateKey', function() {
       var b = new PrivateKey(BN.fromBuffer(buf));
       b.network.should.equal(Networks.testnet);
       // restore the default
-      Networks.defaultNetwork = Networks.livenet;
+      Networks.defaultNetwork = network;
     });
 
     it('returns the same instance if a PrivateKey is provided (immutable)', function() {

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -353,18 +353,18 @@ describe('PublicKey', function() {
   describe('#inspect', function() {
     it('should output known uncompressed pubkey for console', function() {
       var pubkey = PublicKey.fromString('041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341');
-      pubkey.inspect().should.equal('<PublicKey: 041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341, uncompressed, network: livenet>');
+      pubkey.inspect().should.equal('<PublicKey: 041ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a7baad41d04514751e6851f5304fd243751703bed21b914f6be218c0fa354a341, uncompressed>');
     });
 
     it('should output known compressed pubkey for console', function() {
       var pubkey = PublicKey.fromString('031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a');
-      pubkey.inspect().should.equal('<PublicKey: 031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a, network: livenet>');
+      pubkey.inspect().should.equal('<PublicKey: 031ff0fe0f7b15ffaa85ff9f4744d539139c252a49710fb053bb9f2b933173ff9a>');
     });
 
     it('should output known compressed pubkey with network for console', function() {
       var privkey = PrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
       var pubkey = new PublicKey(privkey);
-      pubkey.inspect().should.equal('<PublicKey: 03c87bd0e162f26969da8509cafcb7b8c8d202af30b928c582e263dd13ee9a9781, network: livenet>');
+      pubkey.inspect().should.equal('<PublicKey: 03c87bd0e162f26969da8509cafcb7b8c8d202af30b928c582e263dd13ee9a9781>');
     });
 
   });

--- a/test/transport/explorers/insight.js
+++ b/test/transport/explorers/insight.js
@@ -15,8 +15,13 @@ describe('Insight', function() {
   describe('instantiation', function() {
     it('can be created without any parameters', function() {
       var insight = new Insight();
-      insight.url.should.equal('https://insight.bitpay.com');
-      insight.network.should.equal(Networks.livenet);
+      should.exist(insight.url);
+      should.exist(insight.network);
+      if (insight.network === Networks.livenet) {
+        insight.url.should.equal('https://insight.bitpay.com');
+      } else if (insight.network === Networks.testnet) {
+        insight.url.should.equal('https://test-insight.bitpay.com');
+      }
     });
     it('can be created providing just a network', function() {
       var insight = new Insight(Networks.testnet);

--- a/test/transport/pool.js
+++ b/test/transport/pool.js
@@ -24,7 +24,13 @@ if (typeof(window) === 'undefined'){
 
     it('should be able to create instance', function() {
       var pool = new Pool();
-      pool.network.should.equal(Networks.livenet);
+      should.exist(pool.network);
+      expect(pool.network).to.satisfy(function(network){
+        if (network === Networks.testnet || network === Networks.livenet) {
+          return true;
+        }
+        return false;
+      });
     });
 
     it('should be able to create instance setting the network', function() {


### PR DESCRIPTION
- Updated tests to work for both 'testnet' and 'livenet' as the default network.
- Fixed a bug in Address where the network property was being set as a string.
- Fixed a bug in HDKeys to handle serialized keys when the defaultNetwork changed.