### PR TITLE
Add documentation for instantiating P2SH multisig

### DIFF
--- a/docs/address.md
+++ b/docs/address.md
@@ -38,7 +38,7 @@ A pay-to-script-hash multisignature Address can be instantiated from an array of
 
 ```javascript
 // a 2-of-3 address from public keys
-var P2SHAddress = new Address([publicKey1, publicKey2, publicKey3], 2);
+var p2shAddress = new Address([publicKey1, publicKey2, publicKey3], 2);
 ```
 
 ## Validating an Address

--- a/docs/address.md
+++ b/docs/address.md
@@ -34,6 +34,13 @@ var publicKey = new PublicKey(privateKey);
 var address = new Address(publicKey, Networks.testnet);
 ```
 
+A pay-to-script-hash multisignature Address can be instantiated from an array of [PublicKeys](publickey.md).
+
+```javascript
+// a 2-of-3 address from public keys
+var P2SHAddress = new Address([publicKey1, publicKey2, publicKey3], 2);
+```
+
 ## Validating an Address
 
 The main use that we expect you'll have for the `Address` class in Bitcore is validating that an address is a valid one, what type of address it is (you may be interested on knowing if the address is a simple "pay to public key hash" address or a "pay to script hash" address) and what network does the address belong to.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ var address = privateKey.toAddress();
 
 ```javascript
 // Build a 2-of-3 address from public keys
-var P2SHAddress = new bitcore.Address([publicKey1, publicKey2, publicKey3], 2);
+var p2shAddress = new bitcore.Address([publicKey1, publicKey2, publicKey3], 2);
 ```
 
 ## Request a Payment


### PR DESCRIPTION
There is documentation available at
http://bitcore.io/api/#Create_a_Multisig_Address but I think it would
also be useful in the address.md document.