### PR TITLE
fix Script.set

### DIFF
--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -36,15 +36,17 @@ var Script = function Script(from) {
     return Script.fromAddress(from);
   } else if (from instanceof Script) {
     return Script.fromBuffer(from.toBuffer());
-  } else if (typeof from === 'string') {
+  } else if (_.isString(from)) {
     return Script.fromString(from);
-  } else if (typeof from !== 'undefined') {
+  } else if (_.isObject(from) && _.isArray(from.chunks)) {
     this.set(from);
   }
 };
 
 Script.prototype.set = function(obj) {
-  this.chunks = obj.chunks || this.chunks;
+  $.checkArgument(_.isObject(obj));
+  $.checkArgument(_.isArray(obj.chunks));
+  this.chunks = obj.chunks;
   return this;
 };
 

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -15,7 +15,35 @@ describe('Script', function() {
 
   it('should make a new script', function() {
     var script = new Script();
-    should.exist(script);
+    expect(script).to.be.instanceof(Script);
+    expect(script.chunks).to.deep.equal([]);
+  });
+
+  it('should make a new script when from is null', function() {
+    var script = new Script(null);
+    expect(script).to.be.instanceof(Script);
+    expect(script.chunks).to.deep.equal([]);
+  });
+
+  describe('#set', function() {
+    var script = new Script();
+
+    it('should be object', function() {
+      expect(function() {
+        script.set(null);
+      }).to.throw(/^Invalid Argument$/)
+    });
+
+    it('chunks should be array', function() {
+      expect(function() {
+        script.set({chunks: 1});
+      }).to.throw(/^Invalid Argument$/);
+    });
+
+    it('set chunks', function() {
+      script.set({chunks: [1]});
+      expect(script.chunks).to.deep.equal([1]);
+    });
   });
 
   describe('#fromBuffer', function() {


### PR DESCRIPTION
For example problem with `ad0a426817666f56d5b4fba97177f455bbfba3b80faca32a58ae9f947896ec68` from testnet:
```js
var bitcore = require('bitcore')
var tx = bitcore.Transaction('0100000001cbf75e37f8f57f338dd435d564c7302a02d9c6d03e26c8f0f24fa46052c0c0d1010000008b48304502210095cf913f96c52242b3a88dc59a9aed2a568dc80446541348c89c5430727d548402206adbe00b00db7d71458b990ab69090a038244a6b94faca98652656fd0b9be4e4014104dac5c4da1fd483b8655ab6a5d8e5dd2226ef20d1023d7ff38df29bfa8fcfdf73fb99a07efa0c66112c1fa438a8ed8571364bc04f21eaadf54c4918d43aba8ed3ffffffff02804f1200000000001976a914d40f073684cfac11be0366dc6a56a8d3cc87ece488ac1027000000000000044e6f6e6500000000')
console.log(tx.outputs[1]) // <Output (10000 sats) 4e6f6e65>
var script = bitcore.Script(tx.outputs[1].script) // TypeError: Cannot read property 'chunks' of null
```