### PR TITLE
Fix typo in example config

### DIFF
--- a/packages/bitcore-node/README.md
+++ b/packages/bitcore-node/README.md
@@ -43,7 +43,7 @@ _Requirements_:
       }
     }
   }
-
+}
 ```
 
 


### PR DESCRIPTION
It's missing the closing curly bracket.