### PR TITLE
feat(api): break balance response into confirmed and unconfirmed 

### DIFF
--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -64,7 +64,7 @@ class Coin extends BaseModel<ICoin> {
     );
   }
 
-  async getBalance(params: { query: any }): Promise<{ confirmed: number, unconfirmed: number }> {
+  async getBalance(params: { query: any }): Promise<{ confirmed: number, unconfirmed: number, balance: number }> {
     let { query } = params;
     query = Object.assign(query, {
       spentHeight: { $lt: SpentHeightIndicators.minimum },
@@ -89,7 +89,11 @@ class Coin extends BaseModel<ICoin> {
         }
       ])
       .toArray();
-    return result.reduce((acc, cur) => { acc[cur._id] = cur.balance; return acc; }, {confirmed: 0, unconfirmed: 0}) as {confirmed: number, unconfirmed: number};
+    return result.reduce((acc, cur) => { 
+      acc[cur._id] = cur.balance; 
+      acc.balance += cur.balance;
+      return acc; 
+    }, { confirmed: 0, unconfirmed: 0, balance: 0 }) as { confirmed: number, unconfirmed: number, balance: number };
   }
 
   resolveAuthhead(mintTxid: string, chain?: string, network?: string) {

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -64,25 +64,32 @@ class Coin extends BaseModel<ICoin> {
     );
   }
 
-  getBalance(params: { query: any }) {
+  async getBalance(params: { query: any }): Promise<{ confirmed: number, unconfirmed: number }> {
     let { query } = params;
     query = Object.assign(query, {
       spentHeight: { $lt: SpentHeightIndicators.minimum },
       mintHeight: { $gt: SpentHeightIndicators.conflicting }
     });
-    return this.collection
-      .aggregate<{ balance: number }>([
+    const result =  await this.collection
+      .aggregate<{ _id: string, balance: number }>([
         { $match: query },
-        { $project: { value: 1, _id: 0 } },
+        { 
+          $project: { 
+            value: 1, 
+            status: {$cond: { if: { $gte: ['$mintHeight', SpentHeightIndicators.minimum]}, then: 'confirmed', else: 'unconfirmed' }}, 
+            _id: 0 
+          } 
+        },
         {
           $group: {
-            _id: null,
+            _id: '$status',
             balance: { $sum: '$value' }
+
           }
-        },
-        { $project: { _id: false } }
+        }
       ])
       .toArray();
+    return result.reduce((acc, cur) => { acc[cur._id] = cur.balance; return acc; }, {confirmed: 0, unconfirmed: 0}) as {confirmed: number, unconfirmed: number};
   }
 
   resolveAuthhead(mintTxid: string, chain?: string, network?: string) {

--- a/packages/bitcore-node/src/providers/chain-state/erc20/erc20.ts
+++ b/packages/bitcore-node/src/providers/chain-state/erc20/erc20.ts
@@ -23,6 +23,6 @@ export class ERC20StateProvider extends ETHStateProvider
     const balance= await this.erc20For(network)
       .methods.balanceOf(address)
       .call();
-    return { confirmed: balance, unconfirmed: 0};
+    return { confirmed: balance, unconfirmed: 0, balance };
   };
 }

--- a/packages/bitcore-node/src/providers/chain-state/erc20/erc20.ts
+++ b/packages/bitcore-node/src/providers/chain-state/erc20/erc20.ts
@@ -20,9 +20,9 @@ export class ERC20StateProvider extends ETHStateProvider
 
   async getBalanceForAddress(params: CSP.GetBalanceForAddressParams) {
     const { network, address } = params;
-    const balance: number = await this.erc20For(network)
+    const balance= await this.erc20For(network)
       .methods.balanceOf(address)
       .call();
-    return [{ balance }];
+    return { confirmed: balance, unconfirmed: 0};
   };
 }

--- a/packages/bitcore-node/src/providers/chain-state/eth/eth.ts
+++ b/packages/bitcore-node/src/providers/chain-state/eth/eth.ts
@@ -34,10 +34,10 @@ export class ETHStateProvider extends InternalStateProvider
 
   async getBalanceForAddress(
     params: CSP.GetBalanceForAddressParams
-  ): Promise<{ balance: number }[]> {
+  ) {
     const { network, address } = params;
     const balance = Number(await this.getRPC(network).getBalance(address));
-    return [{ balance }];
+    return {confirmed: balance, unconfirmed: 0};
   }
 
   async getBlock(params: CSP.GetBlockParams) {
@@ -68,13 +68,13 @@ export class ETHStateProvider extends InternalStateProvider
     let addressBalancePromises = addresses.map(({ address }) =>
       this.getBalanceForAddress({ chain: this.chain, network, address })
     );
-    let addressBalances = await Promise.all<{ balance: number }[]>(
+    let addressBalances = await Promise.all<{ confirmed: number, unconfirmed: number }>(
       addressBalancePromises
     );
     let balance = addressBalances.reduce(
       (prev, cur) => Number(prev) + Number(cur[0].balance),
       0
     );
-    return [{ balance }];
+    return {confirmed: balance, unconfirmed: 0};
   }
 }

--- a/packages/bitcore-node/src/providers/chain-state/eth/eth.ts
+++ b/packages/bitcore-node/src/providers/chain-state/eth/eth.ts
@@ -34,7 +34,7 @@ export class ETHStateProvider extends InternalStateProvider implements CSP.IChai
   async getBalanceForAddress(params: CSP.GetBalanceForAddressParams) {
     const { network, address } = params;
     const balance = Number(await this.getRPC(network).getBalance(address));
-    return { confirmed: balance, unconfirmed: 0 };
+    return { confirmed: balance, unconfirmed: 0, balance };
   }
 
   async getBlock(params: CSP.GetBlockParams) {
@@ -66,10 +66,10 @@ export class ETHStateProvider extends InternalStateProvider implements CSP.IChai
     let addressBalancePromises = addresses.map(({ address }) =>
       this.getBalanceForAddress({ chain: this.chain, network, address })
     );
-    let addressBalances = await Promise.all<{ confirmed: number; unconfirmed: number }>(addressBalancePromises);
+    let addressBalances = await Promise.all<{ confirmed: number; unconfirmed: number, balance: number }>(addressBalancePromises);
     let balance = addressBalances.reduce(
-      (prev, cur) => ({ unconfirmed: prev.unconfirmed + cur.unconfirmed, confirmed: prev.confirmed + cur.confirmed }),
-      { unconfirmed: 0, confirmed: 0 }
+      (prev, cur) => ({ unconfirmed: prev.unconfirmed + cur.unconfirmed, confirmed: prev.confirmed + cur.confirmed, balance: prev.balance + cur.balance }),
+      { unconfirmed: 0, confirmed: 0, balance: 0 }
     );
     return balance;
   }

--- a/packages/bitcore-node/src/routes/api/address.ts
+++ b/packages/bitcore-node/src/routes/api/address.ts
@@ -38,7 +38,7 @@ router.get('/:address/balance',  async function(req, res) {
       network,
       address
     });
-    return res.send(result || { confirmed: 0, unconfirmed: 0 });
+    return res.send(result || { confirmed: 0, unconfirmed: 0, balance: 0 });
   } catch (err) {
     return res.status(500).send(err);
   }

