### PR TITLE
Fix double bitcore-lib loading issue

### DIFF
--- a/bin/bitcore
+++ b/bin/bitcore
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-// vi: ft=javascript -*- mode: JavaScript; -*-
 
-var node = require('bitcore-node');
-node.cli.bitcore();
+var bitcore = require('bitcore-node/lib/cli/bitcore');
+var path = require('path');
+var servicesPath = path.resolve(__dirname, '../');
+var additionalServices = ['insight-api', 'insight-ui'];
+bitcore(servicesPath, additionalServices);

--- a/bin/bitcored
+++ b/bin/bitcored
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
-// vi: ft=javascript -*- mode: JavaScript; -*-
 
-var node = require('bitcore-node');
-node.cli.bitcored();
+'use strict';
+
+var path = require('path');
+var bitcored = require('bitcore-node/lib/cli/bitcored');
+var servicesPath = path.resolve(__dirname, '../');
+var additionalServices = ['insight-api', 'insight-ui'];
+bitcored(servicesPath, additionalServices);

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "insight-ui": "^0.3.0"
   },
   "devDependencies": {
-    "bitcore-build": "bitpay/bitcore-build",
+    "bitcore-build": "bitpay/bitcore-build#36e15f",
     "brfs": "^1.2.0",
     "chai": "^1.10.0",
     "gulp": "^3.8.10",


### PR DESCRIPTION
- Pass along services location and additional services for the default.
- Reference specific commit of bitcore-build and remove mode hints.