### PR TITLE
Add alternative to create an Address

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -143,12 +143,13 @@ Address._transformHash = function(hash){
  * @return {Address}
  */
 Address._transformObject = function(data) {
-  $.checkArgument(data.hash, 'Must provide a `hash` property');
+  $.checkArgument(data.hash || data.hashBuffer, 'Must provide a `hash` or `hashBuffer` property');
   $.checkArgument(data.type, 'Must provide a `type` property');
-  data.hashBuffer = new Buffer(data.hash, 'hex');
-  data.network = Networks.get(data.network) || Networks.defaultNetwork;
-
-  return data;
+  return {
+    hashBuffer: data.hash ? new Buffer(data.hash, 'hex') : data.hashBuffer,
+    network: Networks.get(data.network) || Networks.defaultNetwork,
+    type: data.type
+  };
 };
 
 /**

--- a/test/address.js
+++ b/test/address.js
@@ -210,7 +210,18 @@ describe('Address', function() {
         should.not.exist(error);
       }
     });
+  });
 
+  describe('instantiation', function() {
+    it('can be instantiated from another address', function() {
+      var address = Address.fromBuffer(buf);
+      var address2 = new Address({
+        hashBuffer: address.hashBuffer,
+        network: address.network,
+        type: address.type
+      });
+      address.toString().should.equal(address2.toString());
+    });
   });
 
   describe('encodings', function() {


### PR DESCRIPTION
When (by error or any chance) one has two bitcore instances, an address can't be instantiated from the other bitcore instance's address. This fixes that