### PR TITLE
Native cashaddr in BWS

### DIFF
--- a/packages/bitcore-wallet-client/test/client.js
+++ b/packages/bitcore-wallet-client/test/client.js
@@ -2651,6 +2651,12 @@ describe('client API', function() {
       }, function(w) {
         clients[0].createAddress(function(err, address) {
           should.not.exist(err);
+
+          // BWS not uses cashaddress internally
+          if (coin == 'bch') {
+            address.address = Bitcore_['bch'].Address(address.address).toString(true);
+          }
+          
           blockchainExplorerMock.setUtxo(address, 2, 2);
           blockchainExplorerMock.setUtxo(address, 2, 2);
           blockchainExplorerMock.setUtxo(address, 1, 2, 0);
@@ -3191,6 +3197,9 @@ describe('client API', function() {
           clients[0].createAddress(function(err, x0) {
             should.not.exist(err);
             should.exist(x0.address);
+
+            // cash addr internally
+            x0.address = Bitcore_['bch'].Address(x0.address).toString(true);
             blockchainExplorerMock.setUtxo(x0, 1, 2);
             blockchainExplorerMock.setUtxo(x0, 1, 2);
             var opts = {

--- a/packages/bitcore-wallet-client/test/client.js
+++ b/packages/bitcore-wallet-client/test/client.js
@@ -2652,10 +2652,11 @@ describe('client API', function() {
         clients[0].createAddress(function(err, address) {
           should.not.exist(err);
 
-          // BWS not uses cashaddress internally
+          // TODO change createAddress to /v4/, and remove this.
           if (coin == 'bch') {
             address.address = Bitcore_['bch'].Address(address.address).toString(true);
           }
+          // ==
           
           blockchainExplorerMock.setUtxo(address, 2, 2);
           blockchainExplorerMock.setUtxo(address, 2, 2);
@@ -3198,8 +3199,9 @@ describe('client API', function() {
             should.not.exist(err);
             should.exist(x0.address);
 
-            // cash addr internally
+            // TODO change createAddress to /v4/, and remove this.
             x0.address = Bitcore_['bch'].Address(x0.address).toString(true);
+            // ======
             blockchainExplorerMock.setUtxo(x0, 1, 2);
             blockchainExplorerMock.setUtxo(x0, 1, 2);
             var opts = {

--- a/packages/bitcore-wallet-service/README.md
+++ b/packages/bitcore-wallet-service/README.md
@@ -135,10 +135,14 @@ Returns:
  * Uses cashaddr without prefix for BCH
 
 
-`/v1/addresses/`: Get Wallet's main addresses (does not include change addresses)
+`/v4/addresses/`: Get Wallet's main addresses (does not include change addresses)
+
+Optional Arguments:
+ * ignoreMaxGap: [false] Ignore checking less that 20 unused addresses (BIP44 GAP)
 
 Returns:
- * List of Addresses object: (https://github.com/bitpay/bitcore-wallet-service/blob/master/lib/model/address.js)).  This call is mainly provided so the client check this addresses for incoming transactions (using a service like [Insight](https://insight.is)
+ * List of Addresses object: (https://github.com/bitpay/bitcore/blob/master/packages/bitcore-wallet-service/lib/model/address.js)).  This call is mainly provided so the client check this addresses for incoming transactions (using a service like [Insight](https://insight.is)
+ * Returns cashaddr without prefix for BCH
 
 `/v1/balance/`:  Get Wallet's balance
 

--- a/packages/bitcore-wallet-service/README.md
+++ b/packages/bitcore-wallet-service/README.md
@@ -72,6 +72,17 @@ BWS can be used with PM2 with the provided `app.js` script:
 @dabura667 made a report about how to use letsencrypt with BWS: https://github.com/bitpay/bitcore-wallet-service/issues/423
   
 
+# TX proposal life cycle
+
+Tx proposal need to be:
+ 1. First created via /v?/txproposal
+      -> This will create a 'temporary' TX proposal, returning the object, but not locking the inputs
+ 2. Then published via  /v?/txproposal/:id/publish
+      -> This publish the tx proposal to all copayers, looking the inputs. The TX proposal can be `deleted` also, after been published.
+ 3. Then signed via /v?/txproposal/:id/signature for each copayer
+ 4. Then broadcasted to the p2p network via /v?/txproposal/:id/broadcast
+
+
 # REST API
 
 Note: all currency amounts are in units of satoshis (1/100,000,000 of a bitcoin).
@@ -114,9 +125,12 @@ Returns:
  * actions array ['createdOn', 'type', 'copayerId', 'copayerName', 'comment']
   
  
-`/v1/txproposals/`:  Get Wallet's pending transaction proposals and their status
+`/v2/txproposals/`:  Get Wallet's pending transaction proposals and their status
 Returns:
  * List of pending TX Proposals. (see [fields on the source code](https://github.com/bitpay/bitcore-wallet-service/blob/master/lib/model/txproposal.js))
+
+ * Uses cashaddr without prefix for BCH
+
 
 `/v1/addresses/`: Get Wallet's main addresses (does not include change addresses)
 
@@ -174,7 +188,7 @@ Returns:
  * copayerId: Assigned ID of the copayer (to be used on x-identity header)
  * wallet: Object with wallet's information
 
-`/v1/txproposals/`: Add a new transaction proposal
+`/v3/txproposals/`: Add a new temporary transaction proposal
 
 Required Arguments:
  * toAddress: RCPT Bitcoin address.
@@ -184,10 +198,15 @@ Required Arguments:
  * (opt) payProUrl: Paypro URL for peers to verify TX
  * (opt) feePerKb: Use an alternative fee per KB for this TX.
  * (opt) excludeUnconfirmedUtxos: Do not use UTXOs of unconfirmed transactions as inputs for this TX.
+ * BCH addresses need to be cashaddr without prefix.
 
 Returns:
  * TX Proposal object. (see [fields on the source code](https://github.com/bitpay/bitcore-wallet-service/blob/master/lib/model/txproposal.js)). `.id` is probably needed in this case.
 
+`/v2/txproposals/:id/publish`: Publish the previously created `temporary` tx proposal.
+
+Returns:
+ * TX Proposal object. (see [fields on the source code](https://github.com/bitpay/bitcore-wallet-service/blob/master/lib/model/txproposal.js)).
 
 `/v3/addresses/`: Request a new main address from wallet . (creates an address on normal conditions)
 

--- a/packages/bitcore-wallet-service/README.md
+++ b/packages/bitcore-wallet-service/README.md
@@ -83,6 +83,9 @@ Tx proposal need to be:
  4. Then broadcasted to the p2p network via /v?/txproposal/:id/broadcast
 
 
+The are plenty example creating and sending proposals in the `/test/integration` code.
+
+
 # REST API
 
 Note: all currency amounts are in units of satoshis (1/100,000,000 of a bitcoin).

--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -187,10 +187,6 @@ V8.prototype._transformUtxos = function(unspent, bcheight) {
   let ret = _.map(unspent, function(x) {
     var u = {address: x.address};
 
-    if (self.addressFormat) {
-      u.address = self.translateResultAddresses(x.address);
-    }
-
     // v8 field name differences
     u.satoshis = x.value;
     u.amount = x.value / 1e8;
@@ -248,18 +244,15 @@ V8.prototype.getCheckData = function(wallet, cb) {
  */
 V8.prototype.broadcast = function(rawTx, cb) {
 
-console.log('[v8.js.207] BROADCAST'); //TODO
   const payload = {
     rawTx: rawTx,
     network: this.v8network,
     chain: this.coin.toUpperCase(),
   };
 
-console.log('[v8.js.209:payload:]',payload); //TODO
   var client = this._getClient();
   client.broadcast({ payload })
     .then( (ret) => {
-console.log('[v8.js.218:ret:]',ret); //TODO
       if (!ret.txid) {
         return cb(new Error('Error broadcasting'));
       }

--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8/client.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8/client.js
@@ -120,7 +120,7 @@ Client.prototype.importAddresses = async function(params) {
   const { payload, pubKey } = params;
   const url = `${this.baseUrl}/wallet/${pubKey}`;
 
-  console.log('add addresses:',url); //TODO
+  console.log('addAddresses:',url, payload); //TODO
   const signature = this.sign({ method: 'POST', url, payload});
   let h = { 'x-signature': signature};
   return request.post(url, {

--- a/packages/bitcore-wallet-service/lib/errors/errordefinitions.js
+++ b/packages/bitcore-wallet-service/lib/errors/errordefinitions.js
@@ -12,6 +12,7 @@ var errors = {
   COPAYER_VOTED: 'Copayer already voted on this transaction proposal',
   DUST_AMOUNT: 'Amount below dust threshold',
   INCORRECT_ADDRESS_NETWORK: 'Incorrect address network',
+  ONLY_CASHADDR: 'Only cashaddr wo prefix is allowed for outputs',
   INSUFFICIENT_FUNDS: 'Insufficient funds',
   INSUFFICIENT_FUNDS_FOR_FEE: 'Insufficient funds for fee',
   INVALID_ADDRESS: 'Invalid address',

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -346,6 +346,8 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+
+  
   router.get('/v1/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.getPendingTxs({}, function(err, pendings) {
@@ -396,7 +398,21 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+  // DEPRECATED (no cashaddr by default)
   router.post('/v3/addresses/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      var opts = req.body;
+      opts = opts || {};
+      opts.noCashAddr = true;
+      server.createAddress(opts, function(err, address) {
+        if (err) return returnError(err, res, req);
+        res.json(address);
+      });
+    });
+  });
+
+
+  router.post('/v4/addresses/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.createAddress(req.body, function(err, address) {
         if (err) return returnError(err, res, req);
@@ -404,6 +420,7 @@ ExpressApp.prototype.start = function(opts, cb) {
       });
     });
   });
+
 
   router.get('/v1/addresses/', function(req, res) {
     getServerWithAuth(req, res, function(server) {

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -348,7 +348,17 @@ ExpressApp.prototype.start = function(opts, cb) {
 
 
   
+  // DEPRECATED (do not use cashaddr)
   router.get('/v1/txproposals/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      server.getPendingTxs({noCashAddr: true}, function(err, pendings) {
+        if (err) return returnError(err, res, req);
+        res.json(pendings);
+      });
+    });
+  });
+
+  router.get('/v2/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.getPendingTxs({}, function(err, pendings) {
         if (err) return returnError(err, res, req);
@@ -363,14 +373,29 @@ ExpressApp.prototype.start = function(opts, cb) {
     return returnError(err, res, req);
   });
 
+
+  // DEPRECATED, no cash addr
   router.post('/v2/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
+      req.body.noCashAddr = true;
       server.createTx(req.body, function(err, txp) {
         if (err) return returnError(err, res, req);
         res.json(txp);
       });
     });
   });
+
+  router.post('/v3/txproposals/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      req.body.onlyCashAddr = true;
+      server.createTx(req.body, function(err, txp) {
+        if (err) return returnError(err, res, req);
+        res.json(txp);
+      });
+    });
+  });
+
+
 
   // DEPRECATED
   router.post('/v1/addresses/', function(req, res) {
@@ -546,7 +571,20 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+  //
   router.post('/v1/txproposals/:id/publish/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      req.body.txProposalId = req.params['id'];
+      req.body.noCashAddr = true;
+      server.publishTx(req.body, function(err, txp) {
+        if (err) return returnError(err, res, req);
+        res.json(txp);
+        res.end();
+      });
+    });
+  });
+
+  router.post('/v2/txproposals/:id/publish/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       req.body.txProposalId = req.params['id'];
       server.publishTx(req.body, function(err, txp) {
@@ -556,6 +594,8 @@ ExpressApp.prototype.start = function(opts, cb) {
       });
     });
   });
+
+
 
   // TODO Check HTTP verb and URL name
   router.post('/v1/txproposals/:id/broadcast/', function(req, res) {

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -387,7 +387,6 @@ ExpressApp.prototype.start = function(opts, cb) {
 
   router.post('/v3/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
-      req.body.onlyCashAddr = true;
       server.createTx(req.body, function(err, txp) {
         if (err) return returnError(err, res, req);
         res.json(txp);

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -411,7 +411,7 @@ ExpressApp.prototype.start = function(opts, cb) {
 
   // DEPRECATED
   router.post('/v2/addresses/', function(req, res) {
-    logDeprecated(req);
+   logDeprecated(req);
     getServerWithAuth(req, res, function(server) {
       server.createAddress({
         ignoreMaxGap: true

--- a/packages/bitcore-wallet-service/lib/model/address.js
+++ b/packages/bitcore-wallet-service/lib/model/address.js
@@ -54,7 +54,7 @@ Address.fromObj = function(obj) {
   return x;
 };
 
-Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, network) {
+Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, network, noNativeCashAddr) {
   $.checkArgument(Utils.checkValueInCollection(scriptType, Constants.SCRIPT_TYPES));
 
   var publicKeys = _.map(publicKeyRing, function(item) {
@@ -73,16 +73,25 @@ Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, netw
       break;
   }
 
+
+
+  let addrStr = bitcoreAddress.toString(true); 
+  if (noNativeCashAddr && coin == 'bch') {
+    addrStr =  bitcoreAddress.toLegacyAddress();
+  }
+
   return {
     // bws still use legacy addresses for BCH
-    address: coin == 'bch' ? bitcoreAddress.toLegacyAddress() : bitcoreAddress.toString(),
+    address: addrStr,
     path: path,
     publicKeys: _.invokeMap(publicKeys, 'toString'),
   };
 };
 
-Address.derive = function(walletId, scriptType, publicKeyRing, path, m, coin, network, isChange) {
-  var raw = Address._deriveAddress(scriptType, publicKeyRing, path, m, coin, network);
+
+// noNativeCashAddr only for testing
+Address.derive = function(walletId, scriptType, publicKeyRing, path, m, coin, network, isChange, noNativeCashAddr) {
+  var raw = Address._deriveAddress(scriptType, publicKeyRing, path, m, coin, network, noNativeCashAddr);
   return Address.create(_.extend(raw, {
     coin: coin,
     walletId: walletId,

--- a/packages/bitcore-wallet-service/lib/model/wallet.js
+++ b/packages/bitcore-wallet-service/lib/model/wallet.js
@@ -60,6 +60,9 @@ Wallet.create = function(opts) {
   x.beAuthPrivateKey2 = null; 
   x.beAuthPublicKey2 = null; 
 
+  // x.nativeCashAddr opts is only for testing
+  x.nativeCashAddr = _.isUndefined(opts.nativeCashAddr) ? (x.coin == 'bch' ? true : null) : opts.nativeCashAddr;
+
   return x;
 };
 
@@ -94,6 +97,8 @@ Wallet.fromObj = function(obj) {
   x.beRegistered = obj.beRegistered;
   x.beAuthPrivateKey2 = obj.beAuthPrivateKey2; 
   x.beAuthPublicKey2 = obj.beAuthPublicKey2; 
+
+  x.nativeCashAddr = obj.nativeCashAddr;
 
   return x;
 };
@@ -186,12 +191,11 @@ Wallet.prototype.isScanning = function() {
 
 Wallet.prototype.createAddress = function(isChange, step) {
   $.checkState(this.isComplete());
-
   var self = this;
 
   var path = this.addressManager.getNewAddressPath(isChange, step);
   log.verbose('Deriving addr:' + path);
-  var address = Address.derive(self.id, this.addressType, this.publicKeyRing, path, this.m, this.coin, this.network, isChange);
+  var address = Address.derive(self.id, this.addressType, this.publicKeyRing, path, this.m, this.coin, this.network, isChange, !self.nativeCashAddr);
   return address;
 };
 

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -1103,7 +1103,7 @@ WalletService.prototype._store = function(wallet, address, cb, checkSync) {
  * Creates a new address.
  * @param {Object} opts
  * @param {Boolean} [opts.ignoreMaxGap=false] - Ignore constraint of maximum number of consecutive addresses without activity
- * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch
+ * @param {Boolean} opts.noCashAddr (do not use cashaddr, only for backwards compat)
  * @returns {Address} address
  */
 WalletService.prototype.createAddress = function(opts, cb) {
@@ -2060,8 +2060,30 @@ WalletService.prototype._canCreateTx = function(cb) {
   });
 };
 
-WalletService.prototype._validateOutputs = function(opts, wallet, cb) {
+
+WalletService.prototype._validateAddr = function(wallet, inaddr, opts) {
   var A = Bitcore_[wallet.coin].Address;
+
+  var addr = {};
+  try {
+    addr = new A(inaddr);
+  } catch (ex) {
+    return Errors.INVALID_ADDRESS;
+  }
+  if (addr.network.toString() != wallet.network) {
+    return Errors.INCORRECT_ADDRESS_NETWORK;
+  }
+
+  if (wallet.coin == 'bch' && !opts.noCashAddr) {
+    if (addr.toString(true) !=  inaddr)
+    return Errors.ONLY_CASHADDR;
+  }
+
+  return;
+};
+
+WalletService.prototype._validateOutputs = function(opts, wallet, cb) {
+  var self = this;
   var dustThreshold = Math.max(Defaults.MIN_OUTPUT_AMOUNT, Bitcore_[wallet.coin].Transaction.DUST_AMOUNT);
 
   if (_.isEmpty(opts.outputs)) return new ClientError('No outputs were specified');
@@ -2070,24 +2092,13 @@ WalletService.prototype._validateOutputs = function(opts, wallet, cb) {
     var output = opts.outputs[i];
     output.valid = false;
 
+    let addrErr = self._validateAddr(wallet, output.toAddress, opts);
+    if (addrErr) return addrErr;
+
+    
+
     if (!checkRequired(output, ['toAddress', 'amount'])) {
       return new ClientError('Argument missing in output #' + (i + 1) + '.');
-    }
-
-    var toAddress = {};
-    try {
-      toAddress = new A(output.toAddress);
-    } catch (ex) {
-      return Errors.INVALID_ADDRESS;
-    }
-    if (toAddress.network != wallet.network) {
-      return Errors.INCORRECT_ADDRESS_NETWORK;
-    }
-
-    if (toAddress.network == 'bch' ) {
-      let stripped = _.last(output.toAddress.split(':'));
-      if (toAddress.network.toString() !=  stripped)
-        return Errors.ONLY_CASHADDR;
     }
 
     if (!_.isNumber(output.amount) || _.isNaN(output.amount) || output.amount <= 0) {
@@ -2169,7 +2180,8 @@ WalletService.prototype._validateAndSanitizeTxOpts = function(wallet, opts, cb) 
     },
     function(next) {
       // check outputs are on 'copay' format for BCH
-      if (wallet.coin != 'bch' || opts.onlyCashAddr) return next();
+      if (wallet.coin != 'bch') return next();
+      if (!opts.noCashAddr) return next();
 
       // TODO remove one cashaddr is used internally (noCashAddr flag)?
       opts.origAddrOutputs = _.map(opts.outputs, (x) => {
@@ -2244,8 +2256,7 @@ WalletService.prototype._getFeePerKb = function(wallet, opts, cb) {
  * @param {Array} opts.inputs - Optional. Inputs for this TX
  * @param {number} opts.fee - Optional. Use an fixed fee for this TX (only when opts.inputs is specified)
  * @param {Boolean} opts.noShuffleOutputs - Optional. If set, TX outputs won't be shuffled. Defaults to false
- * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch in RESPONSE changeAddress
- * @param {Boolean} [opts.onlyCashAddr] - do not allow non cashAddr outputs
+ * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch
  * @returns {TxProposal} Transaction proposal. outputs address format will use the same format as inpunt.
  */
 WalletService.prototype.createTx = function(opts, cb) {
@@ -2262,6 +2273,12 @@ WalletService.prototype.createTx = function(opts, cb) {
       });
     } else {
       if (opts.changeAddress) {
+
+        // 
+
+        let addrErr = self._validateAddr(wallet, opts.changeAddress, opts);
+        if (addrErr) return cb(addrErr);
+
         self.storage.fetchAddressByWalletId(wallet.id, opts.changeAddress, function(err, address) {
           if (err || !address) return cb(Errors.INVALID_CHANGE_ADDRESS);
           return cb(null, address);
@@ -2898,10 +2915,16 @@ WalletService.prototype.getPendingTxs = function(opts, cb) {
       })
 
       if (opts.noCashAddr && txps[0] && txps[0].coin == 'bch') {
+console.log('## [server.js.2989]'); //TODO
         _.each(txps, (x) => {
           if (x.changeAddress) {
             x.changeAddress.address= BCHAddressTranslator.translate(x.changeAddress.address,'copay');
           }
+          _.each(x.outputs, (x) => {
+            if (x.toAddress) {
+              x.toAddress= BCHAddressTranslator.translate(x.toAddress,'copay');
+            }
+          });
         });
       }
 

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -5,6 +5,7 @@ var $ = require('preconditions').singleton();
 var async = require('async');
 var log = require('npmlog');
 var serverMessages = require('../serverMessages');
+var BCHAddressTranslator = require('./bchaddresstranslator');
 
 log.debug = log.verbose;
 log.disableColor();
@@ -1102,6 +1103,7 @@ WalletService.prototype._store = function(wallet, address, cb, checkSync) {
  * Creates a new address.
  * @param {Object} opts
  * @param {Boolean} [opts.ignoreMaxGap=false] - Ignore constraint of maximum number of consecutive addresses without activity
+ * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch
  * @returns {Address} address
  */
 WalletService.prototype.createAddress = function(opts, cb) {
@@ -1153,6 +1155,10 @@ WalletService.prototype.createAddress = function(opts, cb) {
         return createFn(wallet, (err, address) => {
           if (err) {
             return cb(err);
+          }
+
+          if (wallet.coin == 'bch' && opts.noCashAddr) {
+            address.address = BCHAddressTranslator.translate(address.address, 'copay');
           }
 
           return cb(err, address);
@@ -3666,7 +3672,6 @@ WalletService.prototype.getTxHistory = function(opts, cb) {
         } else {
           self.logi(`History from bc ${from}/${to}: ${finalTxs.length} txs`);
         }
-        //console.log('[server.js.3504:finalTxs:]',finalTxs); //TODO
         return cb(null, finalTxs, !!res.txs.fromCache, !!res.txs.useStream);
       });
     });

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -478,6 +478,7 @@ WalletService.prototype.createWallet = function(opts, cb) {
         singleAddress: !!opts.singleAddress,
         derivationStrategy: derivationStrategy,
         addressType: addressType,
+        nativeCashAddr: opts.nativeCashAddr,
       });
       self.storage.storeWallet(wallet, function(err) {
         self.logi('Wallet created', wallet.id, opts.network);
@@ -501,7 +502,24 @@ WalletService.prototype.getWallet = function(opts, cb) {
   self.storage.fetchWallet(self.walletId, function(err, wallet) {
     if (err) return cb(err);
     if (!wallet) return cb(Errors.WALLET_NOT_FOUND);
-    return cb(null, wallet);
+
+    // cashAddress migration
+    if (wallet.coin != 'bch' || wallet.nativeCashAddr)  
+      return cb(null, wallet);
+
+    // only for testing
+    if (opts.doNotMigrate) return cb(null, wallet);
+
+    // remove someday...
+    log.info(`Migrating wallet ${wallet.id} to cashAddr`);
+    self.storage.migrateToCashAddr(self.walletId,(e)=> {
+      if (e) return cb(e);
+      wallet.nativeCashAddr=true;
+      return self.storage.storeWallet(wallet, (e)=> {
+        if (e) return cb(e);
+        return cb(e, wallet);
+      });
+    });
   });
 };
 
@@ -1124,7 +1142,7 @@ WalletService.prototype.createAddress = function(opts, cb) {
     if (!canCreate) return cb(Errors.MAIN_ADDRESS_GAP_REACHED);
 
     self._runLocked(cb, function(cb) {
-      self.getWallet({}, function(err, wallet) {
+      self.getWallet({doNotMigrate: opts.doNotMigrate}, function(err, wallet) {
         if (err) return cb(err);
         if (!wallet.isComplete()) return cb(Errors.WALLET_NOT_COMPLETE);
         if (wallet.scanStatus == 'error') 
@@ -1239,7 +1257,7 @@ WalletService.prototype._getUtxosForCurrentWallet = function(opts, cb) {
         if (wallet.scanStatus == 'error') 
           return cb(Errors.WALLET_NEED_SCAN);
 
-        coin = opts.coin || wallet.coin;
+        coin = wallet.coin;
 
         bc = self._getBlockchainExplorer(coin, wallet.network);
         if (!bc) return cb(new Error('Could not get blockchain explorer instance'));
@@ -1262,21 +1280,8 @@ WalletService.prototype._getUtxosForCurrentWallet = function(opts, cb) {
       });
     },
     function(next) {
-
       addressStrs = _.map(allAddresses, 'address');
-      if (!opts.coin) return next();
-
-      coin = opts.coin;
-      if (coin != 'bch') return next();
-
-      if (Utils.getAddressCoin(addressStrs[0]) == 'bch') 
-        return next();
-
-      // because some old BCH walelts could have legacy addresses?
-      addressStrs =  _.map(addressStrs, function(a) {
-        return Utils.translateAddress(a, coin);
-      });
-      next();
+      return next();
     },
     function(next) {
       if (!wallet.isComplete()) return next();
@@ -1331,7 +1336,6 @@ WalletService.prototype._getUtxosForCurrentWallet = function(opts, cb) {
       });
     },
     function(next) {
-      if (opts.coin) return next();
       // Needed for the clients to sign UTXOs
       var addressToPath = _.keyBy(allAddresses, 'address');
       _.each(allUtxos, function(utxo) {
@@ -1357,7 +1361,6 @@ WalletService.prototype._getUtxosForCurrentWallet = function(opts, cb) {
 /**
  * Returns list of UTXOs
  * @param {Object} opts
- * @param {String} [opts.coin='btc'] (optional)
  * @param {Array} [opts.addresses] - List of addresses. options. only one address is supported
  * @returns {Array} utxos - List of UTXOs.
  */
@@ -1365,6 +1368,11 @@ WalletService.prototype.getUtxos = function(opts, cb) {
   var self = this;
 
   opts = opts || {};
+
+  if (opts.coin) {
+    return cb(new ClientError('coins option no longer supported'));
+  }
+
   if (opts.addresses) {
 
     if (opts.addresses.length>1)
@@ -1401,15 +1409,7 @@ WalletService.prototype.getUtxos = function(opts, cb) {
 
     });
   }  else {
-
-    if (opts.coin) {
-      if (!Utils.checkValueInCollection(opts.coin, Constants.COINS))
-      return cb(new ClientError('Invalid coin'));
-    }
-
-    self._getUtxosForCurrentWallet({
-      coin: opts.coin
-    }, cb);
+    self._getUtxosForCurrentWallet({}, cb);
   }
 };
 
@@ -1430,7 +1430,6 @@ WalletService.prototype._totalizeUtxos = function(utxos) {
 /**
  * Get wallet balance.
  * @param {Object} opts
- * @param {string} [opts.coin] - Override wallet coin (default wallet's coin).
  * @returns {Object} balance - Total amount & locked amount.
  */
 
@@ -1439,7 +1438,7 @@ WalletService.prototype.getBalance = function(opts, cb, i) {
   opts = opts || {};
 
   if (opts.coin) {
-    return cb(new ClientError('opts.coin no longer supported'));
+    return cb(new ClientError('coin is not longer supported in getBalance'));
   }
   let wallet = opts.wallet;
   let addresses = null;

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -2084,6 +2084,12 @@ WalletService.prototype._validateOutputs = function(opts, wallet, cb) {
       return Errors.INCORRECT_ADDRESS_NETWORK;
     }
 
+    if (toAddress.network == 'bch' ) {
+      let stripped = _.last(output.toAddress.split(':'));
+      if (toAddress.network.toString() !=  stripped)
+        return Errors.ONLY_CASHADDR;
+    }
+
     if (!_.isNumber(output.amount) || _.isNaN(output.amount) || output.amount <= 0) {
       return new ClientError('Invalid amount');
     }
@@ -2163,7 +2169,7 @@ WalletService.prototype._validateAndSanitizeTxOpts = function(wallet, opts, cb) 
     },
     function(next) {
       // check outputs are on 'copay' format for BCH
-      if (wallet.coin != 'bch') return next();
+      if (wallet.coin != 'bch' || opts.onlyCashAddr) return next();
 
       // TODO remove one cashaddr is used internally (noCashAddr flag)?
       opts.origAddrOutputs = _.map(opts.outputs, (x) => {
@@ -2238,7 +2244,9 @@ WalletService.prototype._getFeePerKb = function(wallet, opts, cb) {
  * @param {Array} opts.inputs - Optional. Inputs for this TX
  * @param {number} opts.fee - Optional. Use an fixed fee for this TX (only when opts.inputs is specified)
  * @param {Boolean} opts.noShuffleOutputs - Optional. If set, TX outputs won't be shuffled. Defaults to false
- * @returns {TxProposal} Transaction proposal.
+ * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch in RESPONSE changeAddress
+ * @param {Boolean} [opts.onlyCashAddr] - do not allow non cashAddr outputs
+ * @returns {TxProposal} Transaction proposal. outputs address format will use the same format as inpunt.
  */
 WalletService.prototype.createTx = function(opts, cb) {
   var self = this;
@@ -2359,11 +2367,18 @@ WalletService.prototype.createTx = function(opts, cb) {
         ], function(err) {
           if (err) return cb(err);
 
-          //
-          if (opts.returnOrigAddrOutputs) {
-            log.info('Returning Orig BCH address outputs for compat');
-            txp.outputs = opts.origAddrOutputs;
+          if (txp.coin == 'bch') {
+
+            if (opts.returnOrigAddrOutputs) {
+              log.info('Returning Orig BCH address outputs for compat');
+              txp.outputs = opts.origAddrOutputs;
+            }
+
+            if (opts.noCashAddr && txp.changeAddress) {
+              txp.changeAddress.address= BCHAddressTranslator.translate(txp.changeAddress.address,'copay');
+            }
           }
+
           return cb(null, txp);
         });
 
@@ -2381,6 +2396,7 @@ WalletService.prototype._verifyRequestPubKey = function(requestPubKey, signature
  * @param {Object} opts
  * @param {string} opts.txProposalId - The tx id.
  * @param {string} opts.proposalSignature - S(raw tx). Used by other copayers to verify the proposal.
+ * @param {Boolean} [opts.noCashAddr] - do not use cashaddress for bch
  */
 WalletService.prototype.publishTx = function(opts, cb) {
   var self = this;
@@ -2444,6 +2460,15 @@ WalletService.prototype.publishTx = function(opts, cb) {
             if (err) return cb(err);
 
             self._notifyTxProposalAction('NewTxProposal', txp, function() {
+
+
+              if (opts.noCashAddr && txp.coin == 'bch') {
+                if (txp.changeAddress) {
+                  txp.changeAddress.address= BCHAddressTranslator.translate(txp.changeAddress.address,'copay');
+                }
+              }
+
+
               return cb(null, txp);
             });
           });
@@ -2844,6 +2869,7 @@ WalletService.prototype.rejectTx = function(opts, cb) {
 /**
  * Retrieves pending transaction proposals.
  * @param {Object} opts
+ * @param {Boolean} opts.noCashAddr (do not use cashaddr, only for backwards compat)
  * @returns {TxProposal[]} Transaction proposal.
  */
 WalletService.prototype.getPendingTxs = function(opts, cb) {
@@ -2866,9 +2892,20 @@ WalletService.prototype.getPendingTxs = function(opts, cb) {
         }, next);
       });
     }, function(err) {
-      return cb(err, _.reject(txps, function(txp) {
+
+      txps = _.reject(txps, function(txp) {
         return txp.status == 'broadcasted';
-      }));
+      })
+
+      if (opts.noCashAddr && txps[0] && txps[0].coin == 'bch') {
+        _.each(txps, (x) => {
+          if (x.changeAddress) {
+            x.changeAddress.address= BCHAddressTranslator.translate(x.changeAddress.address,'copay');
+          }
+        });
+      }
+
+      return cb(err, txps);
     });
   });
 };

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -501,8 +501,7 @@ Storage.prototype.migrateToCashAddr = function(walletId, cb) {
 
   cursor.on("end", function() {
     console.log(`Migration to cash address of ${walletId} Finished`);
-    self.clearWalletCache(walletId,cb);
-    return cb();
+    return self.clearWalletCache(walletId,cb);
   }); 
 
   cursor.on("err", function(err) {

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -12,9 +12,9 @@ var Bitcore = require('bitcore-lib');
 var mongodb = require('mongodb');
 
 var Model = require('./model');
+
+// only for migration
 var BCHAddressTranslator = require('./bchaddresstranslator');
-
-
 
 var collections = {
   WALLETS: 'wallets',
@@ -490,6 +490,38 @@ Storage.prototype.fetchAddresses = function(walletId, cb) {
     return cb(null, result.map(Model.Address.fromObj));
   });
 };
+
+Storage.prototype.migrateToCashAddr = function(walletId, cb) {
+  var self = this;
+
+  var cursor = self.db.collection(collections.ADDRESSES).find({
+    walletId: walletId,
+  });
+
+
+  cursor.on("end", function() {
+    console.log(`Migration to cash address of ${walletId} Finished`);
+    return cb();
+  }); 
+
+  cursor.on("err", function(err) {
+    return cb(err);
+  });
+
+  cursor.on("data", function(doc) {
+      cursor.pause();
+      let x;
+      try {
+        x = BCHAddressTranslator.translate(doc.address, 'cashaddr');
+      } catch (e) {
+        return cb(e);
+      }
+
+      self.db.collection(collections.ADDRESSES).update({_id: doc._id}, {$set:{address: x}}, {multi:true});
+      cursor.resume();
+  });
+};
+
 
 Storage.prototype.fetchUnsyncAddresses = function(walletId, cb) {
   var self = this;

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -501,6 +501,7 @@ Storage.prototype.migrateToCashAddr = function(walletId, cb) {
 
   cursor.on("end", function() {
     console.log(`Migration to cash address of ${walletId} Finished`);
+    self.clearWalletCache(walletId,cb);
     return cb();
   }); 
 

--- a/packages/bitcore-wallet-service/scripts/deleteDupAddresses.mongo
+++ b/packages/bitcore-wallet-service/scripts/deleteDupAddresses.mongo
@@ -1,2 +1,6 @@
- db.addresses.aggregate([     {$group: {         _id: {address: "$address"},         dups: {$addToSet: "$_id"},         count: {$sum: 1}         }     },     {$match: {          count: {"$gt": 1}         }     } ], {allowDiskUse:true}).forEach(function(doc) {     doc.dups.shift();     doc.dups.forEach( function(dupId){          duplicates.push(dupId);          }     )     });
+ 
+duplicates=[];
 
+db.addresses.aggregate([     {$group: {         _id: {address: "$address"},         dups: {$addToSet: "$_id"},         count: {$sum: 1}         }     },     {$match: {          count: {"$gt": 1}         }     } ], {allowDiskUse:true}).forEach(function(doc) {     doc.dups.shift();     doc.dups.forEach( function(dupId){          duplicates.push(dupId);          }     )     });
+
+db.addresses.remove({_id:{$in:duplicates}});

--- a/packages/bitcore-wallet-service/test/integration/cashAddrMigration.js
+++ b/packages/bitcore-wallet-service/test/integration/cashAddrMigration.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var _ = require('lodash');
+var async = require('async');
+
+var chai = require('chai');
+var sinon = require('sinon');
+var should = chai.should();
+var log = require('npmlog');
+log.debug = log.verbose;
+log.level = 'info';
+
+var Bitcore = require('bitcore-lib');
+var Bitcore_ = {
+  btc: Bitcore,
+  bch: require('bitcore-lib-cash')
+};
+
+
+
+var Common = require('../../lib/common');
+var Utils = Common.Utils;
+var Constants = Common.Constants;
+var Defaults = Common.Defaults;
+
+var Model = require('../../lib/model');
+
+var WalletService = require('../../lib/server');
+
+var TestData = require('../testdata');
+var helpers = require('./helpers');
+var storage, blockchainExplorer, request;
+
+
+describe('Cash address migration', function() {
+  before(function(done) {
+    helpers.before(done);
+  });
+  beforeEach(function(done) {
+    helpers.beforeEach(function(res) {
+      storage = res.storage;
+      blockchainExplorer = res.blockchainExplorer;
+      helpers.setupGroupingBE(blockchainExplorer);
+      request = res.request;
+      done();
+    });
+  });
+  after(function(done) {
+    helpers.after(done);
+  });
+
+  describe('Migrate wallets', function() {
+
+    it('new BCH wallets should be  native cashAddr', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true}, function(s, w) {
+        let spy = sinon.spy(s.storage, 'migrateToCashAddr');
+        s.getWallet({}, function(err, w) {
+          let calls = spy.getCalls();
+          calls.should.be.empty();
+          helpers.stubUtxos(s, w, 1, function() {
+            s.getStatus({}, function(err, a) {
+              should.not.exist(err);
+              spy.restore();
+              done();
+            });
+          });
+        });
+      });
+    });
+
+
+    it('should create cashAddr addresses for new wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch'}, function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(main, change) {
+          helpers.stubUtxos(s, w, 1, function() {
+            s.getMainAddresses({}, function(err, a) {
+              should.not.exist(err);
+              a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+              done();
+            });
+          });
+        });
+      });
+    });
+
+
+    it('should migrate old wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true, nativeCashAddr: false}, function(s, w) {
+        let spy = sinon.spy(s.storage, 'migrateToCashAddr');
+
+        s.getWallet({}, function(err, w) {
+          let calls = spy.getCalls();
+          calls.length.should.equal(1);
+          spy.restore();
+          done();
+        });
+      });
+    });
+
+
+    it('should create cashAddr in migrated wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', nativeCashAddr: false}, function(s, w) {
+        helpers.createAddresses(s, w, 2, 2, function(main, change) {
+          s.getMainAddresses({}, function(err, a) {
+            should.not.exist(err);
+            a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+            done();
+          });
+        });
+      });
+    });
+
+
+    it('should migrate old addresses', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true, nativeCashAddr: false}, function(s, w) {
+      s.createAddress({doNotMigrate: true}, function(err, address) {
+        address.address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+        s.createAddress({doNotMigrate: true}, function(err, address) {
+          address.address.should.equal('CbkZvkoMiBzxYDTzCvPUK9Mnbhv5FyQQCZ');
+          s.createAddress({doNotMigrate: true}, function(err, address) {
+            address.address.should.equal('CY6RRcu5Zwn25467jtXzGpmyxtJrDWmVG4');
+            s.getWallet({}, function(err, w) {
+              s.getMainAddresses({}, function(err, a) {
+                a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+                a[1].address.should.equal('qrfere3rxlk3jjs7g28n952g8rjasjqcpgx3axq70t');
+                a[2].address.should.equal('qz4h98slcsjhgxdkt3yd8dxz02x8s0u4l5hs80s0q8');
+                should.not.exist(err);
+                done();
+              });
+            });
+          });
+        });
+      });
+      });
+    });
+  });
+});
+

--- a/packages/bitcore-wallet-service/test/integration/cashAddrMigration.js
+++ b/packages/bitcore-wallet-service/test/integration/cashAddrMigration.js
@@ -40,7 +40,6 @@ describe('Cash address migration', function() {
     helpers.beforeEach(function(res) {
       storage = res.storage;
       blockchainExplorer = res.blockchainExplorer;
-      helpers.setupGroupingBE(blockchainExplorer);
       request = res.request;
       done();
     });

--- a/packages/bitcore-wallet-service/test/integration/helpers.js
+++ b/packages/bitcore-wallet-service/test/integration/helpers.js
@@ -202,6 +202,7 @@ helpers.createAndJoinWallet = function(m, n, opts, cb) {
     singleAddress: !!opts.singleAddress,
     coin: opts.coin || 'btc',
     network: opts.network || 'livenet',
+    nativeCashAddr: opts.nativeCashAddr,
   };
   if (_.isBoolean(opts.supportBIP44AndP2PKH))
     walletOpts.supportBIP44AndP2PKH = opts.supportBIP44AndP2PKH;
@@ -238,6 +239,7 @@ helpers.createAndJoinWallet = function(m, n, opts, cb) {
     }, function(err) {
       if (err) return new Error('Could not generate wallet');
       helpers.getAuthServer(copayerIds[0], function(s) {
+        if (opts.earlyRet) return cb(s);
         s.getWallet({}, function(err, w) {
 
           sinon.stub(s, 'checkWalletSync').callsArgWith(2, null, true);

--- a/packages/bitcore-wallet-service/test/integration/helpers.js
+++ b/packages/bitcore-wallet-service/test/integration/helpers.js
@@ -523,10 +523,12 @@ helpers.createAddresses = function(server, wallet, main, change, cb) {
 helpers.createAndPublishTx = function(server, txOpts, signingKey, cb) {
 
   server.createTx(txOpts, function(err, txp) {
+    if (err) console.log(err);
     should.not.exist(err, "Error creating a TX");
     should.exist(txp,"Error... no txp");
     var publishOpts = helpers.getProposalSignatureOpts(txp, signingKey);
     server.publishTx(publishOpts, function(err) {
+      if (err) console.log(err);
       should.not.exist(err);
       return cb(txp);
     });

--- a/packages/bitcore-wallet-service/test/integration/historyV8.js
+++ b/packages/bitcore-wallet-service/test/integration/historyV8.js
@@ -16,8 +16,6 @@ var Bitcore_ = {
   bch: require('bitcore-lib-cash')
 };
 
-
-
 var Common = require('../../lib/common');
 var Utils = Common.Utils;
 var Constants = Common.Constants;

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -2500,27 +2500,36 @@ describe('Wallet service', function() {
     });
   });
 
-  var addrMap = {
-    btc: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
-    bch: 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X',
-  }
+  let testSet = [
+    {
+      coin: 'btc',
+      key: 'id44btc',
+      addr: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+      flags: {},
+    }, 
+    {
+      coin: 'bch',
+      key: 'id44bch',
+      addr: 'qpgjyj728rhu4gca2dqfzlpl8acnhzequshhgvev53',
+      flags: {},
+    }, 
+    {
+      coin: 'bch',
+      key: 'id44bch',
+      addr: 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X',
+      flags: { noCashAddr: true },
+    }, 
+ 
+  ];
 
-  var idKeyMap = {
-      btc: 'id44btc',
-      bch: 'id44bch',
-  };
+  _.each(testSet, function(x) {
 
-  _.each(['bch', 'btc'], function(coin) {
+    let coin = x.coin;
+    let idKey = x.key;
+    let addressStr = x.addr;
+    let flags = x.flags;
   
-    describe('#createTx ' + coin, function() {
-      var addressStr, idKey;
-      before(function() {
-        addressStr = addrMap[coin];
-        idKey = idKeyMap[coin];
-      });
-
-
-
+    describe('#createTx ' + coin + ' flags' + JSON.stringify(flags), function() {
       describe('Tx proposal creation & publishing ' + coin, function() {
         var server, wallet;
         beforeEach(function(done) {
@@ -2546,6 +2555,7 @@ describe('Wallet service', function() {
               customData: 'some custom data',
               feePerKb: 123e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -2581,6 +2591,7 @@ describe('Wallet service', function() {
                 outputs: [],
                 feePerKb: 123e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 should.not.exist(tx);
@@ -2589,6 +2600,7 @@ describe('Wallet service', function() {
               });
             });
           });
+    
           it('should fail to create tx for invalid address', function(done) {
             helpers.stubUtxos(server, wallet, 1, function() {
               var txOpts = {
@@ -2598,6 +2610,7 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 should.not.exist(tx);
@@ -2615,6 +2628,7 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(tx);
                 should.exist(err);
@@ -2632,6 +2646,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(tx);
               should.exist(err);
@@ -2649,6 +2664,7 @@ describe('Wallet service', function() {
                 feeLevel: 'normal',
                 feePerKb: 123e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.exist(err);
                 should.not.exist(txp);
@@ -2670,6 +2686,7 @@ describe('Wallet service', function() {
                   feePerKb: 100e2,
                   inputs: inputs,
                 };
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
@@ -2692,6 +2709,7 @@ describe('Wallet service', function() {
                 feePerKb: 100e2,
                 changeAddress: utxos[0].address,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2713,8 +2731,9 @@ describe('Wallet service', function() {
                   amount: 0.8e8,
                 }],
                 feePerKb: 100e2,
-                changeAddress: addr.toString(),
+                changeAddress: addr.toString(true),
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 err.code.should.equal('INVALID_CHANGE_ADDRESS');
@@ -2733,6 +2752,7 @@ describe('Wallet service', function() {
                 inputs: utxos,
                 fee: 1000e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2759,6 +2779,7 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2777,10 +2798,12 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
                 tx.id.should.equal('123');
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
@@ -2805,6 +2828,7 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2813,6 +2837,7 @@ describe('Wallet service', function() {
                 server.publishTx(publishOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
+              txOpts = Object.assign(txOpts, flags);
                   server.createTx(txOpts, function(err, tx) {
                     should.not.exist(err);
                     should.exist(tx);
@@ -2842,6 +2867,7 @@ describe('Wallet service', function() {
                 message: 'some message',
                 customData: 'some custom data',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2868,6 +2894,7 @@ describe('Wallet service', function() {
                 feePerKb: 100e2,
                 dryRun: true,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2894,6 +2921,7 @@ describe('Wallet service', function() {
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2944,6 +2972,7 @@ describe('Wallet service', function() {
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2968,6 +2997,7 @@ describe('Wallet service', function() {
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3004,10 +3034,12 @@ describe('Wallet service', function() {
                 });
               },
               function(next) {
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
                 txp1 = txp;
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
@@ -3034,6 +3066,7 @@ describe('Wallet service', function() {
               },
               function(next) {
                 // A new tx proposal should use the next available UTXO
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp3, next) {
@@ -3072,10 +3105,12 @@ describe('Wallet service', function() {
                 });
               },
               function(next) {
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
                 txp1 = txp;
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
@@ -3140,6 +3175,7 @@ describe('Wallet service', function() {
                 // ToDo
                 feeLevel: level,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3158,6 +3194,7 @@ describe('Wallet service', function() {
                 }],
                 feeLevel: 'madeUpLevel',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.exist(err);
                 should.not.exist(txp);
@@ -3180,6 +3217,7 @@ describe('Wallet service', function() {
                   amount: 1e8,
                 }],
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3199,9 +3237,11 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx1) {
               should.not.exist(err);
               should.exist(tx1);
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx2) {
                 should.not.exist(err);
                 should.exist(tx2);
@@ -3221,6 +3261,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
@@ -3242,6 +3283,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.toString().should.equal('dummy error');
@@ -3263,6 +3305,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.message.should.equal('dummy exception');
@@ -3282,6 +3325,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_MAX_SIZE_EXCEEDED');
@@ -3299,12 +3343,14 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.getBalance({}, function(err, balance) {
                 should.not.exist(err);
                 balance.totalAmount.should.equal(2e8);
                 balance.lockedAmount.should.equal(2e8);
                 txOpts.outputs[0].amount = 0.8e8;
+                txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.exist(err);
                   err.code.should.equal('LOCKED_FUNDS');
@@ -3324,6 +3370,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('DUST_AMOUNT');
@@ -3344,6 +3391,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3363,9 +3411,11 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txOpts.outputs[0].amount = 0.8e8;
+              txOpts = Object.assign(txOpts, flags);
               helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
                 should.exist(tx);
                 server.getPendingTxs({}, function(err, txs) {
@@ -3391,9 +3441,11 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txOpts.outputs[0].amount = 1.8e8;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 err.code.should.equal('LOCKED_FUNDS');
                 should.not.exist(tx);
@@ -3438,6 +3490,7 @@ describe('Wallet service', function() {
                 message: 'some message',
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3473,6 +3526,7 @@ describe('Wallet service', function() {
               feePerKb: 10000,
               sendMax: true,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3499,6 +3553,7 @@ describe('Wallet service', function() {
               }),
               feePerKb: 123e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
@@ -3508,6 +3563,7 @@ describe('Wallet service', function() {
 
               outputs.should.not.deep.equal(_.map(txOpts.outputs, 'amount'));
               txOpts.noShuffleOutputs = true;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3557,6 +3613,7 @@ describe('Wallet service', function() {
 
           function(next) {
             async.each(_.range(3), function(i, next) {
+                txOpts = Object.assign(txOpts, flags);
                 helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
                   server.rejectTx({
                     txProposalId: tx.id,
@@ -3568,6 +3625,7 @@ describe('Wallet service', function() {
           },
           function(next) {
             // Allow a 4th tx
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3577,6 +3635,7 @@ describe('Wallet service', function() {
           },
           function(next) {
             // Do not allow before backoff time
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_CANNOT_CREATE');
@@ -3585,6 +3644,7 @@ describe('Wallet service', function() {
           },
           function(next) {
             clock.tick((Defaults.BACKOFF_TIME + 1) * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3595,6 +3655,7 @@ describe('Wallet service', function() {
           function(next) {
             // Do not allow a 5th tx before backoff time
             clock.tick((Defaults.BACKOFF_TIME - 1) * 1000);
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_CANNOT_CREATE');
@@ -3603,6 +3664,7 @@ describe('Wallet service', function() {
           },
           function(next) {
             clock.tick(2000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3641,11 +3703,13 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             excludeUnconfirmedUtxos: true,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, tx) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS');
             err.message.should.equal('Insufficient funds');
             txOpts.outputs[0].amount = 2.5e8;
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('INSUFFICIENT_FUNDS_FOR_FEE');
@@ -3665,6 +3729,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             excludeUnconfirmedUtxos: true,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
             should.exist(tx);
             tx.inputs.length.should.equal(2);
@@ -3673,6 +3738,7 @@ describe('Wallet service', function() {
               balance.lockedConfirmedAmount.should.equal(helpers.toSatoshi(2.5));
               balance.availableConfirmedAmount.should.equal(0);
               txOpts.outputs[0].amount = 0.01e8;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 err.code.should.equal('LOCKED_FUNDS');
@@ -3692,11 +3758,13 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             utxosToExclude: [utxos[2].txid + ':' + utxos[2].vout],
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, tx) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS');
             err.message.should.equal('Insufficient funds');
             txOpts.utxosToExclude = [utxos[0].txid + ':' + utxos[0].vout];
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3714,6 +3782,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3734,6 +3803,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3756,6 +3826,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3775,6 +3846,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3795,6 +3867,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3817,6 +3890,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 1200e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3838,6 +3912,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 20e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3857,6 +3932,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3880,6 +3956,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 120e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3900,11 +3977,13 @@ describe('Wallet service', function() {
             }],
             feePerKb: 80e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
             txp.inputs.length.should.equal(3);
             txOpts.feePerKb = 160e2;
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.exist(err);
               should.not.exist(txp);
@@ -3922,6 +4001,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             should.not.exist(txp);
@@ -3939,6 +4019,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             should.not.exist(txp);
@@ -3958,6 +4039,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3977,6 +4059,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3997,6 +4080,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 90e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4016,6 +4100,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4033,6 +4118,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             txp.inputs.length.should.equal(1);
@@ -4054,6 +4140,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 80e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS_FOR_FEE');
@@ -4070,6 +4157,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4086,6 +4174,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
@@ -4103,6 +4192,7 @@ describe('Wallet service', function() {
                 should.not.exist(err);
                 should.exist(txp.txid);
                 txp.status.should.equal('broadcasted');
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, txp) {
                   should.exist(err);
                   err.code.should.equal('INSUFFICIENT_FUNDS');
@@ -4117,53 +4207,172 @@ describe('Wallet service', function() {
     });
   });
 
-  it('should create a BCH tx proposal with cashaddr outputs (w/o prefix) and return Copay addr', function(done) {
+  describe("cashAddr backwards compat", (x) => {
+    /// LEGACY MODE
+    it('should create a BCH tx proposal with cashaddr outputs (w/o prefix) and return Copay addr', function(done) {
 
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: cashAddr,
-            amount: amount,
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: cashAddr,
-            amount: amount,
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
-                amount: amount,
-              }]);
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr:true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: cashAddr,
+              amount: amount,
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  amount: amount,
+                }]);
 
-              done();
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('should create a BCH tx proposal with cashaddr outputs (w/ prefix) and return Copay addr', function(done) {
+
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: 'bitcoincash:'+cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr: true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: 'bitcoincash:'+cashAddr,
+              amount: amount,
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+            
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  amount: amount,
+                }]);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('should create a BCH tx proposal with cashaddr and keep message', function(done) {
+
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: cashAddr,
+              amount: amount,
+              message: 'xxx',
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr: true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: cashAddr,
+              amount: amount,
+              message: 'xxx',
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  message: 'xxx',
+                  amount: amount,
+                }]);
+
+                done();
+              });
             });
           });
         });
@@ -4171,110 +4380,107 @@ describe('Wallet service', function() {
     });
   });
 
-  it('should create a BCH tx proposal with cashaddr outputs (w/ prefix) and return Copay addr', function(done) {
+  describe("cashAddr edge cases (v3 api)", (x) => {
+    it('should fail to create BCH tx proposal with cashaddr w/prefix', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: 'bitcoincash:'+ cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            err.message.should.contain('cashaddr wo prefix');
+            done();
+          });
+        });
+      });
+    });
+    it('should fail to create BCH tx proposal with  legacy addr  ', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: copayAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            err.message.should.contain('cashaddr wo prefix');
+            done();
+          });
+        });
+      });
+    });
 
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: 'bitcoincash:'+cashAddr,
-            amount: amount,
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: 'bitcoincash:'+cashAddr,
-            amount: amount,
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
+    it('should allow cashaddr on change address', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(mainAddresses, changeAddress) {
+          helpers.stubUtxos(s, w, [1, 2], function() {
+            var txOpts = {
+              outputs: [{
+                toAddress: cashAddr,
                 amount: amount,
-              }]);
-
+              }],
+              message: 'some message',
+              customData: 'some custom data',
+              feePerKb: 123e2,
+              changeAddress: changeAddress[0].address,
+            };
+            s.createTx(txOpts, function(err, tx) {
+              should.not.exist(err);
+              tx.changeAddress.address.should.equal(changeAddress[0].address);
+              tx.changeAddress.address.should.equal('qz0d6gueltx0feta7z9777yk97sz9p6peu98mg5vac');
               done();
             });
           });
         });
       });
     });
-  });
 
-  it('should create a BCH tx proposal with cashaddr and keep message', function(done) {
-
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: cashAddr,
-            amount: amount,
-            message: 'xxx',
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: cashAddr,
-            amount: amount,
-            message: 'xxx',
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
-                message: 'xxx',
+    it('should not allow cashaddr w prefix on change address', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(mainAddresses, changeAddress) {
+          helpers.stubUtxos(s, w, [1, 2], function() {
+            var txOpts = {
+              outputs: [{
+                toAddress: cashAddr,
                 amount: amount,
-              }]);
-
+              }],
+              message: 'some message',
+              customData: 'some custom data',
+              feePerKb: 123e2,
+              changeAddress: 'bitcoincash:' + changeAddress[0].address,
+            };
+            s.createTx(txOpts, function(err, tx) {
+              err.message.should.contain('wo prefix');
               done();
             });
           });
@@ -4992,6 +5198,7 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
             should.exist(tx);
             txid = tx.id;
@@ -5087,6 +5294,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               tx.addressType.should.equal('P2PKH');
@@ -5141,6 +5349,7 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txid = tx.id;
@@ -5353,6 +5562,7 @@ describe('Wallet service', function() {
             message: 'some message',
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
@@ -5443,6 +5653,7 @@ describe('Wallet service', function() {
         }],
         feePerKb: 100e2,
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         server.getPendingTxs({}, function(err, txs) {
           should.not.exist(err);
@@ -5469,6 +5680,7 @@ describe('Wallet service', function() {
         }],
         feePerKb: 100e2,
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         server.broadcastTx({
@@ -5564,6 +5776,7 @@ describe('Wallet service', function() {
         feePerKb: 100e2,
         message: 'some message',
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         helpers.getAuthServer(wallet.copayers[1].id, function(server2, wallet) {
@@ -5590,6 +5803,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5683,6 +5897,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5771,6 +5986,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             txpid = txp.id;
@@ -5837,6 +6053,7 @@ describe('Wallet service', function() {
           };
           async.eachSeries(_.range(10), function(i, next) {
             clock.tick(10 * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
 
               next();
@@ -5925,6 +6142,7 @@ describe('Wallet service', function() {
           };
           async.eachSeries(_.range(3), function(i, next) {
             clock.tick(25 * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
               next();
             });
@@ -6194,6 +6412,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
+            txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function() {
             server.getPendingTxs({}, function(err, txs) {
               txp = txs[0];
@@ -6378,7 +6597,6 @@ describe('Wallet service', function() {
       });
     });
   });
-
 
   describe('#scan', function() {
     var server, wallet;
@@ -7175,6 +7393,7 @@ describe('Wallet service', function() {
           feePerKb: 100e2,
           message: 'some message',
         };
+        txOpts = Object.assign(txOpts, flags);
         helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
           should.exist(txp);
           var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -1364,7 +1364,7 @@ describe('Wallet service', function() {
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('livenet');
-          address.address.should.equal('HBf8isgS8EXG1r3X6GP89FmooUmiJ42wHS');
+          address.address.should.equal('pqu9c0xe7g0ngz9hzpky64nva9790m64esxxjmcv2k');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2SH');
@@ -1433,7 +1433,7 @@ describe('Wallet service', function() {
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('livenet');
-          address.address.should.equal('HBf8isgS8EXG1r3X6GP89FmooUmiJ42wHS');
+          address.address.should.equal('pqu9c0xe7g0ngz9hzpky64nva9790m64esxxjmcv2k');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2SH');
@@ -1504,7 +1504,7 @@ describe('Wallet service', function() {
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('testnet');
-          address.address.should.equal('mrM5kMkqZccK5MxZYSsM3SjqdMaNKLJgrJ');
+          address.address.should.equal('qpmvku3x8j9pz7mee89c590xsl3k5l02mqeyfhf3ce');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2PKH');
@@ -2167,7 +2167,7 @@ describe('Wallet service', function() {
         server.getBalance({
           coin: 'bch'
         }, function(err, balance) {
-          err.message.should.contain('no longer supported');
+          err.message.should.contain('not longer supported');
           done();
         });
       });
@@ -2697,11 +2697,7 @@ describe('Wallet service', function() {
                 should.exist(tx);
                 var t = tx.getBitcoreTx();
 
-                if (coin == 'bch') { 
-                  t.getChangeOutput().script.toAddress().toLegacyAddress().should.equal(txOpts.changeAddress);
-                } else {
-                  t.getChangeOutput().script.toAddress().toString().should.equal(txOpts.changeAddress);
-                }
+                t.getChangeOutput().script.toAddress().toString(true).should.equal(txOpts.changeAddress);
                 done();
               });
             });
@@ -7307,7 +7303,7 @@ describe('Wallet service', function() {
           address.walletId.should.equal(wallet.bch.id);
           address.coin.should.equal('bch');
           address.network.should.equal('livenet');
-          address.address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+          address.address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
           server.btc.getMainAddresses({}, function(err, addresses) {
             should.not.exist(err);
             addresses.length.should.equal(1);
@@ -7319,7 +7315,7 @@ describe('Wallet service', function() {
               addresses.length.should.equal(1);
               addresses[0].coin.should.equal('bch');
               addresses[0].walletId.should.equal(wallet.bch.id);
-              addresses[0].address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+              addresses[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
               done();
             });
           });

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -5198,7 +5198,6 @@ describe('Wallet service', function() {
             }],
             feePerKb: 100e2,
           };
-          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
             should.exist(tx);
             txid = tx.id;
@@ -5294,7 +5293,6 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
-            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               tx.addressType.should.equal('P2PKH');
@@ -5349,7 +5347,6 @@ describe('Wallet service', function() {
               }],
               feePerKb: 100e2,
             };
-            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txid = tx.id;
@@ -5562,7 +5559,6 @@ describe('Wallet service', function() {
             message: 'some message',
             feePerKb: 100e2,
           };
-          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
@@ -5653,7 +5649,6 @@ describe('Wallet service', function() {
         }],
         feePerKb: 100e2,
       };
-      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         server.getPendingTxs({}, function(err, txs) {
           should.not.exist(err);
@@ -5680,7 +5675,6 @@ describe('Wallet service', function() {
         }],
         feePerKb: 100e2,
       };
-      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         server.broadcastTx({
@@ -5776,7 +5770,6 @@ describe('Wallet service', function() {
         feePerKb: 100e2,
         message: 'some message',
       };
-      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         helpers.getAuthServer(wallet.copayers[1].id, function(server2, wallet) {
@@ -5803,7 +5796,6 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5897,7 +5889,6 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5986,7 +5977,6 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             txpid = txp.id;
@@ -6053,7 +6043,6 @@ describe('Wallet service', function() {
           };
           async.eachSeries(_.range(10), function(i, next) {
             clock.tick(10 * 1000);
-            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
 
               next();
@@ -6142,7 +6131,6 @@ describe('Wallet service', function() {
           };
           async.eachSeries(_.range(3), function(i, next) {
             clock.tick(25 * 1000);
-            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
               next();
             });
@@ -6412,7 +6400,6 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-            txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function() {
             server.getPendingTxs({}, function(err, txs) {
               txp = txs[0];
@@ -7393,7 +7380,6 @@ describe('Wallet service', function() {
           feePerKb: 100e2,
           message: 'some message',
         };
-        txOpts = Object.assign(txOpts, flags);
         helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
           should.exist(txp);
           var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);

--- a/packages/bitcore-wallet-service/test/v8.js
+++ b/packages/bitcore-wallet-service/test/v8.js
@@ -158,7 +158,7 @@ describe('V8', () => {
         should.exist(utxos);
         let x = utxos[2];
         x.confirmations.should.equal(0);
-        x.address.should.equal('n4J9viXAWZQi3n1eYVuvMXPEmJ7Ckrw7jw');
+        x.address.should.equal('qrua7vsdmks4522wwv8rtamfph7g8s8vpq6a0g3veh');
         x.satoshis.should.equal(2000000);
         x.amount.should.equal(x.satoshis/1e8);
         x.scriptPubKey.should.equal('76a914f9df320ddda15a294e730e35f7690dfc83c0ec0888ac');


### PR DESCRIPTION
use cashAddr internally for BCH wallets
create new endpoints for updated api (createTx / getPendingTxs / getHistory)
update BWC tests