### PR TITLE
Remove total spend and total unspent balances on address page

### DIFF
--- a/packages/insight/app/src/pages/address/address.html
+++ b/packages/insight/app/src/pages/address/address.html
@@ -19,12 +19,6 @@
           {{ currencyProvider.getConvertedNumber(address.balance) | number:'1.0-8' }} {{ currencyProvider.currencySymbol }}
         </ion-note>
       </ion-item>
-      <ion-item>
-        No. Transactions
-        <ion-note item-end>
-          {{ address.txAppearances }}
-        </ion-note>
-      </ion-item>
     </ion-list>
 
     <p text-center>

--- a/packages/insight/app/src/pages/address/address.html
+++ b/packages/insight/app/src/pages/address/address.html
@@ -14,18 +14,6 @@
 
     <ion-list class="list--summary">
       <ion-item>
-        Total Received
-        <ion-note item-end>
-          {{ currencyProvider.getConvertedNumber(address.totalReceived) | number:'1.0-8' }} {{ currencyProvider.currencySymbol }}
-        </ion-note>
-      </ion-item>
-      <ion-item>
-        Total Sent
-        <ion-note item-end>
-          {{ currencyProvider.getConvertedNumber(address.totalSent) | number:'1.0-8' }} {{ currencyProvider.currencySymbol }}
-        </ion-note>
-      </ion-item>
-      <ion-item>
         Final Balance
         <ion-note item-end>
           {{ currencyProvider.getConvertedNumber(address.balance) | number:'1.0-8' }} {{ currencyProvider.currencySymbol }}

--- a/packages/insight/app/src/pages/address/address.ts
+++ b/packages/insight/app/src/pages/address/address.ts
@@ -46,7 +46,6 @@ export class AddressPage {
       this.address = {
         balance: json.balance,
         addrStr: this.addrStr,
-        txAppearances: 0, /* TODO: what's up with this? */
       };
       this.loading = false;
     }, err => {

--- a/packages/insight/app/src/pages/address/address.ts
+++ b/packages/insight/app/src/pages/address/address.ts
@@ -37,28 +37,21 @@ export class AddressPage {
   }
 
   public ionViewDidLoad(): void {
-    let url: string = this.apiProvider.apiPrefix + '/address/' + this.addrStr;
-    this.http.get(url).subscribe(
-      data => {
-        let apiCoin: ApiInput[] = data.json() as ApiInput[];
-        let add: (prev: number, cur: number) => number = (prev, cur) => prev + cur;
-        let sentCoin: ApiInput[] = apiCoin.filter(coin => coin.spentTxid);
-        let totalReceived: number = apiCoin.map(c => c.value).reduce(add, 0);
-        let totalSent: number = sentCoin.map(c => c.value).reduce(add, 0);
-        let balance: number = totalReceived - totalSent;
-        this.address = {
-          addrStr: this.addrStr,
-          totalReceived,
-          totalSent,
-          balance,
-          txAppearances: apiCoin.length
-        };
-        this.loading = false;
-      },
-      err => {
-        console.error('err is', err);
-      }
-    );
+    const url: string = `${this.apiProvider.apiPrefix}/address/${this.addrStr}/balance`;
+    this.http.get(url).subscribe(data => {
+      const json: {
+        balance: number;
+        numberTxs: number;
+      } = data.json();
+      this.address = {
+        balance: json.balance,
+        addrStr: this.addrStr,
+        txAppearances: 0, /* TODO: what's up with this? */
+      };
+      this.loading = false;
+    }, err => {
+      console.error('err is', err);
+    });
 
     let txurl: string = this.apiProvider.apiPrefix + '/address/' + this.addrStr + '/txs';
     this.http.get(txurl).subscribe(


### PR DESCRIPTION
Not known: how to get the total number of transactions without a total spent / total unspent section.
See: https://github.com/bitpay/bitcore/blob/v8.0.0/packages/insight/app/src/pages/address/address.ts#L54