### PR TITLE
Added JavaScript syntax highlighting

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,24 +5,27 @@ description: Sample code for the most common task in any bitcoin application.
 
 ## Create a Private Key
 
-```
+```javascript
 var privKey = new bitcore.PrivateKey();
 ```
 
 ## Create an Address
-```
+
+```javascript
 var privKey = new bitcore.PrivateKey();
 var address = privKey.toAddress();
 ```
 
 ## Create a Multisig Address
-```
+
+```javascript
 // Build a 2-of-3 address from public keys
 var P2SHAddress = new bitcore.Address([publicKey1, publicKey2, publicKey3], 2);
 ```
 
 ## Request a Payment
-```
+
+```javascript
 var paymentInfo = {
   address: '1DNtTk4PUCGAdiNETAzQFWZiy2fCHtGnPx',
   amount: 120000 //satoshis
@@ -31,7 +34,8 @@ var uri = new bitcore.URI(paymentInfo).toString();
 ```
 
 ## Create a Transaction
-```
+
+```javascript
 var transaction = new Transaction()
     .from(utxos)          // Feed information about what unspend outputs one can use
     .to(address, amount)  // Add an output with the given amount of satoshis
@@ -40,7 +44,8 @@ var transaction = new Transaction()
 ```
 
 ## Connect to the Network
-```
+
+```javascript
 var peer = new Peer('5.9.85.34');
 
 peer.on('inv', function(message) {


### PR DESCRIPTION
Hi, just a quick question regarding documentation formatting.

Every file at https://github.com/bitpay/bitcore/tree/master/docs/guide starts with two lines:
**title: Address**
**description: A simple interface to generate and validate a bitcoin address.**

followed by a line containing **---**, which in Markdown speech means &lt;h2&gt;ing the previous line.

Was it meant to introduce a horizontal rule instead (an empty line before the **---** is missing then)?

If it should be so, I can easily fix it, just didn't want to waste the time in case I'm wrong.


Best, Martin