### PR TITLE
fixed PrivateKey initialization from JSON

### DIFF
--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -247,9 +247,10 @@ PrivateKey._transformJSON = function(json) {
     json = JSON.parse(json);
   }
   var bn = new BN(json.bn, 'hex');
+  var network = Networks.get(json.network);
   return {
     bn: bn,
-    network: json.network,
+    network: network,
     compressed: json.compressed
   };
 };

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -177,6 +177,17 @@ describe('PrivateKey', function() {
       PrivateKey.fromJSON(json).toJSON().should.deep.equal(json);
     });
 
+    it('input json should correctly initialize network field', function() {
+      ['livenet', 'testnet', 'mainnet'].forEach(function (net) {
+        var pk = PrivateKey.fromJSON(JSON.stringify({
+          bn: '96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a',
+          compressed: false,
+          network: net
+        }));
+        pk.network.should.be.deep.equal(Networks.get(net));
+      });
+    });
+
     it('an object with private key info can be also used as argument for "fromJSON"', function() {
       expect(PrivateKey._isJSON({bn: true, network: true})).to.equal(true);
     });


### PR DESCRIPTION
I discovered this error after calling toWIF() method on privateKey initialized from a json text like this:
{"bn":"ce6...fec","compressed":true,"network":"testnet"}
The network was not initialized with a Network object but toWIF() needs to read network.privatekey.
