### PR TITLE
Feature/insight coins detach

### DIFF
--- a/packages/insight/app/src/components/transaction/transaction.html
+++ b/packages/insight/app/src/components/transaction/transaction.html
@@ -2,8 +2,10 @@
   <ion-row>
     <ion-col col-7>
       <div class="ellipsis">
-        <ion-icon name="add-circle" [hidden]="expanded" (click)="toggleExpanded()"></ion-icon>
-        <ion-icon name="remove-circle" [hidden]="!expanded" (click)="toggleExpanded()"></ion-icon>
+        <span *ngIf="showCoins">
+          <ion-icon name="add-circle" [hidden]="expanded" (click)="toggleExpanded()"></ion-icon>
+          <ion-icon name="remove-circle" [hidden]="!expanded" (click)="toggleExpanded()"></ion-icon>
+        </span>
         <span>
           <a (click)="goToTx(tx.txid)">{{ tx.txid }}</a>
         </span>
@@ -22,7 +24,7 @@
     </ion-col>
   </ion-row>
 
-  <ion-row>
+  <ion-row *ngIf="showCoins">
     <ion-col col-12 col-md-5>
 
       <ion-list [hidden]="!tx.isCoinBase">
@@ -100,7 +102,7 @@
     </ion-col>
   </ion-row>
 
-  <ion-row align-items-center text-uppercase class="small">
+  <ion-row align-items-center text-uppercase class="small" *ngIf="showCoins">
     <ion-col col-6>
       <div [hidden]="tx.isCoinBase">
         <ion-chip>

--- a/packages/insight/app/src/components/transaction/transaction.ts
+++ b/packages/insight/app/src/components/transaction/transaction.ts
@@ -19,6 +19,7 @@ export class TransactionComponent {
 
   public expanded: boolean = false;
   @Input() public tx: any = {};
+  @Input() public showCoins?: boolean = false;
 
   constructor(
     private navCtrl: NavController,
@@ -28,7 +29,9 @@ export class TransactionComponent {
   }
 
   public ngOnInit(): void {
-    this.getCoins();
+    if (this.showCoins) {
+      this.getCoins();
+    }
   }
 
   public getCoins(): void {
@@ -36,7 +39,7 @@ export class TransactionComponent {
       this.tx.vin = data.inputs;
       this.tx.vout = data.outputs;
       this.tx.fee = this.txProvider.getFee(this.tx);
-      this.tx.valueOut = data.outputs.reduce((a, b) => a + b.value, 0)
+      this.tx.valueOut = data.outputs.reduce((a, b) => a + b.value, 0);
     });
   }
 

--- a/packages/insight/app/src/pages/transaction/transaction.html
+++ b/packages/insight/app/src/pages/transaction/transaction.html
@@ -24,7 +24,7 @@
       <ion-item>
         Fee Rate
         <ion-note item-end>
-          {{ (tx.fees / tx.size) * 1E8 | number:'1.0-8' }} sats/byte
+          {{ (tx.fee / tx.size) | number:'1.0-8' }} sats/byte
         </ion-note>
       </ion-item>
       <ion-item>

--- a/packages/insight/app/src/pages/transaction/transaction.html
+++ b/packages/insight/app/src/pages/transaction/transaction.html
@@ -49,7 +49,7 @@
 
     <h2>Details</h2>
 
-    <transaction [tx]="tx"></transaction>
+    <transaction [tx]="tx" [showCoins]="true"></transaction>
   </div>
 
 </ion-content>


### PR DESCRIPTION
- Add showCoins prop to transaction component to determine whether or not to display coins. Default false.
- In essence, this remove coins from block-detail (and address page), listing only txids.
