### PR TITLE
fix web worker issues

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -34,7 +34,7 @@ Hash.ripemd160 = function(buf) {
 
 // Node.js crypto ripemd160 hashes are not supported in a browser
 // We'll replace with a (slower) version that does.
-if (global.window) {
+if (process.browser) {
   Hash.ripemd160 = function(buf) {
     $.checkArgument(BufferUtil.isBuffer(buf));
     var hash = (new hashjs.ripemd160()).update(buf).digest();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -35,9 +35,9 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "lodash": {
-      "version": "2.4.1",
-      "from": "lodash@=2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+      "version": "3.10.1",
+      "from": "lodash@=3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "sha512": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "elliptic": "=3.0.3",
     "hash.js": "=1.0.2",
     "inherits": "=2.0.1",
-    "lodash": "=2.4.1",
+    "lodash": "=3.10.1",
     "sha512": "=0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
bitcore should be able to run inside a web worker. There were two minor issues
preventing bitcore from running inside a web worker. The first was that lodash
was outdated, and that version of lodash had a problem with web workers. The
second was that the wrong version of ripemd160 was being called, because
global.window does not exist inside a web worker (global.self does instead). A
better way to check if you are in a browser is with process.browser.

This may not be a comprehensive list of issues, they're they are the ones I've noticed.