### PR TITLE
Feature[Insight-previous]/purify css

### DIFF
--- a/packages/insight-previous/purifyCSS
+++ b/packages/insight-previous/purifyCSS
@@ -1,0 +1,19 @@
+!/bin/bash
+PATH=$PATH:$(npm bin)
+set -x
+
+BUILDFOLDER=www/
+
+# clean up previous build
+rm -fr $BUILDFOLDER
+
+# Prod build
+ionic-app-scripts build --prod \
+                        --wwwDir $BUILDFOLDER
+
+# remove unused css
+purifycss $BUILDFOLDER"build/main.css" \
+          $BUILDFOLDER"build/*.js" \
+          --info \
+          --min \
+          --out $BUILDFOLDER"build/main.css" \

--- a/packages/insight-previous/purifyCSS
+++ b/packages/insight-previous/purifyCSS
@@ -8,7 +8,7 @@ BUILDFOLDER=www/
 rm -fr $BUILDFOLDER
 
 # Prod build
-ionic-app-scripts build --prod \
+ENV=prod CHAIN=BTC NETWORK=mainnet API_PREFIX=https://api.bitcore.io/api npm run ionic:build --prod \
                         --wwwDir $BUILDFOLDER
 
 # remove unused css


### PR DESCRIPTION
### With purifyCSS build script main.css size:

![screen shot 2019-02-04 at 5 55 58 pm](https://user-images.githubusercontent.com/23103037/52243116-afc33980-28a6-11e9-99ae-8b60e0d21713.png)

### Ionic-build script main.css size:

![screen shot 2019-02-04 at 5 52 26 pm](https://user-images.githubusercontent.com/23103037/52243120-b2259380-28a6-11e9-9682-45691858a4b5.png)

To run script:

Inside insight-previous project folder:
```
bash purifyCSS
```

Then
```
npm run serve
```

- Cleans main.css by ~ 21.7%

> Note: Needs purifyCSS installed either globally or in package.json as dev dependency