### PR TITLE
Clarify what is meant by CamelCase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Write a `.inspect()` method so an instance can be easily debugged in the console
 
 #### G6 - Naming Utility Namespaces
 
-Name them in CamelCase, as they are namespaces.
+Name them in UpperCamelCase, as they are namespaces.
 
 DO:
 ```javascript


### PR DESCRIPTION
The documentation referred to "CamelCase" meaning "upper camel case".  Since the term "camel case" generally means "lower camel case" if "upper" or "lower" is not stated, this could be confusing.  While the example following the instruction clarifies the meaning, I think it is even more clear to specify "UpperCamelCase".