--- a/packages/bitcore-node/src/routes/api/address.ts
+++ b/packages/bitcore-node/src/routes/api/address.ts
@@ -38,7 +38,7 @@ router.get('/:address/balance',  async function(req, res) {
       network,
       address
     });
-    return res.send((result && result[0]) || { balance: 0 });
+    return res.send(result || { confirmed: 0, unconfirmed: 0 });
   } catch (err) {
     return res.status(500).send(err);
   }

--- a/packages/bitcore-node/src/routes/api/wallet.ts
+++ b/packages/bitcore-node/src/routes/api/wallet.ts
@@ -181,7 +181,7 @@ router.get('/:pubKey/balance', authenticate, async (req: AuthenticatedRequest, r
       network,
       wallet: req.wallet!
     });
-    return res.send((result && result[0]) || { balance: 0 });
+    return res.send(result || { confirmed: 0, unconfirmed: 0 });
   } catch (err) {
     return res.status(500).json(err);
   }

--- a/packages/bitcore-node/src/routes/api/wallet.ts
+++ b/packages/bitcore-node/src/routes/api/wallet.ts
@@ -181,7 +181,7 @@ router.get('/:pubKey/balance', authenticate, async (req: AuthenticatedRequest, r
       network,
       wallet: req.wallet!
     });
