### PR TITLE
Bug/reject conflicting txs

### DIFF
--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -184,7 +184,9 @@ V8.prototype._transformUtxos = function(unspent, bcheight) {
   $.checkState(bcheight>0, 'No BC height passed to _transformUtxos');
   var self = this;
 
-  let ret = _.map(unspent, function(x) {
+  let ret = _.map(_.reject(unspent, (x) => {
+    return x.spentHeight && x.spentHeight <= -3;
+  }), (x) => {
     var u = {address: x.address};
 
     // v8 field name differences

--- a/packages/bitcore-wallet-service/lib/common/defaults.js
+++ b/packages/bitcore-wallet-service/lib/common/defaults.js
@@ -29,23 +29,23 @@ Defaults.FEE_LEVELS = {
     name: 'urgent',
     nbBlocks: 2,
     multiplier: 1.5,
-    defaultValue: 150000,
+    defaultValue: 75000,
   }, {
     name: 'priority',
     nbBlocks: 2,
-    defaultValue: 100000
+    defaultValue: 50000
   }, {
     name: 'normal',
     nbBlocks: 3,
-    defaultValue: 80000
+    defaultValue: 30000
   }, {
     name: 'economy',
     nbBlocks: 6,
-    defaultValue: 50000
+    defaultValue: 25000
   }, {
     name: 'superEconomy',
     nbBlocks: 24,
-    defaultValue: 20000
+    defaultValue: 10000
   }],
   bch: [{
     name: 'normal',

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -1674,7 +1674,7 @@ WalletService.prototype.getFeeLevels = function(opts, cb) {
   let cacheKey = 'feeLevel:' + opts.coin + ':' + opts.network;
 
   self.storage.checkAndUseGlobalCache(
-    cacheKey, Defaults.FEE_LEVEL_CACHE_DURATION, (err, values) =>  {
+    cacheKey, Defaults.FEE_LEVEL_CACHE_DURATION, (err, values, oldvalues) =>  {
 
     if (err) return cb(err);
     if (values) return cb(null, values, true);
@@ -1709,6 +1709,12 @@ WalletService.prototype.getFeeLevels = function(opts, cb) {
     };
 
     self._sampleFeeLevels(opts.coin, opts.network, samplePoints(), function(err, feeSamples) {
+      if (err) {
+        if (oldvalues) {
+          log.warn("##  There was an error estimating fees... using old cached values");
+          return cb(null, oldvalues, true);
+        }
+      }
 
       var values = _.map(feeLevels, function(level) {
         var result = {

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -2986,7 +2986,7 @@ WalletService.prototype.getNotifications = function(opts, cb) {
 };
 
 
-WalletService.prototype._normalizeV8TxHistory = function(walletId, txs, bcHeight, cb) {
+WalletService.prototype._normalizeTxHistory = function(walletId, txs, bcHeight, cb) {
   var self = this;
 
   if (_.isEmpty(txs) )
@@ -3008,7 +3008,13 @@ WalletService.prototype._normalizeV8TxHistory = function(walletId, txs, bcHeight
   var moves = {};
 
   // remove 'fees' and 'moves' (probably change addresses)
+  // also remove conflincting TXs (height=-3)
   var txs =  _.filter(txs, (tx) => {
+
+    // double spend or error
+    if (tx.height && tx.height <= -3) 
+      return false;
+
     if (tx.category == 'receive') {
       var output = {
           address: tx.address,
@@ -3539,7 +3545,7 @@ WalletService.prototype.getTxHistoryV8 = function(bc, wallet, opts, skip, limit,
       bc.getTransactions(wallet, startBlock, (err, txs) => {
         if (err) return cb(err);
 
-        self._normalizeV8TxHistory(wallet.id, txs, bcHeight, function(err, inTxs) {
+        self._normalizeTxHistory(wallet.id, txs, bcHeight, function(err, inTxs) {
           if (err) return cb(err);
 
           if (cacheStatus.tipTxId) {

--- a/packages/bitcore-wallet-service/lib/server.js
+++ b/packages/bitcore-wallet-service/lib/server.js
@@ -3018,8 +3018,8 @@ WalletService.prototype._normalizeTxHistory = function(walletId, txs, bcHeight, 
   var txs =  _.filter(txs, (tx) => {
 
     // double spend or error
-    if (tx.height && tx.height <= -3) 
-      return false;
+//    if (tx.height && tx.height <= -3) 
+//      return false;
 
     if (tx.category == 'receive') {
       var output = {

--- a/packages/bitcore-wallet-service/lib/storage.js
+++ b/packages/bitcore-wallet-service/lib/storage.js
@@ -1179,6 +1179,7 @@ Storage.prototype._dump = function(cb, fn) {
 
 // key: 'feeLevel' + JSON.stringify(opts);
 // duration: FEE_LEVEL_DURATION
+//
 
 Storage.prototype.checkAndUseGlobalCache = function(key, duration, cb) {
   var self = this;
@@ -1192,7 +1193,9 @@ Storage.prototype.checkAndUseGlobalCache = function(key, duration, cb) {
     if (err) return cb(err);
     if (!ret) return cb();
     var validFor = ret.ts + duration - now;
-    return cb(null, validFor > 0 ? ret.result : null);
+
+    // always return the value as a 3 param anyways.
+    return cb(null, validFor > 0 ? ret.result : null, ret.result);
   });
 };
 

--- a/packages/bitcore-wallet-service/test/integration/historyV8.js
+++ b/packages/bitcore-wallet-service/test/integration/historyV8.js
@@ -572,7 +572,6 @@ describe('History V8', function() {
     });
 
     it('should get tx history with accepted proposal, multisend', function(done) {
-      server._normalizeTxHistory = sinon.stub().returnsArg(0);
       var external = '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7';
 
       helpers.stubUtxos(server, wallet, [1, 2], function(utxos) {
@@ -643,6 +642,7 @@ describe('History V8', function() {
  
               helpers.stubHistoryV8(null, null,txs);
               helpers.stubCheckData(blockchainExplorer, server, wallet.coin == 'bch', () =>{ 
+
               server.getTxHistory({}, function(err, txs) {
                 should.not.exist(err);
                 should.exist(txs);
@@ -729,7 +729,6 @@ describe('History V8', function() {
         expected: [],
       }];
 
-      server._normalizeTxHistory = sinon.stub().returnsArg(0);
       var timestamps = [50, 40, 30, 20, 10];
       var txs = _.map(timestamps, function(ts, idx) {
         return {
@@ -794,7 +793,6 @@ describe('History V8', function() {
       helpers.stubFeeLevels({
         24: 10000,
       });
-      server._normalizeTxHistory = sinon.stub().returnsArg(0);
       var txs = [{
         txid: '1',
         confirmations: 0,
@@ -855,7 +853,6 @@ describe('History V8', function() {
     });
     it.skip('should get tx history even if fee levels are unavailable', function(done) {
       blockchainExplorer.estimateFee = sinon.stub().yields('dummy error');
-      server._normalizeTxHistory = sinon.stub().returnsArg(0);
       var txs = [{
         txid: '1',
         confirmations: 1,
@@ -888,7 +885,6 @@ describe('History V8', function() {
       helpers.stubHistoryV8(x);
 
 
-//console.log('[server.js.7149]',HugeTxs[1].vin); //TODO
       server.getTxHistory({}, function(err, txs) {
         should.not.exist(err);
         should.exist(txs);

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -2296,6 +2296,53 @@ describe('Wallet service', function() {
         });
       });
     });
+
+    it('should get not cache old fee levels after fail', function(done) {
+      let x = Defaults.FEE_LEVEL_CACHE_DURATION;
+      Defaults.FEE_LEVEL_CACHE_DURATION = 0;
+
+      helpers.stubFeeLevels({
+        1: 40002,
+        2: 20000,
+        6: 18000,
+        24: 9001,
+      });
+      server.getFeeLevels({}, function(err, fees) {
+        should.not.exist(err);
+        fees = _.fromPairs(_.map(fees, function(item) {
+          return [item.level, item];
+        }));
+        fees.urgent.feePerKb.should.equal(60003);
+        blockchainExplorer.estimateFee = sinon.stub().yields('dummy error');
+        server.getFeeLevels({}, function(err, fees) {
+          should.not.exist(err);
+          fees = _.fromPairs(_.map(fees, function(item) {
+            return [item.level, item];
+          }));
+          fees.urgent.feePerKb.should.equal(60003);
+          fees.superEconomy.feePerKb.should.equal(9001);
+
+          helpers.stubFeeLevels({
+            1: 400,
+            2: 200,
+            6: 180,
+            24: 90,
+          });
+          server.getFeeLevels({}, function(err, fees) {
+            should.not.exist(err);
+            fees = _.fromPairs(_.map(fees, function(item) {
+              return [item.level, item];
+            }));
+            fees.urgent.feePerKb.should.equal(600);
+            fees.superEconomy.feePerKb.should.equal(90);
+            Defaults.FEE_LEVEL_CACHE_DURATION = x;
+            done();
+          });
+        });
+      });
+    });
+ 
+ 
  
     it('should fallback to slower confirmation times if network cannot estimate (returns -1)', function(done) {
       helpers.stubFeeLevels({

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -4700,7 +4700,7 @@ describe('Wallet service', function() {
     it('should include the note in tx history listing', function(done) {
       helpers.createAddresses(server, wallet, 1, 1, function(mainAddresses, changeAddress) {
         blockchainExplorer.getBlockchainHeight = sinon.stub().callsArgWith(0, null, 1000);
-        server._normalizeV8TxHistory = function(a,b,c,d) { return d(null,b);}
+        server._normalizeTxHistory = function(a,b,c,d) { return d(null,b);}
         var txs = [{
           txid: '123',
           blockheight: 100,


### PR DESCRIPTION
Extend fee estimation cache life, if RPC fails.
Remove double spend txs (conflicting txs) from tx history.