### PR TITLE
Add `lockTime` value to transactions

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -319,6 +319,7 @@ export class Transaction extends BaseModel<ITransaction> {
       blockTime: tx.blockTime,
       blockTimeNormalized: tx.blockTimeNormalized,
       coinbase: tx.coinbase,
+      locktime: tx.locktime,
       size: tx.size,
       fee: tx.fee
     };


### PR DESCRIPTION
I think the `lockTime` value is important and should be returned by the BlockExplorer.