### PR TITLE
changed order or priority for options in StorageService.start

### DIFF
--- a/packages/bitcore-node/lib/services/storage.js
+++ b/packages/bitcore-node/lib/services/storage.js
@@ -6,7 +6,7 @@ require('../models');
 const StorageService = function() {};
 
 StorageService.prototype.start = function(ready, args) {
-  let options = Object.assign({}, args, config);
+  let options = Object.assign({}, config, args);
   let { dbName, dbHost } = options;
   const connectUrl = `mongodb://${dbHost}/${dbName}?socketTimeoutMS=3600000&noDelay=true`;
   let attemptConnect = async () => {


### PR DESCRIPTION
In `StorageService.start` any args passed were being overwritten by the config instead of those args overwriting the config.