### PR TITLE
[bitcore-node] Fix calculating tx confirmations

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -454,9 +454,30 @@ export class InternalStateProvider implements CSP.IChainStateService {
       .addCursorFlag('noCursorTimeout', true)
       .toArray();
 
+    const tip = await this.getLocalTip({chain, network});
+    const tipHeight = tip ? tip.height : 0;
+
+    const inputsTransform = inputs.map((c: ICoin) => {
+      let confirmations = 0;
+      if (c.mintHeight && c.mintHeight >= 0) {
+        confirmations = tipHeight - c.mintHeight + 1;
+      }
+      c.confirmations = confirmations;
+      return CoinStorage._apiTransform(c, { object: true });
+    });
+
+    let outputsTransform = outputs.map((c: ICoin) => {
+      let confirmations = 0;
+      if (c.mintHeight && c.mintHeight >= 0) {
+        confirmations = tipHeight - c.mintHeight + 1;
+      }
+      c.confirmations = confirmations;
+      return CoinStorage._apiTransform(c, { object: true });
+    });
+
     return {
-      inputs: inputs.map(input => CoinStorage._apiTransform(input, { object: true })),
-      outputs: outputs.map(output => CoinStorage._apiTransform(output, { object: true }))
+      inputs: inputsTransform,
+      outputs: outputsTransform
     };
   }
 


### PR DESCRIPTION
Confimations of coin inputs and outputs of a transaction are currently not calculated at all.
For eg:
```
$ curl -v localhost:3000/api/BTC/testnet/tx/79f2fab5172af5ad2ed95d9a76ca65ac4e41c2bfee71101b339c8dbcc1ba6d0e/coins | jq
  {
  "inputs": [
    {
      "_id": "5c651dc075aa1d6093ff0f6e",
      "chain": "BTC",
      "network": "testnet",
      "coinbase": false,
      "mintIndex": 0,
      "spentTxid": "79f2fab5172af5ad2ed95d9a76ca65ac4e41c2bfee71101b339c8dbcc1ba6d0e",
      "mintTxid": "d42e5ebe03a2cb339f1c773933c9203dd74fd0082164e28a29f177792b28076a",
      "mintHeight": 1356510,
      "spentHeight": 1356510,
      "address": "mty2YN9jwiWQRscpCRDjV1pueprW9gZV6j",
      "script": "76a9149387fec5a7924f0c3dcf3fc25c81100bf8cfc6b588ac",
      "value": 145933200,
      "confirmations": -1
    }
  ],
  "outputs": [
    {
      "_id": "5c651dc075aa1d6093ff0ff0",
      "chain": "BTC",
      "network": "testnet",
      "coinbase": false,
      "mintIndex": 0,
      "spentTxid": "",
      "mintTxid": "79f2fab5172af5ad2ed95d9a76ca65ac4e41c2bfee71101b339c8dbcc1ba6d0e",
      "mintHeight": 1356510,
      "spentHeight": -2,
      "address": "false",
      "script": "6a4c500000d37a0001ee026279c9926e400a1c79282f2b074d9f92b670f25579a7533f6b2b8ad52b1ff84d28dad58ab5734f3b8d3096cb5b61f3d60543aa2aaa2d9e00a7deece6ad238a08b12458edb4e73c86",
      "value": 0,
      "confirmations": -1
    },
    {
      "_id": "5c651dc075aa1d6093ff0ffe",
      "chain": "BTC",
      "network": "testnet",
      "coinbase": false,
      "mintIndex": 1,
      "spentTxid": "425ab8e83ef1a07edd713d0b1e4d246bf33344ffc1cfcb9937c6b64de966b07f",
      "mintTxid": "79f2fab5172af5ad2ed95d9a76ca65ac4e41c2bfee71101b339c8dbcc1ba6d0e",
      "mintHeight": 1356510,
      "spentHeight": 1356511,
      "address": "mgd3QvQEJZAQ9DBUZW4nsvPy91y8L61K3p",
      "script": "76a9140c1ee4e93c61c0a0f15f65982e9cdc941e2c570d88ac",
      "value": 145897800,
      "confirmations": -1
    }
  ]
}
```

The output here incorrectly shows the confirmations as `-1`