-    return res.send(result || { confirmed: 0, unconfirmed: 0 });
+    return res.send(result || { confirmed: 0, unconfirmed: 0, balance: 0 });
   } catch (err) {
     return res.status(500).json(err);
   }

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -110,8 +110,8 @@ export declare namespace CSP {
   export type Provider<T> = { get(params: { chain: string }): T };
   export type ChainStateProvider = Provider<IChainStateService> & IChainStateService;
   export interface IChainStateService {
-    getBalanceForAddress(params: GetBalanceForAddressParams): Promise<{ balance: number }[]>;
-    getBalanceForWallet(params: GetBalanceForWalletParams): Promise<{ balance: number }[]>;
+    getBalanceForAddress(params: GetBalanceForAddressParams): Promise<{ confirmed: number, unconfirmed: number }>;
+    getBalanceForWallet(params: GetBalanceForWalletParams): Promise<{ confirmed: number, unconfirmed: number }>;
     getBlock(params: GetBlockParams): Promise<IBlock | string>;
     streamBlocks(params: StreamBlocksParams): any;
     getFee(params: GetEstimateSmartFeeParams): any;
@@ -119,7 +119,7 @@ export declare namespace CSP {
     createWallet(params: CreateWalletParams): Promise<IWallet>;
     getWallet(params: GetWalletParams): Promise<IWallet | null>;
     updateWallet(params: UpdateWalletParams): Promise<{}>;
-    getWalletBalance(params: GetWalletBalanceParams): Promise<{ balance: number }[]>;
+    getWalletBalance(params: GetWalletBalanceParams): Promise<{ confirmed: number, unconfirmed: number }>;
     streamAddressUtxos(params: StreamAddressUtxosParams): any;
     streamAddressTransactions(params: StreamAddressUtxosParams): any;
     streamTransactions(params: StreamTransactionsParams): any;

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -110,8 +110,8 @@ export declare namespace CSP {
   export type Provider<T> = { get(params: { chain: string }): T };
   export type ChainStateProvider = Provider<IChainStateService> & IChainStateService;
   export interface IChainStateService {
-    getBalanceForAddress(params: GetBalanceForAddressParams): Promise<{ confirmed: number, unconfirmed: number }>;
-    getBalanceForWallet(params: GetBalanceForWalletParams): Promise<{ confirmed: number, unconfirmed: number }>;
+    getBalanceForAddress(params: GetBalanceForAddressParams): Promise<{ confirmed: number, unconfirmed: number, balance: number }>;
+    getBalanceForWallet(params: GetBalanceForWalletParams): Promise<{ confirmed: number, unconfirmed: number, balance: number }>;
     getBlock(params: GetBlockParams): Promise<IBlock | string>;
     streamBlocks(params: StreamBlocksParams): any;
     getFee(params: GetEstimateSmartFeeParams): any;
@@ -119,7 +119,7 @@ export declare namespace CSP {
     createWallet(params: CreateWalletParams): Promise<IWallet>;
     getWallet(params: GetWalletParams): Promise<IWallet | null>;
     updateWallet(params: UpdateWalletParams): Promise<{}>;
-    getWalletBalance(params: GetWalletBalanceParams): Promise<{ confirmed: number, unconfirmed: number }>;
+    getWalletBalance(params: GetWalletBalanceParams): Promise<{ confirmed: number, unconfirmed: number, balance: number }>;
     streamAddressUtxos(params: StreamAddressUtxosParams): any;
     streamAddressTransactions(params: StreamAddressUtxosParams): any;
     streamTransactions(params: StreamTransactionsParams): any;


### PR DESCRIPTION
BREAKING CHANGE: balance response has changed from `{balance: number}` to `{confirmed: number, unconfirmed: number, balance: number}`

@micahriggan take a look at the eth and erc20 providers, they still need some work
@matiu this is a breaking change for the balance endpoints, BWS will need to be ready for this change