### PR TITLE
drop cached value for inputAmount and outputAmount

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -570,6 +570,7 @@ Transaction.prototype.addInput = function(input, outputScript, satoshis) {
 Transaction.prototype.uncheckedAddInput = function(input) {
   $.checkArgumentType(input, Input, 'input');
   this.inputs.push(input);
+  this._inputAmount = undefined;
   this._updateChangeOutput();
   return this;
 };
@@ -805,6 +806,7 @@ Transaction.prototype._estimateSize = function() {
 Transaction.prototype._removeOutput = function(index) {
   var output = this.outputs[index];
   this.outputs = _.without(this.outputs, output);
+  this._outputAmount = undefined;
 };
 
 Transaction.prototype.removeOutput = function(index) {
@@ -864,6 +866,7 @@ Transaction.prototype.removeInput = function(txId, outputIndex) {
   }
   var input = this.inputs[index];
   this.inputs = _.without(this.inputs, input);
+  this._inputAmount = undefined;
   this._updateChangeOutput();
 };
 

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -498,17 +498,19 @@ describe('Transaction', function() {
       var transaction = new Transaction()
         .from(simpleUtxoWith1BTC);
       transaction.inputs.length.should.equal(1);
+      transaction.inputAmount.should.equal(simpleUtxoWith1BTC.satoshis);
       transaction.removeInput(0);
-      transaction.inputAmount.should.equal(0);
       transaction.inputs.length.should.equal(0);
+      transaction.inputAmount.should.equal(0);
     });
     it('can remove an input by transaction id', function() {
       var transaction = new Transaction()
         .from(simpleUtxoWith1BTC);
       transaction.inputs.length.should.equal(1);
+      transaction.inputAmount.should.equal(simpleUtxoWith1BTC.satoshis);
       transaction.removeInput(simpleUtxoWith1BTC.txId, simpleUtxoWith1BTC.outputIndex);
-      transaction.inputAmount.should.equal(0);
       transaction.inputs.length.should.equal(0);
+      transaction.inputAmount.should.equal(0);
     });
     it('fails if the index provided is invalid', function() {
       var transaction = new Transaction()
@@ -522,8 +524,10 @@ describe('Transaction', function() {
         .to(toAddress, 40000000)
         .to(toAddress, 40000000);
       transaction.outputs.length.should.equal(2);
+      transaction.outputAmount.should.equal(80000000);
       transaction.removeOutput(0);
       transaction.outputs.length.should.equal(1);
+      transaction.outputAmount.should.equal(40000000);
     });
   });
 


### PR DESCRIPTION
Approximate code for getting a bug:
```js
var bitcore = require('bitcore')
var tx = new bitcore.Transaction().change('...').from({...}).to('...', xxx).serialize()
```