### PR TITLE
Simplify wallet transaction export

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -342,25 +342,7 @@ TransactionSchema.statics.getTransactions = function(params: {
   query: TransactionQuery;
 }) {
   let query = params.query;
-  return TransactionModel.collection.aggregate([
-    { $match: query },
-    {
-      $lookup: {
-        from: "coins",
-        localField: "txid",
-        foreignField: "spentTxid",
-        as: "inputs"
-      }
-    },
-    {
-      $lookup: {
-        from: "coins",
-        localField: "txid",
-        foreignField: "mintTxid",
-        as: "outputs"
-      }
-    }
-  ]);
+  return this.find(query).cursor();
 };
 
 TransactionSchema.statics._apiTransform = function(


### PR DESCRIPTION
* Stops using $lookup, since there were issues with passing chain and network to the coin query
* Removes irrelevant warning about missing change addresses