### PR TITLE
V8.0.0 -> Fixing Issue with Wallets on Coins

### DIFF
--- a/packages/bitcore-node/lib/models/transaction.js
+++ b/packages/bitcore-node/lib/models/transaction.js
@@ -219,7 +219,7 @@ TransactionSchema.statics.mintCoins = async function(params) {
     try {
       let wallets = await WalletAddress.collection
         .find(
-          { chain, network, address: { $in: mintOpsAddresses } },
+          { address: { $in: mintOpsAddresses } },
           { batchSize: 100 }
         )
         .toArray();

--- a/packages/bitcore-wallet-client/lib/api.js
+++ b/packages/bitcore-wallet-client/lib/api.js
@@ -1310,7 +1310,7 @@ API.prototype.createWallet = function(walletName, copayerName, m, n, opts, cb) {
   $.checkArgument(coin, "Coin is a required paramter");
   $.checkArgument(network, "Network is a required paramter");
   $.shouldBeObject(config.chains[coin], 'Invalid coin');
-  $.shouldBeObject(config.chains[coin][network], 'Invalid network');
+  $.checkState(config.chains[coin][network], 'Network not enabled in config');
 
   if (!self.credentials) {
     log.info('Generating new keys');

--- a/packages/bitcore-wallet-client/lib/common/config.js
+++ b/packages/bitcore-wallet-client/lib/common/config.js
@@ -2,7 +2,8 @@ module.exports = {
   chains : {
     btc: {
       livenet: true,
-      testnet: true
+      testnet: true,
+      regtest: true
     },
     bch: {
       livenet: true,

--- a/packages/bitcore-wallet-client/lib/credentials.js
+++ b/packages/bitcore-wallet-client/lib/credentials.js
@@ -212,7 +212,7 @@ Credentials.prototype._expand = function() {
   var network = Credentials._getNetworkFromExtendedKey(this.xPrivKey || this.xPubKey);
   if (this.network) {
     // the default network of livenet should be okay
-    $.checkState(this.network == network || network === 'livenet');
+    $.checkState(this.network.name === network.name || network === 'livenet');
   } else {
     this.network = network;
   }


### PR DESCRIPTION
Includes regtest support for bitcore-wallet and bitcore-wallet-client.

Coins were never getting wallets because chain and network aren't in that collection.