### PR TITLE
The fee response of BCH is a json object to be consistent with BTC

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/bch/bch.ts
+++ b/packages/bitcore-node/src/providers/chain-state/bch/bch.ts
@@ -8,6 +8,6 @@ export class BCHStateProvider extends BTCStateProvider {
 
   async getFee(params: CSP.GetEstimateSmartFeeParams) {
     const { chain, network, target } = params;
-    return this.getRPC(chain, network).getEstimateFee(Number(target));
+    return { feerate: await this.getRPC(chain, network).getEstimateFee(Number(target)) };
   }
 }


### PR DESCRIPTION
For `BCH`, `estiamtefee` RPC just return a decimal value, as opposed to the `estimatesmartfee` in `BTC` that returns a `json` object with `feerate` as the decimal value.

So for consistency of the API `fee` request, we should wrap the `BCH` response in the same format we expect from `BTC`. Also the default fee for `regtest`
https://github.com/bitpay/bitcore/blob/f178aab51735e58b054af79c93f8ad96238a5480/packages/bitcore-node/src/routes/api/fee.ts#L8
assumes the same format for all the blockchains, so it's confusing when `BCH` behaves differently on `testnet` or `mainnet`.