### PR TITLE
Tests(Node) Added services allow creation before complete sync in bitcore-test.co…

### DIFF
--- a/bitcore-test.config.json
+++ b/bitcore-test.config.json
@@ -1,5 +1,12 @@
 {
   "bitcoreNode": {
+    "services": {
+      "api": {
+        "wallets": {
+          "allowCreationBeforeCompleteSync": true
+        }
+      }
+    },
     "chains": {
       "BTC": {
         "regtest": {

--- a/packages/bitcore-node/src/services/api.ts
+++ b/packages/bitcore-node/src/services/api.ts
@@ -15,6 +15,7 @@ export class ApiService {
   storageService: StorageService;
   socketService: SocketService;
   httpServer: http.Server;
+  stopped = true;
 
   constructor({
     port = 3000,
@@ -39,15 +40,19 @@ export class ApiService {
     if (!this.storageService.connected) {
       await this.storageService.start({});
     }
-    this.httpServer.timeout = this.timeout;
-    this.httpServer.listen(this.port, () => {
-      logger.info(`Starting API Service on port ${this.port}`);
-      this.socketService.start({ server: this.httpServer });
-    });
+    if (this.stopped) {
+      this.stopped = false;
+      this.httpServer.timeout = this.timeout;
+      this.httpServer.listen(this.port, () => {
+        logger.info(`Starting API Service on port ${this.port}`);
+        this.socketService.start({ server: this.httpServer });
+      });
+    }
     return this.httpServer;
   }
 
   stop() {
+    this.stopped = true;
     return new Promise(resolve => {
       this.httpServer.close(resolve);
     });

--- a/packages/bitcore-node/src/services/socket.ts
+++ b/packages/bitcore-node/src/services/socket.ts
@@ -25,6 +25,7 @@ export class SocketService {
   serviceConfig: ConfigType['services']['socket'];
   eventService: EventService;
   eventModel: EventModel;
+  stopped = true;
 
   constructor({ eventService = Event, eventModel = EventStorage, configService = Config } = {}) {
     this.eventService = eventService;
@@ -43,19 +44,23 @@ export class SocketService {
       logger.info('Disabled Socket Service');
       return;
     }
-    logger.info('Starting Socket Service');
-    this.httpServer = server;
-    this.io = SocketIO(server);
-    this.io.sockets.on('connection', socket => {
-      socket.on('room', room => {
-        socket.join(room);
+    if (this.stopped) {
+      this.stopped = false;
+      logger.info('Starting Socket Service');
+      this.httpServer = server;
+      this.io = SocketIO(server);
+      this.io.sockets.on('connection', socket => {
+        socket.on('room', room => {
+          socket.join(room);
+        });
       });
-    });
+    }
     this.wireup();
   }
 
   stop() {
     logger.info('Stopping Socket Service');
+    this.stopped = true;
     return new Promise(resolve => {
       if (this.io) {
         this.io.close(resolve);

--- a/packages/bitcore-node/test/integration/models/wallet.integration.ts
+++ b/packages/bitcore-node/test/integration/models/wallet.integration.ts
@@ -1,7 +1,56 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
+import { Wallet } from 'bitcore-client';
+import { Api } from '../../../src/services/api';
+import { Event } from '../../../src/services/event';
+import { WalletStorage } from '../../../src/models/wallet';
 
-describe('Wallet Model', function(){
-    it('should have a test which runs', function(){
-        expect(true).to.equal(true);
+describe('Wallet Model', () => {
+  describe('Wallet Create', () => {
+    it('should return a locked wallet on create', async () => {
+      const walletName = 'Test Wallet';
+      const password = 'iamsatoshi';
+      const chain = 'BTC';
+      const network = 'regtest';
+      const baseUrl = 'http://localhost:3000/api';
+      let lockedWallet: Wallet;
+      await Event.start();
+      await Api.start();
+
+      lockedWallet = await Wallet.create({
+        name: walletName,
+        chain,
+        network,
+        baseUrl,
+        password
+      });
+
+      expect(lockedWallet).to.have.includes({
+        name: 'Test Wallet',
+        chain: 'BTC',
+        network: 'regtest',
+        baseUrl: 'http://localhost:3000/api/BTC/regtest'
+      });
+      expect(lockedWallet).to.have.property('pubKey');
+      expect(lockedWallet).to.have.property('password');
+      expect(lockedWallet).to.have.property('authKey');
+      expect(lockedWallet).to.have.property('encryptionKey');
+
+      let result = await WalletStorage.collection.findOne({
+        name: 'Test Wallet',
+        chain: 'BTC',
+        network: 'regtest'
+      });
+
+      expect(result).to.includes({
+        name: 'Test Wallet',
+        chain: 'BTC',
+        network: 'regtest',
+        path: null,
+        singleAddress: null
+      });
+      expect(result).to.have.property('pubKey');
+      expect(result).to.have.property('path');
+      expect(result).to.have.property('singleAddress');
     });
+  });
 });


### PR DESCRIPTION
…nfig.json and integration test for wallet.create()

issue closes: #1954 
issue: #1949 

Note: API socket service does not close after test end and will stay open for the rest of the tests.