### PR TITLE
feat(api): Adds check wallet endpoint

### DIFF
--- a/packages/bitcore-client/bin/wallet-check
+++ b/packages/bitcore-client/bin/wallet-check
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const program = require('../ts_build/program');
+const { Wallet } = require('../ts_build/wallet');
+
+program
+  .version(require('../package.json').version)
+  .option('--name <name>', 'REQUIRED - Wallet name')
+  .option('--path [path]', 'optional - Custom wallet storage path')
+  .parse(process.argv);
+
+const main = async () => {
+  const { name, path } = program;
+  try {
+    const wallet = await Wallet.loadWallet({ name, path });
+    const registered = await wallet.checkWallet();
+    // TODO compare with local addresses
+    console.log(registered);
+  } catch (e) {
+    console.error(e);
+  }
+};
+
+main();

--- a/packages/bitcore-client/src/client.ts
+++ b/packages/bitcore-client/src/client.ts
@@ -141,4 +141,14 @@ export class Client {
     const url = `${this.baseUrl}/tx/send`;
     return request.post(url, { body: payload, json: true });
   }
+
+  async checkWallet(params) {
+    const { pubKey } = params;
+    const url = `${this.baseUrl}/wallet/${pubKey}/check`;
+    const signature = this.sign({ method: 'GET', url });
+    return request.get(url, {
+      headers: { 'x-signature': signature },
+      json: true
+    });
+  }
 }

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -297,4 +297,10 @@ export class Wallet {
     let keys = await Promise.all(keyPromises);
     return TxProvider.sign({ ...payload, keys });
   }
+
+  async checkWallet() {
+    return this.client.checkWallet({
+      pubKey: this.authPubKey
+    });
+  }
 }

--- a/packages/bitcore-node/src/providers/chain-state/index.ts
+++ b/packages/bitcore-node/src/providers/chain-state/index.ts
@@ -72,6 +72,10 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return this.get(params).streamWalletAddresses(params);
   }
 
+  walletCheck(params: CSP.WalletCheckParams) {
+    return this.get(params).walletCheck(params);
+  }
+
   async updateWallet(params: CSP.UpdateWalletParams) {
     return this.get(params).updateWallet(params);
   }

--- a/packages/bitcore-node/src/routes/api/wallet.ts
+++ b/packages/bitcore-node/src/routes/api/wallet.ts
@@ -133,6 +133,21 @@ router.get('/:pubKey/addresses', authenticate, async (req: AuthenticatedRequest,
   }
 });
 
+router.get('/:pubKey/check', authenticate, async (req: AuthenticatedRequest, res) => {
+  const { chain, network } = req.params;
+  const wallet = req.wallet!._id!;
+  try {
+    const result = await ChainStateProvider.walletCheck({
+      chain,
+      network,
+      wallet
+    });
+    return res.send(result);
+  } catch (err) {
+    return res.status(500).json(err);
+  }
+});
+
 // update wallet
 router.post('/:pubKey', authenticate, async (req: AuthenticatedRequest, res) => {
   let { chain, network } = req.params;

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -86,6 +86,10 @@ export declare namespace CSP {
     limit: number;
   };
 
+  export type WalletCheckParams = ChainNetwork & {
+    wallet: ObjectId;
+  };
+
   export type StreamWalletMissingAddressesParams = ChainNetwork & {
     pubKey: string;
     req: Request;
@@ -127,6 +131,7 @@ export declare namespace CSP {
     getDailyTransactions(params: { chain: string; network: string }): Promise<DailyTransactionsJSON>;
     getTransaction(params: StreamTransactionParams): Promise<TransactionJSON | string | undefined>;
     streamWalletAddresses(params: StreamWalletAddressesParams): any;
+    walletCheck(params: WalletCheckParams): any;
     streamWalletTransactions(params: StreamWalletTransactionsParams): any;
     streamWalletUtxos(params: StreamWalletUtxosParams): any;
     streamMissingWalletAddresses(params: StreamWalletMissingAddressesParams);


### PR DESCRIPTION
Provides last imported address and hash of all wallet addresses

example response:
```
{ lastAddress: 'mxHr228NH6mLVGz5PMXBrqDX8mvVXGdQ7C',
  hash: '5e40213ef562528958cdfda88859b8020ccbcdeb65b327f4d122eeaae606a981' }
```