### PR TITLE
Added getID to PublicKey

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,7 +28,7 @@
     "maxcomplexity": 6,   // Cyclomatic complexity (http://en.wikipedia.org/wiki/Cyclomatic_complexity)
     "maxdepth": 4,        // Maximum depth of nested control structures
     "maxlen": 120,        // Maximum number of cols in a line
-    "multistr": true      // Allow use of multiline EOL escaping
+    "multistr": true,     // Allow use of multiline EOL escaping
 
     "predef": [ // Extra globals.
         "after",

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -385,12 +385,12 @@ PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
   }
 };
 
-/*
+/**
  * Will return a sha256 + ripemd160 hash of the serialized public key
  * @see https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.h#L141
  * @returns {Buffer}
  */
-PublicKey.prototype.getID = function getID() {
+PublicKey.prototype._getID = function _getID() {
   return Hash.sha256ripemd160(this.toBuffer());
 };
 

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -3,6 +3,7 @@
 var Address = require('./address');
 var BN = require('./crypto/bn');
 var Point = require('./crypto/point');
+var Hash = require('./crypto/hash');
 var JSUtil = require('./util/js');
 var Network = require('./networks');
 var _ = require('lodash');
@@ -383,6 +384,15 @@ PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
     return Buffer.concat([prefix, xbuf]);
   }
 };
+
+/*
+ * Will return a sha256 + ripemd160 hash of the serialized public key
+ * @see https://github.com/bitcoin/bitcoin/blob/master/src/pubkey.h#L141
+ * @returns {Buffer}
+ */
+PublicKey.prototype.getID = function getID() {
+  return Hash.sha256ripemd160(this.toBuffer())
+}
 
 /**
  * Will return an address for the public key

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -391,8 +391,8 @@ PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
  * @returns {Buffer}
  */
 PublicKey.prototype.getID = function getID() {
-  return Hash.sha256ripemd160(this.toBuffer())
-}
+  return Hash.sha256ripemd160(this.toBuffer());
+};
 
 /**
  * Will return an address for the public key

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -355,7 +355,7 @@ describe('PublicKey', function() {
     data.forEach(function(d){
       var publicKey = PrivateKey.fromWIF(d[0]).toPublicKey();
       var address = Address.fromString(d[1]);
-      address.hashBuffer.should.deep.equal(publicKey.getID());
+      address.hashBuffer.should.deep.equal(publicKey._getID());
     });
     
   });

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -8,6 +8,7 @@ var Point = bitcore.crypto.Point;
 var BN = bitcore.crypto.BN;
 var PublicKey = bitcore.PublicKey;
 var PrivateKey = bitcore.PrivateKey;
+var Address = bitcore.Address;
 var Networks = bitcore.Networks;
 
 /* jshint maxlen: 200 */
@@ -338,6 +339,25 @@ describe('PublicKey', function() {
       address.toString().should.equal('mtX8nPZZdJ8d3QNLRJ1oJTiEi26Sj6LQXS');
     });
 
+  });
+
+  describe('hashes', function() {
+
+    // wif private key, address
+    // see: https://github.com/bitcoin/bitcoin/blob/master/src/test/key_tests.cpp#L20
+    var data = [
+      ['5HxWvvfubhXpYYpS3tJkw6fq9jE9j18THftkZjHHfmFiWtmAbrj', '1QFqqMUD55ZV3PJEJZtaKCsQmjLT6JkjvJ'],
+      ['5KC4ejrDjv152FGwP386VD1i2NYc5KkfSMyv1nGy1VGDxGHqVY3', '1F5y5E5FMc5YzdJtB9hLaUe43GDxEKXENJ'],
+      ['Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw', '1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs'],
+      ['L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g', '1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs']
+    ];
+    
+    data.forEach(function(d){
+      var publicKey = PrivateKey.fromWIF(d[0]).toPublicKey();
+      var address = Address.fromString(d[1]);
+      address.hashBuffer.should.deep.equal(publicKey.getID());
+    });
+    
   });
 
   describe('#toString', function() {


### PR DESCRIPTION
- Tests in BloomFilter in [bitcoin core](https://github.com/bitcoin/bitcoin/blob/master/src/test/bloom_tests.cpp#L85) use the CPubKey.GetID as input into the BloomFilter
- The hash is calculated when generating an Address however the hash itself is not currently available