### PR TITLE
modularize network version check issues/1265 (2nd)

### DIFF
--- a/lib/networks.js
+++ b/lib/networks.js
@@ -19,15 +19,6 @@ Network.prototype.toString = function toString() {
 };
 
 /**
- * @member Networks#all
- * Retrieves all networks registered.
- * @return Array
- */
-function all() {
-  return networks;
-}
-
-/**
  * @function
  * @member Networks#get
  * Retrieves the network associated with a magic number or string.
@@ -181,6 +172,5 @@ module.exports = {
   livenet: livenet,
   mainnet: livenet,
   testnet: testnet,
-  get: get,
-  all: all
+  get: get
 };

--- a/lib/networks.js
+++ b/lib/networks.js
@@ -19,6 +19,15 @@ Network.prototype.toString = function toString() {
 };
 
 /**
+ * @member Networks#all
+ * Retrieves all networks registered.
+ * @return Array
+ */
+function all() {
+  return networks;
+}
+
+/**
  * @function
  * @member Networks#get
  * Retrieves the network associated with a magic number or string.
@@ -172,5 +181,6 @@ module.exports = {
   livenet: livenet,
   mainnet: livenet,
   testnet: testnet,
-  get: get
+  get: get,
+  all: all
 };

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -158,16 +158,9 @@ PrivateKey._transformBuffer = function(buf, network) {
 
   info.network = Networks.get(buf[0], 'privatekey');
 
-  var allNetworks = Networks.all();
-  var matches = _.filter( allNetworks, function( network) {
-    return buf[0] === network.privatekey;
-  });
-
-  if (matches.length !== 1) {
+  if (!info.network) {
     throw new Error('Invalid network');
   }
-
-  info.network = matches[0];
 
   if (network && info.network !== Networks.get(network)) {
     throw new TypeError('Private key network mismatch');

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -157,13 +157,17 @@ PrivateKey._transformBuffer = function(buf, network) {
   }
 
   info.network = Networks.get(buf[0], 'privatekey');
-  if (buf[0] === Networks.livenet.privatekey) {
-    info.network = Networks.livenet;
-  } else if (buf[0] === Networks.testnet.privatekey) {
-    info.network = Networks.testnet;
-  } else {
+
+  var allNetworks = Networks.all();
+  var matches = _.filter( allNetworks, function( network) {
+    return buf[0] === network.privatekey;
+  });
+
+  if (matches.length !== 1) {
     throw new Error('Invalid network');
   }
+
+  info.network = matches[0];
 
   if (network && info.network !== Networks.get(network)) {
     throw new TypeError('Private key network mismatch');

--- a/test/networks.js
+++ b/test/networks.js
@@ -49,30 +49,6 @@ describe('Networks', function() {
     should.equal(net, undefined);
   });
 
-  it('can return custom networks', function() {
-    var custom = {
-      name: 'customnet',
-      alias: 'mynet',
-      pubkeyhash: 0x10,
-      privatekey: 0x90,
-      scripthash: 0x08,
-      xpubkey: 0x0278b20e,
-      xprivkey: 0x0278ade4,
-      networkMagic: 0xe7beb4d4,
-      port: 20001,
-      dnsSeeds: [
-        'localhost',
-        'mynet.localhost'
-      ]
-    };
-    networks.add(custom);
-    customnet = networks.get('customnet');
-    var allNetworks = networks.all();
-    var customInOutput = allNetworks.indexOf(customnet) > -1;
-    should.equal(customInOutput, true);
-    networks.remove(customnet);
-  });
-
   it('should not set a network map for an undefined value', function() {
     var custom = {
       name: 'somenet',

--- a/test/networks.js
+++ b/test/networks.js
@@ -48,7 +48,31 @@ describe('Networks', function() {
     var net = networks.get('customnet');
     should.equal(net, undefined);
   });
-  
+
+  it('can return custom networks', function() {
+    var custom = {
+      name: 'customnet',
+      alias: 'mynet',
+      pubkeyhash: 0x10,
+      privatekey: 0x90,
+      scripthash: 0x08,
+      xpubkey: 0x0278b20e,
+      xprivkey: 0x0278ade4,
+      networkMagic: 0xe7beb4d4,
+      port: 20001,
+      dnsSeeds: [
+        'localhost',
+        'mynet.localhost'
+      ]
+    };
+    networks.add(custom);
+    customnet = networks.get('customnet');
+    var allNetworks = networks.all();
+    var customInOutput = allNetworks.indexOf(customnet) > -1;
+    should.equal(customInOutput, true);
+    networks.remove(customnet);
+  });
+
   it('should not set a network map for an undefined value', function() {
     var custom = {
       name: 'somenet',

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -44,6 +44,35 @@ describe('PrivateKey', function() {
     should.exist(a.bn);
   });
 
+  it('should create a private key from a custom network WIF string', function() {
+    var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
+    var nmc = {
+      name: 'namecoin',
+      alias: 'namecoin',
+      pubkeyhash: 0x34,
+      privatekey: 0xB4,
+      // these below aren't the real NMC version numbers
+      scripthash: 0x08,
+      xpubkey: 0x0278b20e,
+      xprivkey: 0x0278ade4,
+      networkMagic: 0xf9beb4fe,
+      port: 20001,
+      dnsSeeds: [
+        'localhost',
+        'mynet.localhost'
+      ]
+    };
+    Networks.add(nmc);
+    var nmcNet = Networks.get('namecoin');
+    var a = new PrivateKey(
+      '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz',
+      nmcNet
+    );
+    should.exist(a);
+    should.exist(a.bn);
+    Networks.remove(nmcNet);
+  });
+
   it('should create a new random testnet private key with empty data', function() {
     var a = new PrivateKey(null, Networks.testnet);
     should.exist(a);

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -64,7 +64,7 @@ describe('PrivateKey', function() {
     };
     Networks.add(nmc);
     var nmcNet = Networks.get('namecoin');
-    var a = new PrivateKey( wifNamecoin, nmcNet);
+    var a = new PrivateKey(wifNamecoin, nmcNet);
     should.exist(a);
     should.exist(a.bn);
     Networks.remove(nmcNet);
@@ -141,18 +141,8 @@ describe('PrivateKey', function() {
     });
 
     it('should not be able to instantiate private key WIF because of network mismatch', function() {
-      var invalidNet = {
-        name: 'invalidnet',
-        alias: 'invalidnet',
-        pubkeyhash: 0xFF,
-        privatekey: 0xFF,
-        scripthash: 0xFF,
-        xpubkey: 0xFFFFFFFF,
-        xprivkey: 0xFFFFFFFF,
-        networkMagic: 0xFFFFFFFF
-      };
       expect(function(){
-        var a = new PrivateKey( wifNamecoin, invalidNet );
+        var a = new PrivateKey(wifNamecoin, 'testnet');
       }).to.throw('Invalid network');
     });
 

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -22,6 +22,7 @@ describe('PrivateKey', function() {
   var wifTestnetUncompressed = '92jJzK4tbURm1C7udQXxeCBvXHoHJstDXRxAMouPG1k1XUaXdsu';
   var wifLivenet = 'L2Gkw3kKJ6N24QcDuH4XDqt9cTqsKTVNDGz1CRZhk9cq4auDUbJy';
   var wifLivenetUncompressed = '5JxgQaFM1FMd38cd14e3mbdxsdSa9iM2BV6DHBYsvGzxkTNQ7Un';
+  var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
 
   it('should create a new random private key', function() {
     var a = new PrivateKey();
@@ -45,7 +46,6 @@ describe('PrivateKey', function() {
   });
 
   it('should create a private key from a custom network WIF string', function() {
-    var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
     var nmc = {
       name: 'namecoin',
       alias: 'namecoin',
@@ -64,10 +64,7 @@ describe('PrivateKey', function() {
     };
     Networks.add(nmc);
     var nmcNet = Networks.get('namecoin');
-    var a = new PrivateKey(
-      '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz',
-      nmcNet
-    );
+    var a = new PrivateKey( wifNamecoin, nmcNet);
     should.exist(a);
     should.exist(a.bn);
     Networks.remove(nmcNet);
@@ -140,6 +137,22 @@ describe('PrivateKey', function() {
         var buf = Base58Check.decode('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
         var buf2 = Buffer.concat([new Buffer('ff', 'hex'), buf.slice(1, 33)]);
         return new PrivateKey(buf2);
+      }).to.throw('Invalid network');
+    });
+
+    it('should not be able to instantiate private key WIF because of network mismatch', function() {
+      var invalidNet = {
+        name: 'invalidnet',
+        alias: 'invalidnet',
+        pubkeyhash: 0xFF,
+        privatekey: 0xFF,
+        scripthash: 0xFF,
+        xpubkey: 0xFFFFFFFF,
+        xprivkey: 0xFFFFFFFF,
+        networkMagic: 0xFFFFFFFF
+      };
+      expect(function(){
+        var a = new PrivateKey( wifNamecoin, invalidNet );
       }).to.throw('Invalid network');
     });
 


### PR DESCRIPTION
This is a fix for the Bitcoin (mainnet & testnet) specific hardcode that only allows privkeys to be imported for those two networks. This change allows custom networks to import private keys, as well. See #1265 for discussion.

This is mostly the same as the old, closed, PR (https://github.com/bitpay/bitcore/pull/1267) but with slightly different test structure.