### PR TITLE
fix broken api (api only works in DEBUG)

### DIFF
--- a/packages/bitcore-node/src/server.ts
+++ b/packages/bitcore-node/src/server.ts
@@ -39,15 +39,27 @@ const startAPI = async () => {
   server.timeout = 600000;
 };
 
-const start = async() => {
-  if(cluster.isMaster){
-    await startServices();
-    if(args.DEBUG) {
-      startAPI();
-    }
-  }else if(!args.DEBUG){
+const runMaster = async() => {
+  await startServices();
+  // start the API on master if we are in debug
+  if(args.DEBUG){
+    startAPI();
+  }
+};
+
+const runWorker = async() => {
+  // don't run any workers when in debug mode
+  if(!args.DEBUG){
     await startServices();
     startAPI();
+  }
+}
+
+const start = async() => {
+  if(cluster.isMaster){
+    await runMaster();
+  } else{
+    await runWorker();
   }
 }
 

--- a/packages/bitcore-node/src/server.ts
+++ b/packages/bitcore-node/src/server.ts
@@ -1,17 +1,11 @@
 import { P2pService } from './services/p2p';
 import { Storage } from './services/storage';
-import { Worker } from './services/worker';
 import logger from './logger';
 import config from './config';
-import cluster = require('cluster');
 import app from './routes';
-import parseArgv from './utils/parseArgv';
-
-let args = parseArgv([], ['DEBUG']);
 
 const startServices = async () => {
   await Storage.start({});
-  await Worker.start();
 
   // TODO this needs to move to a static p2pService method
   let p2pServices = [] as Array<P2pService>;
@@ -39,13 +33,5 @@ const startAPI = async () => {
   server.timeout = 600000;
 };
 
-if (cluster.isMaster) {
-  startServices();
-  if (args.DEBUG) {
-    startAPI();
-  }
-} else {
-  if (!args.DEBUG) {
-    startAPI();
-  }
-}
+startServices();
+startAPI();


### PR DESCRIPTION
API is broken in `bitcore-node` v8.0.0 unless you are in `DEBUG`.  I recommend we remove the cluster logic until we can get it to work correctly.  

For example, when calling a tx route (`http://localhost:3000/api/BTC/regtest/tx/43bfa06e4b594861e345dbadbb02488a05fa2505f761120eb1d224392e3e64ab`)
```
TypeError: Cannot read property 'pipe' of undefined
    at BTCStateProvider.streamTransaction (/home/bitcore/packages/bitcore-node/build/src/providers/chain-state/internal/internal.js:140:13)
    at ChainStateProxy.streamTransaction (/home/bitcore/packages/bitcore-node/build/src/providers/chain-state/index.js:39:33)
    at /home/bitcore/packages/bitcore-node/build/src/routes/tx.js:38:45
    at Layer.handle [as handle_request] (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/layer.js:95:5)
    at next (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/layer.js:95:5)
    at /home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:281:22
    at param (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:354:14)
    at param (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:365:14)
    at Function.process_params (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:410:3)
    at next (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:275:10)
    at Function.handle (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:174:3)
    at router (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:47:12)
    at Layer.handle [as handle_request] (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/bitcore/packages/bitcore-node/node_modules/express/lib/router/index.js:317:13)
```