### PR TITLE
Add version member to bitcore object

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,3 +55,6 @@ bitcore.transport = require('./lib/transport');
 
 // Internal usage, exposed for testing/advanced tweaking
 bitcore._HDKeyCache = require('./lib/hdkeycache');
+
+// module information
+bitcore.version = 'v'+require('./package.json').version;


### PR DESCRIPTION
Resolves issue #908

var bitcore = require('bitcore');
console.log(bitcore.version);
// prints 'v0.8.6'