### PR TITLE
sighash: remove dead branch

### DIFF
--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -62,11 +62,8 @@ var sighash = function sighash(transaction, sighashType, inputNumber, subscript)
   } else if ((sighashType & 31) === Signature.SIGHASH_SINGLE) {
     // The SIGHASH_SINGLE bug.
     // https://bitcointalk.org/index.php?topic=260595.0
-    if (inputNumber > txcopy.outputs.length - 1) {
+    if (inputNumber >= txcopy.outputs.length) {
       return new Buffer(SIGHASH_SINGLE_BUG, 'hex');
-    }
-    if (txcopy.outputs.length <= inputNumber) {
-      throw new Error('Missing output to sign');
     }
 
     txcopy.outputs.length = inputNumber + 1;


### PR DESCRIPTION
Best I can tell, this branch would never be reached as:

`a > b - 1` is the same as `a >= b`.

Quick verification for those unsure: 

``` javascript
b = 5
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].forEach(function(a) { console.log(a > b - 1, a >= b) })
```