### PR TITLE
Fix(node) - getBalanceAtTime()

### DIFF
--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -100,14 +100,17 @@ class CoinModel extends BaseModel<ICoin> {
 
   async getBalanceAtTime(params: { query: any; time: string; chain: string; network: string }) {
     let { query, time, chain, network } = params;
-    const block = await BlockStorage.collection.findOne({
-      $query: {
-        chain,
-        network,
-        timeNormalized: { $lte: new Date(time) }
-      },
-      $orderBy: { timeNormalized: -1 }
-    });
+    const [block] = await BlockStorage.collection
+      .find({
+        $query: {
+          chain,
+          network,
+          timeNormalized: { $lte: new Date(time) }
+        }
+      })
+      .limit(1)
+      .sort({ timeNormalized: -1 })
+      .toArray();
     const blockHeight = block!.height;
     const combinedQuery = Object.assign(
       {},

--- a/packages/bitcore-node/test/helpers/index.ts
+++ b/packages/bitcore-node/test/helpers/index.ts
@@ -1,5 +1,5 @@
 import { StateStorage } from '../../src/models/state';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import { BlockStorage } from '../../src/models/block';
 import { TransactionStorage } from '../../src/models/transaction';
 import { CoinStorage } from '../../src/models/coin';
@@ -59,8 +59,9 @@ export function mockStorage(toReturn, collectionMethods = {}) {
   return Storage;
 }
 
-export function mockModel(model, toReturn, collectionMethods = {}) {
-  model.db = {
-    collection: sinon.stub().returns(mockCollection(toReturn, collectionMethods))
-  };
+export function mockModel(collectionName: string, toReturn: any, collectionMethods = {}) {
+  const isStubbed: sinon.SinonStub = Storage.db!.collection as sinon.SinonStub;
+  if (isStubbed.withArgs) {
+    isStubbed.withArgs(collectionName).returns(mockCollection(toReturn, collectionMethods));
+  }
 }

--- a/packages/bitcore-node/test/helpers/index.ts
+++ b/packages/bitcore-node/test/helpers/index.ts
@@ -58,3 +58,9 @@ export function mockStorage(toReturn, collectionMethods = {}) {
   } as any;
   return Storage;
 }
+
+export function mockModel(model, toReturn, collectionMethods = {}) {
+  model.db = {
+    collection: sinon.stub().returns(mockCollection(toReturn, collectionMethods))
+  };
+}

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -118,8 +118,8 @@ describe('Coin Model', function() {
       };
 
       let blockModelHeight = { height: 123 };
-      mockStorage([{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
-      mockModel(BlockStorage, blockModelHeight);
+      mockModel('coins', [{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
+      mockModel('blocks', blockModelHeight);
       let coinModelAggregateSpy = CoinStorage.collection.aggregate as sinon.SinonSpy;
       let blockModelFindSpy = BlockStorage.collection.find as sinon.SinonSpy;
 

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -4,7 +4,7 @@ import { SpentHeightIndicators } from '../../../src/types/Coin';
 import { ObjectId } from 'mongodb';
 import sinon from 'sinon';
 import { BlockStorage } from '../../../src/models/block';
-import { mockStorage } from '../../helpers/index.js';
+import { mockStorage, mockModel } from '../../helpers/index.js';
 
 describe('Coin Model', function() {
   describe('_apiTransform', () => {
@@ -119,7 +119,7 @@ describe('Coin Model', function() {
 
       let blockModelHeight = { height: 123 };
       mockStorage([{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
-      Object.assign(BlockStorage.collection.find, sandbox.stub().resolves(blockModelHeight));
+      mockModel(BlockStorage, blockModelHeight);
       let coinModelAggregateSpy = CoinStorage.collection.aggregate as sinon.SinonSpy;
       let blockModelFindSpy = BlockStorage.collection.find as sinon.SinonSpy;
 

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import { BlockStorage } from '../../../src/models/block';
 import { mockStorage } from '../../helpers/index.js';
 
-describe('Coin Model', function () {
+describe('Coin Model', function() {
   describe('_apiTransform', () => {
     it('should return the transform object with coin info', () => {
       let id = new ObjectId();
@@ -91,40 +91,40 @@ describe('Coin Model', function () {
       sandbox.restore();
     });
 
-    it('should return an object with confirmed, unconfirmed, and balance when additional time parameter is passed in', async () => {      
-      let id = new ObjectId("5c364e342ab5602e97a56f0e");
+    it('should return an object with confirmed, unconfirmed, and balance when additional time parameter is passed in', async () => {
+      let id = new ObjectId('5c364e342ab5602e97a56f0e');
       let chain = 'BTC';
       let network = 'regtest';
       let time = new Date().toISOString();
       let query = { wallets: id, 'wallets.0': { $exists: true } };
-      let matchObject = { 
-        "$or": [
+      let matchObject = {
+        $or: [
           {
-            "spentHeight": {
-              "$gt": 123
+            spentHeight: {
+              $gt: 123
             }
           },
           {
-            "spentHeight": {
-              "$lt": 0
+            spentHeight: {
+              $lt: 0
             }
           }
         ],
-        "mintHeight": {
-          "$lte": 123
+        mintHeight: {
+          $lte: 123
         },
-        "wallets": new ObjectId('5c364e342ab5602e97a56f0e'),
-        "wallets.0": { '$exists': true },
-      }
+        wallets: new ObjectId('5c364e342ab5602e97a56f0e'),
+        'wallets.0': { $exists: true }
+      };
 
       let blockModelHeight = { height: 123 };
-      mockStorage([{_id: 'confirmed', balance: 123123}, {_id: 'unconfirmed', balance: 1}]);
-      Object.assign(BlockStorage.collection.findOne, sandbox.stub().resolves(blockModelHeight));
+      mockStorage([{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
+      Object.assign(BlockStorage.collection.find, sandbox.stub().resolves(blockModelHeight));
       let coinModelAggregateSpy = CoinStorage.collection.aggregate as sinon.SinonSpy;
       let blockModelFindOneSpy = BlockStorage.collection.findOne as sinon.SinonSpy;
 
-      const result = await CoinStorage.getBalanceAtTime({query, time, chain, network});
-      expect(coinModelAggregateSpy.called).to.deep.equal(true, "CoinStorage.aggregation should have been called");
+      const result = await CoinStorage.getBalanceAtTime({ query, time, chain, network });
+      expect(coinModelAggregateSpy.called).to.deep.equal(true, 'CoinStorage.aggregation should have been called');
       expect(blockModelFindOneSpy.called).to.deep.equal(true, 'BlockModel.findOne should have been called');
       expect(coinModelAggregateSpy.getCall(0).args[0][0].$match).to.deep.equal(matchObject);
       expect(result).to.has.property('confirmed');
@@ -143,20 +143,20 @@ describe('Coin Model', function () {
       sandbox.restore();
     });
 
-    it('should return an object with confirmed, unconfirmed, and balance', async () => {      
-      let id = new ObjectId("5c364e342ab5602e97a56f0e");
+    it('should return an object with confirmed, unconfirmed, and balance', async () => {
+      let id = new ObjectId('5c364e342ab5602e97a56f0e');
       let query = {
-        "wallets": id, 
-        'wallets.0': { "$exists": true },
-        "spentHeight": { "$lt": 0 },
-        "mintHeight": { "$gt": -3 }
+        wallets: id,
+        'wallets.0': { $exists: true },
+        spentHeight: { $lt: 0 },
+        mintHeight: { $gt: -3 }
       };
 
-      mockStorage([{_id: 'confirmed', balance: 123123}, {_id: 'unconfirmed', balance: 1}]);
+      mockStorage([{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
       let coinModelAggregateSpy = CoinStorage.collection.aggregate as sinon.SinonSpy;
 
-      const result = await CoinStorage.getBalance({query});
-      expect(coinModelAggregateSpy.called).to.deep.equal(true, "CoinStorage.aggregation should have been called");
+      const result = await CoinStorage.getBalance({ query });
+      expect(coinModelAggregateSpy.called).to.deep.equal(true, 'CoinStorage.aggregation should have been called');
       expect(coinModelAggregateSpy.getCall(0).args[0][0].$match).to.deep.equal(query);
       expect(result).to.has.property('confirmed');
       expect(result).to.has.property('unconfirmed');

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -121,11 +121,11 @@ describe('Coin Model', function() {
       mockStorage([{ _id: 'confirmed', balance: 123123 }, { _id: 'unconfirmed', balance: 1 }]);
       Object.assign(BlockStorage.collection.find, sandbox.stub().resolves(blockModelHeight));
       let coinModelAggregateSpy = CoinStorage.collection.aggregate as sinon.SinonSpy;
-      let blockModelFindOneSpy = BlockStorage.collection.findOne as sinon.SinonSpy;
+      let blockModelFindSpy = BlockStorage.collection.find as sinon.SinonSpy;
 
       const result = await CoinStorage.getBalanceAtTime({ query, time, chain, network });
       expect(coinModelAggregateSpy.called).to.deep.equal(true, 'CoinStorage.aggregation should have been called');
-      expect(blockModelFindOneSpy.called).to.deep.equal(true, 'BlockModel.findOne should have been called');
+      expect(blockModelFindSpy.called).to.deep.equal(true, 'BlockModel.find should have been called');
       expect(coinModelAggregateSpy.getCall(0).args[0][0].$match).to.deep.equal(matchObject);
       expect(result).to.has.property('confirmed');
       expect(result).to.has.property('unconfirmed');


### PR DESCRIPTION
- replaced deprecated orderBy with .sort() mongo query for getBalanceAtTime()
- Added mockModel() to specify model to stub.
- Added isStubbed conditional to check if a model has been stubbed already.