### PR TITLE
Return zero for coinbase transaction fee.

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -843,6 +843,9 @@ Transaction.prototype._updateChangeOutput = function() {
  * @return {Number} fee of this transaction in satoshis
  */
 Transaction.prototype.getFee = function() {
+  if (this.isCoinbase()) {
+    return 0;
+  }
   if (!_.isUndefined(this._fee)) {
     return this._fee;
   }

--- a/test/transaction/transaction.js
+++ b/test/transaction/transaction.js
@@ -62,6 +62,12 @@ describe('Transaction', function() {
     testTransaction.getFee().should.equal(10000);
   });
 
+  it('will return zero as the fee for a coinbase', function() {
+    // block #2: 0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098
+    var coinbaseTransaction = new Transaction('01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000');
+    coinbaseTransaction.getFee().should.equal(0);
+  });
+
   it('serialize to Object roundtrip', function() {
     var a = testTransaction.toObject();
     var newTransaction = new Transaction(a);


### PR DESCRIPTION
See: https://github.com/bitpay/bitcore-node/blob/master/lib/services/address/history.js#L211

```js
var fees = !transaction.isCoinbase() ? transaction.getFee() : null
```

Can simply be:
```js
var fees = transaction.getFee();
```