### PR TITLE
Bug fix: Wallet utxos stream was not being returned

### DIFF
--- a/packages/bitcore-client/src/client.ts
+++ b/packages/bitcore-client/src/client.ts
@@ -66,8 +66,7 @@ export class Client {
       this.baseUrl
     }/wallet/${pubKey}/utxos?includeSpent=${includeSpent}`;
     const signature = this.sign({ method: 'GET', url, payload });
-    return requestStream({
-      uri: url,
+    return requestStream(url, {
       headers: { 'x-signature': signature },
       body: payload,
       json: true

--- a/packages/bitcore-client/src/client.ts
+++ b/packages/bitcore-client/src/client.ts
@@ -66,7 +66,8 @@ export class Client {
       this.baseUrl
     }/wallet/${pubKey}/utxos?includeSpent=${includeSpent}`;
     const signature = this.sign({ method: 'GET', url, payload });
-    return requestStream.get(url, {
+    return requestStream({
+      uri: url,
       headers: { 'x-signature': signature },
       body: payload,
       json: true

--- a/packages/bitcore-client/src/client.ts
+++ b/packages/bitcore-client/src/client.ts
@@ -66,7 +66,7 @@ export class Client {
       this.baseUrl
     }/wallet/${pubKey}/utxos?includeSpent=${includeSpent}`;
     const signature = this.sign({ method: 'GET', url, payload });
-    return requestStream(url, {
+    return requestStream.get(url, {
       headers: { 'x-signature': signature },
       body: payload,
       json: true

--- a/packages/bitcore-client/src/providers/tx-provider/bch/index.ts
+++ b/packages/bitcore-client/src/providers/tx-provider/bch/index.ts
@@ -1,4 +1,4 @@
-export class BCHTxProvder {
+export class BCHTxProvider {
   lib = require('bitcore-lib-cash');
   create({ recipients, utxos, change, fee }) {
     let tx = new this.lib.Transaction().from(utxos).fee(Number(fee));
@@ -11,4 +11,3 @@ export class BCHTxProvder {
     return tx;
   }
 }
-export default new BCHTxProvder();

--- a/packages/bitcore-client/src/providers/tx-provider/btc/index.ts
+++ b/packages/bitcore-client/src/providers/tx-provider/btc/index.ts
@@ -1,4 +1,4 @@
-export class BTCTxProvder {
+export class BTCTxProvider {
   lib = require('bitcore-lib');
 
   create({ recipients, utxos, change, fee }) {
@@ -48,4 +48,3 @@ export class BTCTxProvder {
     return applicableUtxos.map(utxo => utxo.address);
   }
 }
-export default new BTCTxProvder();

--- a/packages/bitcore-client/src/providers/tx-provider/index.ts
+++ b/packages/bitcore-client/src/providers/tx-provider/index.ts
@@ -1,6 +1,8 @@
+import { BTCTxProvider } from './btc'
+import { BCHTxProvider } from './bch';
 const providers = {
-  BTC: require('./btc'),
-  BCH: require('./bch')
+  BTC: new BTCTxProvider(),
+  BCH: new BCHTxProvider()
 };
 
 export class TxProvider {

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -101,7 +101,7 @@ export class Wallet {
     let alreadyExists;
     try {
       alreadyExists = await this.loadWallet({ storage, name, chain, network });
-    } catch (err) {}
+    } catch (err) { }
     if (alreadyExists) {
       throw new Error('Wallet already exists');
     }
@@ -141,7 +141,7 @@ export class Wallet {
         chain,
         network
       });
-    } catch (err) {}
+    } catch (err) { }
     return alreadyExists != undefined;
   }
 
@@ -218,7 +218,7 @@ export class Wallet {
     return this.client.getFee({ target });
   }
 
-  getUtxos(params: {includeSpent?: boolean} = {}) {
+  getUtxos(params: { includeSpent?: boolean } = {}) {
     const { includeSpent = false } = params;
     return this.client.getCoins({
       pubKey: this.authPubKey,
@@ -276,7 +276,15 @@ export class Wallet {
 
   async signTx(params) {
     let { tx } = params;
-    const utxos = params.utxos || (await this.getUtxos(params));
+    const utxos = params.utxos || [];
+    if (!params.utxos) {
+      this.getUtxos(params).on('data', (data) => {
+        const stringData = data.toString().replace(',\n', '');
+        if (stringData.includes('{') && stringData.includes('}')) {
+          utxos.push(JSON.parse(stringData));
+        }
+      })
+    }
     const payload = {
       chain: this.chain,
       network: this.network,


### PR DESCRIPTION
How to replicate:

Inside bitcore-client/bin/

Run

./wallet-sign --name {walletName} --tx {signedTxHere}

Error Message:

TypeError: this.get(...).getSigningAddresses is not a function