### PR TITLE
Create storage worker on the same node as P2P workers.

### DIFF
--- a/packages/bitcore-node/src/server.ts
+++ b/packages/bitcore-node/src/server.ts
@@ -10,7 +10,9 @@ import parseArgv from './utils/parseArgv';
 let args = parseArgv([], ['DEBUG']);
 
 const startServices = async () => {
+  await Storage.start({});
   await Worker.start();
+
   // TODO this needs to move to a static p2pService method
   let p2pServices = [] as Array<P2pService>;
   for (let chain of Object.keys(config.chains)) {
@@ -30,7 +32,6 @@ const startServices = async () => {
 };
 
 const startAPI = async () => {
-  await Storage.start({});
   const server = app.listen(config.port, function() {
     logger.info(`API server started on port ${config.port}`);
   });


### PR DESCRIPTION
This only reverts bitcore-node/src/server.ts of commit 37931b0df1129bd776db84a2fd5f3cb2261642c9, to fix p2p syncing. Without this p2p syncing is stuck at the after it gets headers (but works in debug mode, where this is not a problem).