### PR TITLE
[v8, insight] update 'npm-run-all' to remove dependancy on 'event-stream'

### DIFF
--- a/packages/insight/package.json
+++ b/packages/insight/package.json
@@ -83,7 +83,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "npm-run-all": "^4.1.3",
+    "npm-run-all": "^4.1.5",
     "prettier": "^1.14.3",
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",


### PR DESCRIPTION
A fresh `npm install` currently fails because `event-stream@3.3.6` is removed from `npm`, this commit will bump the version of the package `npm-run-all`to avoid the dependency path below 

+ ─┬ npm-run-all@4.1.3
  └─┬ ps-tree@1.1.0
    └── event-stream@3.3.6

The error log is as follows
```
    ami: npm ERR! code E404
    ami: npm ERR! 404 Not Found: event-stream@https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz
    ami:
    ami: npm ERR! A complete log of this run can be found in:
    ami: npm ERR!     /home/bitcore/.npm/_logs/2018-11-30T20_31_03_338Z-debug.log
    ami:
    ami:     at Promise.all.then.arr (/home/bitcore/bitcore-v8/node_modules/execa/index.js:236:11)
    ami:     at <anonymous>
    ami:     at process._tickCallback (internal/process/next_tick.js:188:7)
    ami:   code: 1,
    ami:   killed: false,
    ami:   stdout: '',
    ami:   stderr: 
```