### PR TITLE
Feature/node paging

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   },
   "scripts": {
     "build": "docker build -t bitcore-node .",
-    "postinstall": "./node_modules/.bin/lerna bootstrap"
+    "postinstall": "./node_modules/.bin/lerna bootstrap",
+    "insight": "cd packages/insight && npm start",
+    "node": "cd packages/bitcore-node && npm start"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/packages/bitcore-node/src/models/base.ts
+++ b/packages/bitcore-node/src/models/base.ts
@@ -6,6 +6,9 @@ export abstract class BaseModel<T> {
   client?: MongoClient;
   db?: Db;
 
+  // each model must implement an array of keys that are indexed, for paging
+  abstract allowedPaging: Array<keyof T>;
+
   constructor(private collectionName: string) {
     this.handleConnection();
   }

--- a/packages/bitcore-node/src/models/base.ts
+++ b/packages/bitcore-node/src/models/base.ts
@@ -7,7 +7,10 @@ export abstract class BaseModel<T> {
   db?: Db;
 
   // each model must implement an array of keys that are indexed, for paging
-  abstract allowedPaging: Array<keyof T>;
+  abstract allowedPaging: Array<{
+    type: 'string' | 'number' | 'date';
+    key: keyof T;
+  }>;
 
   constructor(private collectionName: string) {
     this.handleConnection();

--- a/packages/bitcore-node/src/models/block.ts
+++ b/packages/bitcore-node/src/models/block.ts
@@ -32,7 +32,12 @@ export class Block extends BaseModel<IBlock> {
     super('blocks');
   }
 
-  allowedPaging = ['height' as 'height'];
+  allowedPaging = [
+    {
+      key: 'height' as 'height',
+      type: 'number' as 'number'
+    }
+  ];
 
   async onConnect() {
     this.collection.createIndex({ hash: 1 });

--- a/packages/bitcore-node/src/models/block.ts
+++ b/packages/bitcore-node/src/models/block.ts
@@ -32,6 +32,8 @@ export class Block extends BaseModel<IBlock> {
     super('blocks');
   }
 
+  allowedPaging = ['height' as 'height'];
+
   async onConnect() {
     this.collection.createIndex({ hash: 1 });
     this.collection.createIndex({ chain: 1, network: 1, processed: 1, height: -1 });

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -25,6 +25,11 @@ class Coin extends BaseModel<ICoin> {
     super('coins');
   }
 
+  allowedPaging = [
+    "mintHeight" as "mintHeight",
+    "spentHeight" as "spentHeight",
+  ];
+
   onConnect() {
     this.collection.createIndex({ mintTxid: 1 });
     this.collection.createIndex(

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -26,8 +26,8 @@ class Coin extends BaseModel<ICoin> {
   }
 
   allowedPaging = [
-    "mintHeight" as "mintHeight",
-    "spentHeight" as "spentHeight",
+    { key: 'mintHeight' as 'mintHeight', type: 'number' as 'number' },
+    { key: 'spentHeight' as 'spentHeight', type: 'number' as 'number' }
   ];
 
   onConnect() {
@@ -61,7 +61,7 @@ class Coin extends BaseModel<ICoin> {
   }
 
   _apiTransform(coin: ICoin, options: { object: boolean }) {
-    let sbuf = coin.script ? coin.script.buffer: Buffer.from('');
+    let sbuf = coin.script ? coin.script.buffer : Buffer.from('');
     const script = Chain[coin.chain].lib.Script.fromBuffer(sbuf);
     let transform = {
       txid: coin.mintTxid,
@@ -71,7 +71,7 @@ class Coin extends BaseModel<ICoin> {
       address: coin.address,
       script: {
         type: script.classify(),
-        asm: script.toASM(),
+        asm: script.toASM()
       },
       value: coin.value
     };

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -32,6 +32,10 @@ export class Transaction extends BaseModel<ITransaction> {
     super('transactions');
   }
 
+  allowedPaging = [
+    "blockHeight" as "blockHeight"
+  ];
+
   onConnect() {
     this.collection.createIndex({ txid: 1 });
     this.collection.createIndex({ chain: 1, network: 1, blockHeight: 1 });

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -32,9 +32,7 @@ export class Transaction extends BaseModel<ITransaction> {
     super('transactions');
   }
 
-  allowedPaging = [
-    "blockHeight" as "blockHeight"
-  ];
+  allowedPaging = [{ key: 'blockHeight' as 'blockHeight', type: 'number' as 'number' }];
 
   onConnect() {
     this.collection.createIndex({ txid: 1 });
@@ -159,12 +157,14 @@ export class Transaction extends BaseModel<ITransaction> {
     let mintOps = new Array<any>();
     let parentChainCoins = new Array<ICoin>();
     if (parentChain && forkHeight && height < forkHeight) {
-      parentChainCoins = await CoinModel.collection.find({
-        chain: parentChain,
-        network,
-        mintHeight: height,
-        spentHeight: { $gt: -2, $lt: forkHeight }
-      }).toArray();
+      parentChainCoins = await CoinModel.collection
+        .find({
+          chain: parentChain,
+          network,
+          mintHeight: height,
+          spentHeight: { $gt: -2, $lt: forkHeight }
+        })
+        .toArray();
     }
     for (let tx of txs) {
       tx._hash = tx.hash;

--- a/packages/bitcore-node/src/models/wallet.ts
+++ b/packages/bitcore-node/src/models/wallet.ts
@@ -17,6 +17,7 @@ export class Wallet extends BaseModel<IWallet> {
   constructor() {
     super('wallets');
   }
+  allowedPaging = [];
 
   onConnect() {
     this.collection.createIndex({ pubKey: 1 });

--- a/packages/bitcore-node/src/models/walletAddress.ts
+++ b/packages/bitcore-node/src/models/walletAddress.ts
@@ -18,6 +18,8 @@ export class WalletAddress extends BaseModel<IWalletAddress> {
     super('walletaddresses');
   }
 
+  allowedPaging = [];
+
   onConnect() {
     this.collection.createIndex({ address: 1, wallet: 1 });
   }

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -57,23 +57,22 @@ export class InternalStateProvider implements CSP.IChainStateService {
   }
 
   streamBlocks(params: CSP.StreamBlocksParams) {
-    const { stream, args } = params;
-    const { limit = 10 } = args;
-    const query = this.getBlocksQuery(params);
-    Storage.apiStreamingFind(BlockModel, query, { limit, sort: { height: -1 } }, stream);
+    const { stream } = params;
+    const { query, options } = this.getBlocksQuery(params);
+    Storage.apiStreamingFind(BlockModel, query, options, stream);
   }
 
   async getBlocks(params: CSP.StreamBlocksParams) {
     const { query, options } = this.getBlocksQuery(params);
-    let blocks = await BlockModel.collection.find(query, options ).toArray();
+    let blocks = await BlockModel.collection.find(query, options).toArray();
     return blocks.map(block => BlockModel._apiTransform(block, { object: true }));
   }
 
   private getBlocksQuery(params: CSP.StreamBlocksParams) {
-    const { network, sinceBlock, blockId, args = {}} = params;
-    let { startDate, endDate, date } = args;
-    let { limit = 10, sort = {height: -1 }} = args;
-    let options = {limit, sort};
+    const { network, sinceBlock, blockId, args = {} } = params;
+    let { startDate, endDate, date, since, direction, paging } = args;
+    let { limit = 10, sort = { height: -1 } } = args;
+    let options = { limit, sort, since, direction, paging };
     if (!this.chain || !network) {
       throw 'Missing required param';
     }
@@ -112,7 +111,7 @@ export class InternalStateProvider implements CSP.IChainStateService {
       nextDate.setDate(nextDate.getDate() + 1);
       query.time = { $gt: firstDate, $lt: nextDate };
     }
-    return {query, options};
+    return { query, options };
   }
 
   async getBlock(params: CSP.StreamBlocksParams) {

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -64,16 +64,16 @@ export class InternalStateProvider implements CSP.IChainStateService {
   }
 
   async getBlocks(params: CSP.StreamBlocksParams) {
-    const { args = {} } = params;
-    const { limit = 10 } = args;
-    const query = this.getBlocksQuery(params);
-    let blocks = await BlockModel.collection.find(query, { limit, sort: { height: -1 } }).toArray();
+    const { query, options } = this.getBlocksQuery(params);
+    let blocks = await BlockModel.collection.find(query, options ).toArray();
     return blocks.map(block => BlockModel._apiTransform(block, { object: true }));
   }
 
   private getBlocksQuery(params: CSP.StreamBlocksParams) {
     const { network, sinceBlock, blockId, args = {}} = params;
     let { startDate, endDate, date } = args;
+    let { limit = 10, sort = {height: -1 }} = args;
+    let options = {limit, sort};
     if (!this.chain || !network) {
       throw 'Missing required param';
     }
@@ -112,7 +112,7 @@ export class InternalStateProvider implements CSP.IChainStateService {
       nextDate.setDate(nextDate.getDate() + 1);
       query.time = { $gt: firstDate, $lt: nextDate };
     }
-    return query;
+    return {query, options};
   }
 
   async getBlock(params: CSP.StreamBlocksParams) {

--- a/packages/bitcore-node/src/routes/api/block.ts
+++ b/packages/bitcore-node/src/routes/api/block.ts
@@ -4,16 +4,16 @@ const router = require('express').Router({ mergeParams: true });
 
 router.get('/', async function(req: Request, res: Response) {
   let { chain, network } = req.params;
-  const { sinceBlock, date, limit } = req.query;
+  const { sinceBlock, date, limit, since, direction, paging } = req.query;
   try {
     let payload = {
       chain,
       network,
       sinceBlock,
-      args: { date, limit },
+      args: { date, limit, since, direction, paging },
       stream: res
     };
-    return ChainStateProvider.streamBlocks(payload);;
+    return ChainStateProvider.streamBlocks(payload);
   } catch (err) {
     return res.status(500).send(err);
   }
@@ -22,7 +22,7 @@ router.get('/', async function(req: Request, res: Response) {
 router.get('/tip', async function(req: Request, res: Response) {
   let { chain, network } = req.params;
   try {
-    let tip = await ChainStateProvider.getBlock({chain, network});
+    let tip = await ChainStateProvider.getBlock({ chain, network });
     return res.json(tip);
   } catch (err) {
     return res.status(500).send(err);

--- a/packages/bitcore-node/src/services/storage.ts
+++ b/packages/bitcore-node/src/services/storage.ts
@@ -63,7 +63,7 @@ export class StorageService {
   stop() {}
 
   validPagingProperty<T>(model: TransformableModel<T>, property: keyof T) {
-    return model.allowedPaging.some(allowed => allowed.key === property);
+    return model.allowedPaging.some((prop) => prop.key === property);
   }
 
   /**

--- a/packages/bitcore-node/src/services/storage.ts
+++ b/packages/bitcore-node/src/services/storage.ts
@@ -1,11 +1,18 @@
 import { EventEmitter } from 'events';
-import { Response } from "express";
-import { TransformableModel } from "../types/TransformableModel";
+import { Response } from 'express';
+import { TransformableModel } from '../types/TransformableModel';
 import logger from '../logger';
 import config from '../config';
-import { LoggifyClass } from "../decorators/Loggify";
-import { MongoClient, Db, FindOneOptions } from "mongodb";
-import "../models"
+import { LoggifyClass } from '../decorators/Loggify';
+import { MongoClient, Db, FindOneOptions } from 'mongodb';
+import '../models';
+
+export type StreamingFindOptions<T> = {
+  paging: keyof T;
+  since: T[keyof T];
+  direction: 1 | -1;
+  limit: number;
+} & FindOneOptions;
 
 @LoggifyClass
 export class StorageService {
@@ -20,13 +27,16 @@ export class StorageService {
       let { dbName, dbHost } = options;
       const connectUrl = `mongodb://${dbHost}/${dbName}?socketTimeoutMS=3600000&noDelay=true`;
       let attemptConnect = async () => {
-        return MongoClient.connect(connectUrl, {
-          keepAlive: 1,
-          poolSize: config.maxPoolSize,
-          /*
+        return MongoClient.connect(
+          connectUrl,
+          {
+            keepAlive: 1,
+            poolSize: config.maxPoolSize
+            /*
            *nativeParser: true
            */
-        });
+          }
+        );
       };
       let attempted = 0;
       let attemptConnectId = setInterval(async () => {
@@ -42,7 +52,7 @@ export class StorageService {
           attempted++;
           if (attempted > 5) {
             clearInterval(attemptConnectId);
-            reject(new Error("Failed to connect to database"));
+            reject(new Error('Failed to connect to database'));
           }
         }
       }, 5000);
@@ -54,9 +64,18 @@ export class StorageService {
   apiStreamingFind<T>(
     model: TransformableModel<T>,
     query: any,
-    options: FindOneOptions,
+    options: StreamingFindOptions<T>,
     res: Response
   ) {
+    if (options.since !== undefined && model.allowedPaging.includes(options.paging)) {
+      if (options.direction === 1) {
+        query[options.paging] = { $gt: options.since };
+        options.sort = { [options.paging]: 1 };
+      } else {
+        query[options.paging] = { $lt: options.since };
+        options.sort = { [options.paging]: -1 };
+      }
+    }
     options.limit = Math.min(options.limit || 100, 1000);
     let cursor = model.collection.find(query, options).stream({
       transform: model._apiTransform

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -2,6 +2,7 @@ import { IBlock } from '../../models/block';
 import { Response } from 'express';
 import { IWallet } from '../../models/wallet';
 import { ChainNetwork } from '../../types/ChainNetwork';
+import { StreamingFindOptions } from "../../services/storage";
 export declare namespace CSP {
   export type StreamWalletTransactionsArgs = {
     startBlock: number;
@@ -30,7 +31,7 @@ export declare namespace CSP {
   export type StreamBlocksParams = ChainNetwork & {
     blockId?: string;
     sinceBlock: number | string;
-    args: Partial<{ startDate: Date; endDate: Date; date: Date;}>;
+    args: Partial<{ startDate: Date; endDate: Date; date: Date;} & StreamingFindOptions<IBlock>>;
     stream: Response;
   };
   export type GetEstimateSmartFeeParams = ChainNetwork & {

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -30,12 +30,12 @@ export declare namespace CSP {
   export type StreamBlocksParams = ChainNetwork & {
     blockId?: string;
     sinceBlock: number | string;
-    args: Partial<{ limit: number; startDate: Date; endDate: Date; date: Date }>;
+    args: Partial<{ startDate: Date; endDate: Date; date: Date;}>;
     stream: Response;
   };
   export type GetEstimateSmartFeeParams = ChainNetwork & {
     target: number;
-  }
+  };
   export type BroadcastTransactionParams = ChainNetwork & {
     rawTx: string;
   };
@@ -102,7 +102,7 @@ export declare namespace CSP {
     streamWalletAddresses(params: StreamWalletAddressesParams): any;
     streamWalletTransactions(params: StreamWalletTransactionsParams): any;
     streamWalletUtxos(params: StreamWalletUtxosParams): any;
-    getCoinsForTx(params: {chain: string, network: string, txid: string }): Promise<any>;
+    getCoinsForTx(params: { chain: string; network: string; txid: string }): Promise<any>;
   }
 
   type ChainStateServices = { [key: string]: IChainStateService };

--- a/packages/insight/app/src/providers/blocks/blocks.ts
+++ b/packages/insight/app/src/providers/blocks/blocks.ts
@@ -99,7 +99,7 @@ export class BlocksProvider {
     return this.getCurrentHeight().flatMap(height => {
       return this.http.get(url).map(data => {
         let blocks: Array<ApiBlock> = data.json();
-        let appBlocks: Array<AppBlock> = blocks.map(this.toAppBlock);
+        let appBlocks: Array<AppBlock> = blocks.map(block => this.toAppBlock(block, height));
         return { blocks: appBlocks };
       });
     });


### PR DESCRIPTION
```
http://localhost:8100/api/BTC/regtest/block?since=582&limit=100&paging=height&direction=-1
```

This MR's goal is to allow paging of various data types by enabling whitelisted keys.

In order for this generic feature to work, models must have an array of whitelisted keys, as well as the type those keys should be before being sent off to the database.