### PR TITLE
Memoize transaction.hash

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -126,7 +126,22 @@ Object.defineProperty(Transaction.prototype, 'outputAmount', ioProperty);
  * @return {Buffer}
  */
 Transaction.prototype._getHash = function() {
-  return Hash.sha256sha256(this.toBuffer());
+  var buf = this.toBuffer();
+
+  // Check if we computed this hash before
+  if (this._hashMemo && buf.equals(this._hashMemo.buf)) {
+    return this._hashMemo.hash;
+  }
+
+  var hash = Hash.sha256sha256(buf);
+
+  // Memoize buf/hash pair
+  this._hashMemo = {
+    buf: buf,
+    hash: hash
+  };
+
+  return hash;
 };
 
 /**

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -85,6 +85,15 @@ describe('Transaction', function() {
     transaction.id.should.equal(tx_1_id);
   });
 
+  it('transaction hash is only computed once for the same data', function() {
+    var transaction = new Transaction(tx_1_hex);
+    var hash = transaction.hash;
+    hash.should.equal(transaction.hash);
+    transaction._getHash().should.equal(transaction._hashMemo.hash);
+    transaction.inputs.pop();
+    hash.should.not.equal(transaction.hash);
+  });
+
   it('serializes an empty transaction', function() {
     var transaction = new Transaction();
     transaction.uncheckedSerialize().should.equal(tx_empty_hex);


### PR DESCRIPTION
What this basically does is avoid computing the hash if we already did so previously. It just memorizes the last computed hash so doesn't leak memory.