### PR TITLE
Remove versionGuard error if versions are same.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var bitcore = module.exports;
 // module information
 bitcore.version = 'v' + require('./package.json').version;
 bitcore.versionGuard = function(version) {
-  if (version !== undefined) {
+  if (version !== undefined && version !== bitcore.version) {
     var message = 'More than one instance of bitcore found with versions: ' + bitcore.version +
       ' and ' + version + '. Please make sure to require bitcore and check that submodules do' +
       ' not also include their own bitcore dependency.';


### PR DESCRIPTION
I'm not sure why there is this version guard in the first place. It's extremely annoying and non idiomatic. What's the big deal if there is more than one bitcore in memory?