### PR TITLE
Transaction serialization errors: check the output amount before fee errors

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -192,10 +192,10 @@ Transaction.prototype.getSerializationError = function(opts) {
   opts = opts || {};
 
   return this._isInvalidSatoshis() ||
+      this._hasMoreOutputThanInput(opts) ||
       this._hasFeeError(opts) ||
       this._hasDustOutputs(opts) ||
-      this._isMissingSignatures(opts) ||
-      this._hasMoreOutputThanInput(opts);
+      this._isMissingSignatures(opts);
 };
 
 Transaction.prototype._isInvalidSatoshis = function() {

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -205,7 +205,7 @@ Transaction.prototype._isInvalidSatoshis = function() {
 };
 
 Transaction.prototype._hasFeeError = function(opts) {
-  if (opts.disableMoreOutputThanInput) {
+  if (this._getUnspentValue() < 0) {
     // The concept of a fee is meaningless when the unspent output value is negative.
     return;
   }

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -191,9 +191,10 @@ Transaction.prototype.invalidSatoshis = function() {
 Transaction.prototype.getSerializationError = function(opts) {
   opts = opts || {};
 
+  var unspent = this._getUnspentValue();
   return this._isInvalidSatoshis() ||
-      this._hasMoreOutputThanInput(opts) ||
-      this._hasFeeError(opts) ||
+      this._hasMoreOutputThanInput(opts, unspent) ||
+      this._hasFeeError(opts, unspent) ||
       this._hasDustOutputs(opts) ||
       this._isMissingSignatures(opts);
 };
@@ -204,31 +205,28 @@ Transaction.prototype._isInvalidSatoshis = function() {
   }
 };
 
-Transaction.prototype._hasFeeError = function(opts) {
-  if (this._getUnspentValue() < 0) {
+Transaction.prototype._hasFeeError = function(opts, unspent) {
+  if (unspent < 0) {
     // The concept of a fee is meaningless when the unspent output value is negative.
     return;
   }
-  return this._isFeeDifferent() ||
-      this._isFeeTooLarge(opts) ||
-      this._isFeeTooSmall(opts);
+  return this._isFeeDifferent(unspent) ||
+      this._isFeeTooLarge(opts, unspent) ||
+      this._isFeeTooSmall(opts, unspent);
 };
 
-Transaction.prototype._isFeeDifferent = function() {
-  if (!_.isUndefined(this._fee)) {
-    var fee = this._fee;
-    var unspent = this._getUnspentValue();
-    if (fee !== unspent) {
-      return new errors.Transaction.FeeError.Different('Unspent value is ' + unspent + ' but specified fee is ' + fee);
-    }
+Transaction.prototype._isFeeDifferent = function(unspent) {
+  if (!_.isUndefined(this._fee) && this._fee !== unspent) {
+    return new errors.Transaction.FeeError.Different(
+      'Unspent value is ' + unspent + ' but specified fee is ' + this._fee
+    );
   }
 };
 
-Transaction.prototype._isFeeTooLarge = function(opts) {
+Transaction.prototype._isFeeTooLarge = function(opts, fee) {
   if (opts.disableLargeFees) {
     return;
   }
-  var fee = this._getUnspentValue();
   var maximumFee = Math.floor(Transaction.FEE_SECURITY_MARGIN * this._estimateFee());
   if (fee > maximumFee) {
     if (this._missingChange()) {
@@ -238,11 +236,10 @@ Transaction.prototype._isFeeTooLarge = function(opts) {
   }
 };
 
-Transaction.prototype._isFeeTooSmall = function(opts) {
+Transaction.prototype._isFeeTooSmall = function(opts, fee) {
   if (opts.disableSmallFees) {
     return;
   }
-  var fee = this._getUnspentValue();
   var minimumFee = Math.ceil(this._estimateFee() / Transaction.FEE_SECURITY_MARGIN);
   if (fee < minimumFee) {
     return new errors.Transaction.FeeError.TooSmall('expected more than ' + minimumFee + ' but got ' + fee);
@@ -275,11 +272,11 @@ Transaction.prototype._isMissingSignatures = function(opts) {
   }
 };
 
-Transaction.prototype._hasMoreOutputThanInput = function(opts) {
+Transaction.prototype._hasMoreOutputThanInput = function(opts, unspent) {
   if (opts.disableMoreOutputThanInput) {
     return;
   }
-  if (this._getUnspentValue() < 0) {
+  if (unspent < 0) {
     return new errors.Transaction.InvalidOutputAmountSum();
   }
 };

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -205,6 +205,10 @@ Transaction.prototype._isInvalidSatoshis = function() {
 };
 
 Transaction.prototype._hasFeeError = function(opts) {
+  if (opts.disableMoreOutputThanInput) {
+    // The concept of a fee is meaningless when the unspent output value is negative.
+    return;
+  }
   return this._isFeeDifferent() ||
       this._isFeeTooLarge(opts) ||
       this._isFeeTooSmall(opts);

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -420,38 +420,43 @@ describe('Transaction', function() {
             .fee(50000000)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableLargeFees', errors.Transaction.FeeError.TooLarge));
+        }, 'disableLargeFees', errors.Transaction.FeeError.TooLarge
+      ));
       it('can skip the check for a fee that is too small', buildSkipTest(
         function(transaction) {
           return transaction
             .fee(1)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableSmallFees', errors.Transaction.FeeError.TooSmall));
+        }, 'disableSmallFees', errors.Transaction.FeeError.TooSmall
+      ));
       it('can skip the check that prevents dust outputs', buildSkipTest(
         function(transaction) {
           return transaction
             .to(toAddress, 100)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableDustOutputs', errors.Transaction.DustOutputs));
+        }, 'disableDustOutputs', errors.Transaction.DustOutputs
+      ));
       it('can skip the check that prevents unsigned outputs', buildSkipTest(
         function(transaction) {
           return transaction
             .to(toAddress, 10000)
             .change(changeAddress);
-        }, 'disableIsFullySigned', errors.Transaction.MissingSignatures));
+        }, 'disableIsFullySigned', errors.Transaction.MissingSignatures
+      ));
       it('can skip the check that avoids spending more bitcoins than the inputs for a transaction', buildSkipTest(
         function(transaction) {
           return transaction
             .to(toAddress, 10000000000000)
             .change(changeAddress);
-          }, 'disableMoreOutputThanInput',
-          errors.Transaction.InvalidOutputAmountSum,
-          {
-            'disableSmallFees': true,
-            'disableIsFullySigned': true
-          }));
+        }, 'disableMoreOutputThanInput',
+        errors.Transaction.InvalidOutputAmountSum,
+        {
+          'disableSmallFees': true,
+          'disableIsFullySigned': true
+        }
+      ));
     });
   });
 

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -440,7 +440,7 @@ describe('Transaction', function() {
           return transaction
             .to(toAddress, 10000)
             .change(changeAddress);
-        }, 'disableIsFullySigned', errors.Transaction.UnableToVerifySignature));
+        }, 'disableIsFullySigned', errors.Transaction.MissingSignatures));
       it('can skip the check that avoids spending more bitcoins than the inputs for a transaction', buildSkipTest(
         function(transaction) {
           return transaction

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -394,6 +394,18 @@ describe('Transaction', function() {
         return transaction.serialize();
       }).to.throw(errors.Transaction.InvalidOutputAmountSum);
     });
+    it('will throw fee error with disableMoreOutputThanInput enabled (but not triggered)', function() {
+      var transaction = new Transaction();
+      transaction.from(simpleUtxoWith1BTC);
+      transaction
+        .to(toAddress, 90000000)
+        .change(changeAddress)
+        .fee(10000000);
+
+      expect(function() {
+        return transaction.serialize({disableMoreOutputThanInput: true});
+      }).to.throw(errors.Transaction.FeeError.TooLarge);
+    });
     describe('skipping checks', function() {
       var buildSkipTest = function(builder, check, expectedError) {
         return function() {

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -395,22 +395,20 @@ describe('Transaction', function() {
       }).to.throw(errors.Transaction.InvalidOutputAmountSum);
     });
     describe('skipping checks', function() {
-      var buildSkipTest = function(builder, check, expectedError, opts) {
+      var buildSkipTest = function(builder, check, expectedError) {
         return function() {
           var transaction = new Transaction();
           transaction.from(simpleUtxoWith1BTC);
           builder(transaction);
 
-          var options = opts || {};
+          var options = {};
           options[check] = true;
 
           expect(function() {
             return transaction.serialize(options);
           }).not.to.throw();
-
-          options[check] = false;
           expect(function() {
-            return transaction.serialize(options);
+            return transaction.serialize();
           }).to.throw(expectedError);
         };
       };
@@ -449,13 +447,9 @@ describe('Transaction', function() {
         function(transaction) {
           return transaction
             .to(toAddress, 10000000000000)
-            .change(changeAddress);
-        }, 'disableMoreOutputThanInput',
-        errors.Transaction.InvalidOutputAmountSum,
-        {
-          'disableSmallFees': true,
-          'disableIsFullySigned': true
-        }
+            .change(changeAddress)
+            .sign(privateKey);
+        }, 'disableMoreOutputThanInput', errors.Transaction.InvalidOutputAmountSum
       ));
     });
   });

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -382,22 +382,36 @@ describe('Transaction', function() {
         return transaction.serialize();
       }).to.throw(errors.Transaction.FeeError.Different);
     });
