### PR TITLE
Fix env var name for DB port config

### DIFF
--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -55,7 +55,7 @@ const Config = function(): ConfigType {
     port: 3000,
     dbHost: process.env.DB_HOST || "127.0.0.1",
     dbName: process.env.DB_NAME || "bitcore",
-    dbPort: process.env.DB_NAME || "27017",
+    dbPort: process.env.DB_PORT || "27017",
     numWorkers: os.cpus().length,
     chains: {}
   };


### PR DESCRIPTION
The wrong variable name prevents to use a different port other than the default.