### PR TITLE
Fixed script.isPublicKeyHashIn bug with variable length signatures.

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -250,7 +250,6 @@ Script.prototype.isPublicKeyHashOut = function() {
 Script.prototype.isPublicKeyHashIn = function() {
   return this.chunks.length === 2 &&
     this.chunks[0].buf &&
-    this.chunks[0].buf.length >= 0x47 &&
     this.chunks[0].buf.length <= 0x49 &&
     PublicKey.isValid(this.chunks[1].buf);
 };

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -249,6 +249,10 @@ describe('Script', function() {
       Script('73 0x3046022100bb3c194a30e460d81d34be0a230179c043a656f67e3c5c8bf47eceae7c4042ee0221008bf54ca11b2985285be0fd7a212873d243e6e73f5fad57e8eb14c4f39728b8c601 65 0x04e365859b3c78a8b7c202412b949ebca58e147dba297be29eee53cd3e1d300a6419bc780cc9aec0dc94ed194e91c8f6433f1b781ee00eac0ead2aae1e8e0712c6 OP_CHECKSIG').isPublicKeyHashIn().should.equal(false);
     });
 
+    it('should identify this known pubkey', function() {
+      Script('70 0x3043021f336721e4343f67c835cbfd465477db09073dc38a936f9c445d573c1c8a7fdf022064b0e3cb6892a9ecf870030e3066bc259e1f24841c9471d97f9be08b73f6530701 33 0x0370b2e1dcaa8f51cb0ead1221dd8cb31721502b3b5b7d4b374d263dfec63a4369').isPublicKeyHashIn().should.equal(true);
+    });
+
   });
 
   describe('#isPublicKeyHashOut', function() {


### PR DESCRIPTION
- DER encoded signatures have a max length of 72 bytes, however a minimum size isn't defined.
- R and S values can have arbitrary lengths
- For more information: https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#der-encoding