### PR TITLE
Bug/confirmations in cached history

### DIFF
--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -3605,6 +3605,13 @@ WalletService.prototype.getTxHistoryV8 = function(bc, wallet, opts, skip, limit,
         if (oldTxs.length) {
           fromCache = true;
         }
+
+        // update confirmations from height
+        _.each(oldTxs, (x) => {
+          if (x.blockheight>0) {
+            x.confirmations = bcHeight - x.blockheight + 1;
+          } 
+        });
       
         resultTxs  = resultTxs.concat(oldTxs);
         return next();
@@ -3616,12 +3623,13 @@ WalletService.prototype.getTxHistoryV8 = function(bc, wallet, opts, skip, limit,
       }
       // We have now TXs from 'tipHeight` to end in `lastTxs`.
       // Store hard confirmed TXs
+      // confirmations here is bcHeight - tip + 1, so OK.
       txsToCache = _.filter(lastTxs, function(i) {
         if (i.confirmations < Defaults.CONFIRMATIONS_TO_START_CACHING)  {
           return false;
         };
         if (!cacheStatus.tipHeight)
-        return true;  
+          return true;  
 
         return i.blockheight > cacheStatus.tipHeight;
       });

--- a/packages/bitcore-wallet/bin/cli-utils.js
+++ b/packages/bitcore-wallet/bin/cli-utils.js
@@ -93,14 +93,14 @@ Utils.getClient = function(args, opts, cb) {
   opts = opts || {};
 
   var filename = args.file || process.env['WALLET_FILE'] || process.env['HOME'] + '/.wallet.dat';
-  var host = args.host || process.env['BWS_HOST'] || 'http://localhost:3000/';
+  var host = args.host || process.env['BWS_HOST'] || 'https://bws.bitpay.com/bws/api';
 
   var storage = new FileStorage({
     filename: filename,
   });
 
   var client = new Client({
-    baseUrl: url.resolve(host, '/'),
+    baseUrl: host,
     verbose: args.verbose,
     supportStaffWalletId: opts.walletId,
   });
@@ -251,7 +251,7 @@ Utils.configureCommander = function(program) {
   program
     .version('0.0.1')
     .option('-f, --file <filename>', 'Wallet file')
-    .option('-h, --host <host>', 'Bitcore Wallet Service URL (eg: http://localhost:3001/copay/api')
+    .option('-h, --host <host>', 'Bitcore Wallet Service URL (eg: http://localhost:3000/bws/api')
     .option('-v, --verbose', 'be verbose')
 
   return program;


### PR DESCRIPTION
- updates confirmations nr for cached TXs in tx history.
  (this bug does not affect Copay with in Copay confirmations >6 are shown as 6+ and only TX with 36+ confirmations are cached.

- update dflt server in bitcore-wallet.