### PR TITLE
Immutable network Object

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -2,6 +2,7 @@
 var _ = require('lodash');
 
 var BufferUtil = require('./util/buffer');
+var JSUtil = require('./util/js');
 var networks = [];
 var networkMaps = {};
 
@@ -64,7 +65,7 @@ function addNetwork(data) {
 
   var network = new Network();
 
-  _.extend(network, {
+  JSUtil.defineImmutable(network, {
     name: data.name,
     alias: data.alias,
     pubkeyhash: data.pubkeyhash,
@@ -77,7 +78,7 @@ function addNetwork(data) {
     dnsSeeds: data.dnsSeeds
   });
 
-  _.each(_.values(network), function(value) {
+  _.each(network, function(value) {
     if (!_.isUndefined(value) && !_.isObject(value)) {
       networkMaps[value] = network;
     }

--- a/test/networks.js
+++ b/test/networks.js
@@ -93,4 +93,10 @@ describe('Networks', function() {
     networks.livenet.toString().should.equal('livenet');
   });
 
+  it('network object should be immutable', function() {
+    expect(networks.testnet.name).to.equal('testnet')
+    var fn = function() { networks.testnet.name = 'livenet' }
+    expect(fn).to.throw(TypeError)
+  });
+
 });


### PR DESCRIPTION
Related with #1171 
I don't know what make with `networkMagic` (Buffer) and with `dnsSeeds` (Array), may be use [Object.freeze](http://mdn.io/object.freeze)? But may be in this case also use *Object.freeze* for network instead `JSUtil.defineImmutable`?
Also tests not looks strong... I should check all properties or name will be enough?