### PR TITLE
Update transaction.getFee() JSDoc

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -741,13 +741,20 @@ Transaction.prototype._updateChangeOutput = function() {
   }
 };
 /**
- * Calculates the fees for the transaction.
+ * Calculates the fee of the transaction.
  *
- * If there is no change output set, the fee will be the
- * output amount minus the input amount.
- * If there's a fixed fee set, return that
- * If there's no fee set, estimate it based on size
- * @return {Number} miner fee for this transaction in satoshis
+ * If there is no change output set, the fee is the
+ * total value of the outputs minus inputs. Note that
+ * a serialized transaction only specifies the value
+ * of its outputs. (The value of inputs are recorded
+ * in the previous transaction outputs being spent.)
+ * This method therefore raises a "MissingPreviousOutput"
+ * error when called on a serialized transaction.
+ *
+ * If there's a fixed fee set, return that.
+ * If there's no fee set, estimate it based on size.
+ *
+ * @return {Number} fee of this transaction in satoshis
  */
 Transaction.prototype.getFee = function() {
   // if no change output is set, fees should equal all the unspent amount


### PR DESCRIPTION
Attempt at resolving https://github.com/bitpay/bitcore/issues/1157, "Add docs for `transaction.getFee()` to mention that the method is not available once a transaction is serialized."