+    it('checks output amount before fee errors', function() {
+      var transaction = new Transaction();
+      transaction.from(simpleUtxoWith1BTC);
+      transaction
+        .to(toAddress, 10000000000000)
+        .change(changeAddress)
+        .fee(5);
+
+      expect(function() {
+        return transaction.serialize();
+      }).to.throw(errors.Transaction.InvalidOutputAmountSum);
+    });
     describe('skipping checks', function() {
-      var buildSkipTest = function(builder, check) {
+      var buildSkipTest = function(builder, check, expectedError, opts) {
         return function() {
           var transaction = new Transaction();
           transaction.from(simpleUtxoWith1BTC);
           builder(transaction);
 
-          var options = {};
+          var options = opts || {};
           options[check] = true;
 
           expect(function() {
             return transaction.serialize(options);
           }).not.to.throw();
+
+          options[check] = false;
           expect(function() {
-            return transaction.serialize();
-          }).to.throw();
+            return transaction.serialize(options);
+          }).to.throw(expectedError);
         };
       };
       it('can skip the check for too much fee', buildSkipTest(
@@ -406,54 +420,38 @@ describe('Transaction', function() {
             .fee(50000000)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableLargeFees'));
+        }, 'disableLargeFees', errors.Transaction.FeeError.TooLarge));
       it('can skip the check for a fee that is too small', buildSkipTest(
         function(transaction) {
           return transaction
             .fee(1)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableSmallFees'));
+        }, 'disableSmallFees', errors.Transaction.FeeError.TooSmall));
       it('can skip the check that prevents dust outputs', buildSkipTest(
         function(transaction) {
           return transaction
             .to(toAddress, 100)
             .change(changeAddress)
             .sign(privateKey);
-        }, 'disableDustOutputs'));
-      it('can skip the check that prevents unsigned outputs', function() {
-        var transaction = new Transaction();
-        transaction.from(simpleUtxoWith1BTC);
-        transaction.to(toAddress, 10000);
-        transaction.change(changeAddress);
-        var options = {};
-        options.disableIsFullySigned = true;
-        expect(function() {
-          return transaction.serialize(options);
-        }).not.to.throw(errors.Transaction.MissingSignatures);
-        expect(function() {
-          return transaction.serialize();
-        }).to.throw(errors.Transaction.MissingSignatures);
-      });
-      it('can skip the check that avoids spending more bitcoins than the inputs for a transaction', function() {
-        var transaction = new Transaction();
-        transaction.from(simpleUtxoWith1BTC);
-        transaction.to(toAddress, 10000000000000);
-        transaction.change(changeAddress);
-        expect(function() {
-          return transaction.serialize({
-            disableSmallFees: true,
-            disableIsFullySigned: true,
-            disableMoreOutputThanInput: true
-          });
-        }).not.to.throw(errors.Transaction.InvalidOutputAmountSum);
-        expect(function() {
-          return transaction.serialize({
-            disableIsFullySigned: true,
-            disableSmallFees: true
-          });
-        }).to.throw(errors.Transaction.InvalidOutputAmountSum);
-      });
+        }, 'disableDustOutputs', errors.Transaction.DustOutputs));
+      it('can skip the check that prevents unsigned outputs', buildSkipTest(
+        function(transaction) {
+          return transaction
+            .to(toAddress, 10000)
+            .change(changeAddress);
+        }, 'disableIsFullySigned', errors.Transaction.UnableToVerifySignature));
+      it('can skip the check that avoids spending more bitcoins than the inputs for a transaction', buildSkipTest(
+        function(transaction) {
+          return transaction
+            .to(toAddress, 10000000000000)
+            .change(changeAddress);
+          }, 'disableMoreOutputThanInput',
+          errors.Transaction.InvalidOutputAmountSum,
+          {
+            'disableSmallFees': true,
+            'disableIsFullySigned': true
+          }));
     });
   });
 


### PR DESCRIPTION
With transaction serialization errors check the output amount before fee errors. Also added a test for it and also improved buildSkipTest by specifying which error to expect and using it for some tests where it wasn't used yet.