### PR TITLE
Ref/locker expire

### DIFF
--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -1427,9 +1427,10 @@ Storage.prototype.walletCheck = async function(params) {
 }
 
 
-Storage.prototype.acquireLock = function(key, cb) {
+Storage.prototype.acquireLock = function(key, expireTs, cb) {
   this.db.collection(collections.LOCKS).insert({
     _id: key,
+    expireOn: expireTs,
   },{}, cb);
 };
 
@@ -1439,6 +1440,23 @@ Storage.prototype.releaseLock = function(key, cb) {
     _id: key,
   }, {} , cb);
 };
+
+Storage.prototype.clearExpiredLock = function(key, cb) {
+  var self = this;
+
+  this.db.collection(collections.LOCKS).findOne({
+    _id: key,
+  }, (err, ret) => {
+    if (err || !ret) return;
+
+    if (ret.expireOn < Date.now()) {
+      return self.releaseLock(key, cb);
+    }
+    return cb();
+
+  });
+};
+
 
 
 Storage.collections = collections;

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -1450,6 +1450,7 @@ Storage.prototype.clearExpiredLock = function(key, cb) {
     if (err || !ret) return;
 
     if (ret.expireOn < Date.now()) {
+      log.info("Releasing expired lock : " + key);
       return self.releaseLock(key, cb);
     }
     return cb();

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -134,7 +134,6 @@ Storage.prototype.connect = function(opts, cb) {
     }
     self.db = db;
     self._createIndexes();
-    self.clearLocks();
     console.log('Connection established to mongoDB');
     return cb();
   });
@@ -1440,12 +1439,6 @@ Storage.prototype.releaseLock = function(key, cb) {
     _id: key,
   }, {} , cb);
 };
-
-Storage.prototype.clearLocks = function() {
-  this.db.collection(collections.LOCKS).remove({
-  }, {multi:1} );
-};
-
 
 
 Storage.collections = collections;

--- a/packages/bitcore-wallet-service/test/lock.js
+++ b/packages/bitcore-wallet-service/test/lock.js
@@ -148,8 +148,8 @@ describe('Locks', function() {
         release();
         err.should.contain('LOCKED');
         done();
-      },2);
-    }, 1);
+      });
+    });
   });
   it('should release lock if acquired for a long time', function(done) {
 
@@ -158,8 +158,8 @@ describe('Locks', function() {
       lock.acquire('123', {waitTime:1000}, function(err, release) {
         should.not.exist(err);
         done();
-      },2);
-    }, 1);
+      });
+    });
   });
 
 

--- a/packages/bitcore-wallet-service/test/lock.js
+++ b/packages/bitcore-wallet-service/test/lock.js
@@ -161,6 +161,28 @@ describe('Locks', function() {
       });
     });
   });
+  it('should release lock if acquired for a long time (case 2)', function(done) {
+
+    // no releases
+    lock.acquire('123', {lockTime:10}, function(err, release) {
+      should.not.exist(err);
+    });
+
+    lock.acquire('123', {lockTime:20}, function(err, release) {
+      should.not.exist(err);
+    });
+    lock.acquire('123', {lockTime:30}, function(err, release) {
+      should.not.exist(err);
+      lock.acquire('123', {lockTime:30}, function(err, release) {
+        should.not.exist(err);
+        lock.acquire('123', {waitTime:1000}, function(err, release) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+  });
+
 
 
   describe("#runLocked", () => {


### PR DESCRIPTION
- handles better lock expiration by storing the expire time and checking in when the lock is taken. so if a thread holding the lock died, the lock still expires at the designated time.