### PR TITLE
Removing percentage

### DIFF
--- a/packages/bitcore-node/src/services/p2p.ts
+++ b/packages/bitcore-node/src/services/p2p.ts
@@ -280,7 +280,7 @@ export class P2pService {
           await this.processBlock(block);
           currentHeight++;
           if (Date.now() - lastLog > 100) {
-            logger.info(`Sync progress ${((100 * currentHeight) / this.getBestPoolHeight()).toFixed(3)}%`, {
+            logger.info(`Sync `, {
               chain,
               network,
               height: currentHeight


### PR DESCRIPTION
Using peer height is actually misleading, and can't be updated due to version message being a "one time" message.