### PR TITLE
Fix SequenceNumber for nLockTime transactions

### DIFF
--- a/lib/transaction/input/input.js
+++ b/lib/transaction/input/input.js
@@ -13,6 +13,7 @@ var Output = require('../output');
 
 
 var DEFAULT_SEQNUMBER = 0xFFFFFFFF;
+var DEFAULT_LOCKTIME_SEQNUMBER = 0x00000000;
 
 function Input(params) {
   if (!(this instanceof Input)) {
@@ -24,6 +25,7 @@ function Input(params) {
 }
 
 Input.DEFAULT_SEQNUMBER = DEFAULT_SEQNUMBER;
+Input.DEFAULT_LOCKTIME_SEQNUMBER = DEFAULT_LOCKTIME_SEQNUMBER;
 
 Object.defineProperty(Input.prototype, 'script', {
   configurable: false,

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -414,6 +414,13 @@ Transaction.prototype.lockUntilDate = function(time) {
   if (_.isDate(time)) {
     time = time.getTime() / 1000;
   }
+
+  for (var i = 0; i < this.inputs.length; i++) {
+    if (this.inputs[i].sequenceNumber === Input.DEFAULT_SEQNUMBER){
+      this.inputs[i].sequenceNumber = Input.DEFAULT_LOCKTIME_SEQNUMBER;
+    }
+  }
+
   this.nLockTime = time;
   return this;
 };
@@ -433,6 +440,14 @@ Transaction.prototype.lockUntilBlockHeight = function(height) {
   if (height < 0) {
     throw new errors.Transaction.NLockTimeOutOfRange();
   }
+
+  for (var i = 0; i < this.inputs.length; i++) {
+    if (this.inputs[i].sequenceNumber === Input.DEFAULT_SEQNUMBER){
+      this.inputs[i].sequenceNumber = Input.DEFAULT_LOCKTIME_SEQNUMBER;
+    }
+  }
+
+
   this.nLockTime = height;
   return this;
 };

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -769,6 +769,8 @@ describe('Transaction', function() {
       var serialized_tx = transaction.uncheckedSerialize();
       var copy = new Transaction(serialized_tx);
       serialized_tx.should.equal(copy.uncheckedSerialize());
+      copy.inputs[0].sequenceNumber
+      .should.equal(Transaction.Input.DEFAULT_LOCKTIME_SEQNUMBER)
     });
     it('should serialize correctly for a block height locktime', function() {
       var transaction= new Transaction()
@@ -777,6 +779,8 @@ describe('Transaction', function() {
       var serialized_tx = transaction.uncheckedSerialize();
       var copy = new Transaction(serialized_tx);
       serialized_tx.should.equal(copy.uncheckedSerialize());
+      copy.inputs[0].sequenceNumber
+      .should.equal(Transaction.Input.DEFAULT_LOCKTIME_SEQNUMBER)
     });
   });
 

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -748,6 +748,36 @@ describe('Transaction', function() {
         return new Transaction().lockUntilBlockHeight(-1);
       }).to.throw(errors.Transaction.NLockTimeOutOfRange);
     });
+    it('has a non-max sequenceNumber for effective date locktime tx', function() {
+      var transaction = new Transaction()
+        .from(simpleUtxoWith1BTC)
+        .lockUntilDate(date);
+      expect(transaction.inputs[0].sequenceNumber
+        .should.not.equal(Transaction.Input.DEFAULT_SEQNUMBER));
+    });
+    it('has a non-max sequenceNumber for effective blockheight locktime tx', function() {
+      var transaction = new Transaction()
+        .from(simpleUtxoWith1BTC)
+        .lockUntilBlockHeight(blockHeight);
+      expect(transaction.inputs[0].sequenceNumber
+        .should.not.equal(Transaction.Input.DEFAULT_SEQNUMBER));
+    });
+    it('should serialize correctly for date locktime ', function() {
+      var transaction= new Transaction()
+        .from(simpleUtxoWith1BTC)
+        .lockUntilDate(date);
+      var serialized_tx = transaction.uncheckedSerialize();
+      var copy = new Transaction(serialized_tx);
+      expect(serialized_tx.should.equal(copy.uncheckedSerialize()));
+    });
+    it('should serialize correctly for a block height locktime', function() {
+      var transaction= new Transaction()
+        .from(simpleUtxoWith1BTC)
+        .lockUntilBlockHeight(blockHeight);
+      var serialized_tx = transaction.uncheckedSerialize();
+      var copy = new Transaction(serialized_tx);
+      expect(serialized_tx.should.equal(copy.uncheckedSerialize()));
+    });
   });
 
   it('handles anyone-can-spend utxo', function() {

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -752,15 +752,15 @@ describe('Transaction', function() {
       var transaction = new Transaction()
         .from(simpleUtxoWith1BTC)
         .lockUntilDate(date);
-      expect(transaction.inputs[0].sequenceNumber
-        .should.not.equal(Transaction.Input.DEFAULT_SEQNUMBER));
+      transaction.inputs[0].sequenceNumber
+        .should.equal(Transaction.Input.DEFAULT_LOCKTIME_SEQNUMBER);
     });
     it('has a non-max sequenceNumber for effective blockheight locktime tx', function() {
       var transaction = new Transaction()
         .from(simpleUtxoWith1BTC)
         .lockUntilBlockHeight(blockHeight);
-      expect(transaction.inputs[0].sequenceNumber
-        .should.not.equal(Transaction.Input.DEFAULT_SEQNUMBER));
+      transaction.inputs[0].sequenceNumber
+        .should.equal(Transaction.Input.DEFAULT_LOCKTIME_SEQNUMBER);
     });
     it('should serialize correctly for date locktime ', function() {
       var transaction= new Transaction()
@@ -768,7 +768,7 @@ describe('Transaction', function() {
         .lockUntilDate(date);
       var serialized_tx = transaction.uncheckedSerialize();
       var copy = new Transaction(serialized_tx);
-      expect(serialized_tx.should.equal(copy.uncheckedSerialize()));
+      serialized_tx.should.equal(copy.uncheckedSerialize());
     });
     it('should serialize correctly for a block height locktime', function() {
       var transaction= new Transaction()
@@ -776,7 +776,7 @@ describe('Transaction', function() {
         .lockUntilBlockHeight(blockHeight);
       var serialized_tx = transaction.uncheckedSerialize();
       var copy = new Transaction(serialized_tx);
-      expect(serialized_tx.should.equal(copy.uncheckedSerialize()));
+      serialized_tx.should.equal(copy.uncheckedSerialize());
     });
   });
 


### PR DESCRIPTION
To be effective within the current Bitcoin network, the inputs to a transaction with an nLocktime must be not the standard max value.We set the sequence number of 0 if the value is max.Currently sequence numbers other than MAX_INT32 have no meaning in the Bitcoin protoco but this may change in future BIPS
