### PR TITLE
crypto-browserify library has ripemd160 support

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var hashjs = require('hash.js');
 var sha512 = require('sha512');
 var crypto = require('crypto');
 var BufferUtil = require('../util/buffer');
@@ -29,18 +28,8 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('ripemd160').update(buf).digest();
+  return crypto.createHash('rmd160').update(buf).digest();
 };
-
-// Node.js crypto ripemd160 hashes are not supported in a browser
-// We'll replace with a (slower) version that does.
-if (process.browser) {
-  Hash.ripemd160 = function(buf) {
-    $.checkArgument(BufferUtil.isBuffer(buf));
-    var hash = (new hashjs.ripemd160()).update(buf).digest();
-    return new Buffer(hash);
-  };
-}
 
 Hash.sha256ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));

--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -28,7 +28,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.ripemd160 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
-  return crypto.createHash('rmd160').update(buf).digest();
+  return crypto.createHash('ripemd160').update(buf).digest();
 };
 
 Hash.sha256ripemd160 = function(buf) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,13 +26,13 @@
           "version": "1.0.5",
           "from": "brorand@^1.0.1",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+        },
+        "hash.js": {
+          "version": "1.0.3",
+          "from": "hash.js@=1.0.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
         }
       }
-    },
-    "hash.js": {
-      "version": "1.0.2",
-      "from": "hash.js@^1.0.0",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
     },
     "inherits": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "bs58": "=2.0.0",
     "buffer-compare": "=1.0.0",
     "elliptic": "=3.0.3",
-    "hash.js": "=1.0.2",
     "inherits": "=2.0.1",
     "lodash": "=3.10.1",
     "sha512": "=0.0.1"


### PR DESCRIPTION
See: https://github.com/crypto-browserify/crypto-browserify/issues/135