### PR TITLE
Objects passed as arguments are unmodified.

### DIFF
--- a/lib/transaction/input/input.js
+++ b/lib/transaction/input/input.js
@@ -40,12 +40,15 @@ Object.defineProperty(Input.prototype, 'script', {
 });
 
 Input.prototype._fromObject = function(params) {
+  var prevTxId;
   if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
-    params.prevTxId = new buffer.Buffer(params.prevTxId, 'hex');
+    prevTxId = new buffer.Buffer(params.prevTxId, 'hex');
+  } else {
+    prevTxId = params.prevTxId;
   }
   this.output = params.output ?
     (params.output instanceof Output ? params.output : new Output(params.output)) : undefined;
-  this.prevTxId = params.prevTxId || params.txidbuf;
+  this.prevTxId = prevTxId || params.txidbuf;
   this.outputIndex = _.isUndefined(params.outputIndex) ? params.txoutnum : params.outputIndex;
   this.sequenceNumber = _.isUndefined(params.sequenceNumber) ?
     (_.isUndefined(params.seqnum) ? DEFAULT_SEQNUMBER : params.seqnum) : params.sequenceNumber;

--- a/lib/transaction/output.js
+++ b/lib/transaction/output.js
@@ -21,10 +21,13 @@ function Output(args) {
     if (bufferUtil.isBuffer(args.script)) {
       this._scriptBuffer = args.script;
     } else {
+      var script;
       if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
-        args.script = new buffer.Buffer(args.script, 'hex');
+        script = new buffer.Buffer(args.script, 'hex');
+      } else {
+        script = args.script;
       }
-      this.setScript(args.script);
+      this.setScript(script);
     }
   } else if (JSUtil.isValidJSON(args)) {
     return Output.fromJSON(args);

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -358,11 +358,11 @@ Transaction.prototype.fromObject = function(transaction) {
       self.uncheckedAddInput(new Input(input));
       return;
     }
-    input.output.script = new Script(input.output.script);
+    var script = new Script(input.output.script);
     var txin;
-    if (input.output.script.isPublicKeyHashOut()) {
+    if (script.isPublicKeyHashOut()) {
       txin = new Input.PublicKeyHash(input);
-    } else if (input.output.script.isScriptHashOut() && input.publicKeys && input.threshold) {
+    } else if (script.isScriptHashOut() && input.publicKeys && input.threshold) {
       txin = new Input.MultiSigScriptHash(
         input, input.publicKeys, input.threshold, input.signatures
       );

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -63,8 +63,10 @@ describe('Transaction', function() {
   });
 
   it('serialize to Object roundtrip', function() {
-    new Transaction(testTransaction.toObject()).uncheckedSerialize()
-      .should.equal(testTransaction.uncheckedSerialize());
+    var a = testTransaction.toObject();
+    var newTransaction = new Transaction(a);
+    var b = newTransaction.toObject();
+    a.should.deep.equal(b);
   });
 
   it('constructor returns a shallow copy of another transaction', function() {


### PR DESCRIPTION
Ran into an issue where arguments passing into a Transaction constructor were mysteriously being modified in the transaction `toObject/fromObject` round trip tests, this will fix the issue so that arguments are not modified.