### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "bitcore",
   "main": "./bitcore.min.js",
-  "version": "0.12.8",
   "homepage": "http://bitcore.io",
   "authors": [
     "BitPay, Inc."


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property