### PR TITLE
V8 with raw tx

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/index.ts
+++ b/packages/bitcore-node/src/providers/chain-state/index.ts
@@ -52,6 +52,10 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return this.get(params).streamTransaction(params);
   }
 
+  streamTransactionRaw(params: CSP.StreamTransactionParams) {
+    return this.get(params).streamTransactionRaw(params);
+  }
+
   async createWallet(params: CSP.CreateWalletParams) {
     return this.get(params).createWallet(params);
   }

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -163,6 +163,17 @@ export class InternalStateProvider implements CSP.IChainStateService {
     Storage.apiStreamingFind(TransactionModel, query, { limit: 100 }, stream);
   }
 
+  streamTransactionRaw(params: CSP.StreamTransactionParams) {
+    let { network, txId, stream } = params;
+    if (typeof txId !== 'string' || !this.chain || !network || !stream) {
+      throw 'Missing required param';
+    }
+    this.getRPC(network).getTransaction(txId, true, (_: any, result: any) => {
+    const transaction = typeof result !== "undefined" ? {rawTx : result.hex} : [];
+    stream.send(JSON.stringify(transaction));
+    });
+  }
+
   async createWallet(params: CSP.CreateWalletParams) {
     const { network, name, pubKey, path, singleAddress } = params;
     if (typeof name !== 'string' || !network) {

--- a/packages/bitcore-node/src/routes/api/tx.ts
+++ b/packages/bitcore-node/src/routes/api/tx.ts
@@ -58,6 +58,16 @@ router.get('/:txid/coins', (req, res, next) => {
   }
 });
 
+router.get('/:txId/raw', function(req, res) {
+    let { chain, network, txId } = req.params;
+    if (typeof txId !== 'string' || !chain || !network) {
+      return res.status(400).send('Missing required param');
+    }
+    chain = chain.toUpperCase();
+    network = network.toLowerCase();
+    return ChainStateProvider.streamTransactionRaw({ chain, network, txId, stream: res });
+});
+
 router.post('/send', async function(req, res) {
   try {
     let { chain, network } = req.params;

--- a/packages/bitcore-node/src/rpc.ts
+++ b/packages/bitcore-node/src/rpc.ts
@@ -86,9 +86,9 @@ export class RPC {
     });
   }
 
-  getTransaction(txid: string, callback: CallbackType) {
+  getTransaction(txid: string, verbose:boolean, callback: CallbackType) {
     var self = this;
-    self.callMethod('getrawtransaction', [txid, true], function(err, result) {
+    self.callMethod('getrawtransaction', [txid, verbose], function(err, result) {
       if (err) {
         return callback(err);
       }

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -102,6 +102,7 @@ export declare namespace CSP {
     streamAddressTransactions(params: StreamAddressUtxosParams): any;
     streamTransactions(params: StreamTransactionsParams): any;
     streamTransaction(params: StreamTransactionParams): any;
+    streamTransactionRaw(params: StreamTransactionParams): any;
     streamWalletAddresses(params: StreamWalletAddressesParams): any;
     streamWalletTransactions(params: StreamWalletTransactionsParams): any;
     streamWalletUtxos(params: StreamWalletUtxosParams): any;


### PR DESCRIPTION
This follows from bitpay/bitcore-node#574 This will add the API endpoint `tx/:txid/raw` that will return the hex string of the transaction (using the RPC command `getrawtransaction`). 

In the previous versions of the node, There used to be a separate endpoint for rawTx. The raw transaction can used as a common way to initialize a Transaction object in various bitcoin libraries, that's why it's really helpful.