### PR TITLE
fix(node): resync uses connect

### DIFF
--- a/packages/bitcore-node/test/verification/resync.ts
+++ b/packages/bitcore-node/test/verification/resync.ts
@@ -11,7 +11,7 @@ import { Storage } from '../../src/services/storage';
     await Storage.start();
     const chainConfig = Config.chainConfig({ chain, network });
     const worker = new P2pWorker({ chain, network, chainConfig });
-    await worker.start();
+    await worker.connect();
 
     await worker.resync(Number(START), Number(END));
 


### PR DESCRIPTION
resync used start before, but that uses the syncing node designation. connect bypasses that