### PR TITLE
Allow unauthenticated wallet requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "scripts": {
     "build": "docker build -t bitcore-node .",
-    "postinstall": "npm run bootstrap",
+    "postinstall": "npm run bootstrap && npm run compile",
     "bootstrap": "./node_modules/.bin/lerna bootstrap",
     "insight": "cd packages/insight && npm start",
     "node": "cd packages/bitcore-node && npm start",

--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -59,7 +59,8 @@ const Config = function(): ConfigType {
     numWorkers: cpus().length,
     api: {
       wallets: {
-        allowCreationBeforeCompleteSync: false
+        allowCreationBeforeCompleteSync: false,
+        allowUnauthenticatedCalls: false
       }
     },
     chains: {}

--- a/packages/bitcore-node/src/types/Config.ts
+++ b/packages/bitcore-node/src/types/Config.ts
@@ -12,6 +12,7 @@ export default interface Config {
   api: {
     wallets: {
       allowCreationBeforeCompleteSync?: boolean;
+      allowUnauthenticatedCalls?: boolean;
     };
   };
 }


### PR DESCRIPTION
Helpful with debugging locally, allows you to curl wallet endpoints directly.