### PR TITLE
replaced  to equal to unspent -2 for getBalanceAtTime query

### DIFF
--- a/packages/bitcore-node/package.json
+++ b/packages/bitcore-node/package.json
@@ -49,7 +49,7 @@
     "@types/express": "^4.11.1",
     "@types/lodash": "^4.14.116",
     "@types/mocha": "^5.2.0",
-    "@types/mongodb": "^3.1.12",
+    "@types/mongodb": "^3.1.19",
     "@types/mongoose": "^5.0.11",
     "@types/node": "10.0.2",
     "@types/request": "^2.47.0",

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -115,7 +115,7 @@ class CoinModel extends BaseModel<ICoin> {
     const combinedQuery = Object.assign(
       {},
       {
-        $or: [{ spentHeight: { $gt: blockHeight } }, { spentHeight: { $lt: SpentHeightIndicators.minimum } }],
+        $or: [{ spentHeight: { $gt: blockHeight } }, { spentHeight: SpentHeightIndicators.unspent }],
         mintHeight: { $lte: blockHeight }
       },
       query

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -65,28 +65,33 @@ class CoinModel extends BaseModel<ICoin> {
   async getBalance(params: { query: any }) {
     let { query } = params;
     const result = await this.collection
-      .aggregate<{ _id: string; balance: number }>([
-        { $match: query },
-        {
-          $project: {
-            value: 1,
-            status: {
-              $cond: {
-                if: { $gte: ['$mintHeight', SpentHeightIndicators.minimum] },
-                then: 'confirmed',
-                else: 'unconfirmed'
-              }
-            },
-            _id: 0
+      .aggregate<{ _id: string; balance: number }>(
+        [
+          { $match: query },
+          {
+            $project: {
+              value: 1,
+              status: {
+                $cond: {
+                  if: { $gte: ['$mintHeight', SpentHeightIndicators.minimum] },
+                  then: 'confirmed',
+                  else: 'unconfirmed'
+                }
+              },
+              _id: 0
+            }
+          },
+          {
+            $group: {
+              _id: '$status',
+              balance: { $sum: '$value' }
+            }
           }
-        },
+        ],
         {
-          $group: {
-            _id: '$status',
-            balance: { $sum: '$value' }
-          }
+          hint: { wallets: 1, spentHeight: 1, value: 1 }
         }
-      ])
+      )
       .toArray();
     return result.reduce<{ confirmed: number; unconfirmed: number; balance: number }>(
       (acc, cur) => {
@@ -117,9 +122,6 @@ class CoinModel extends BaseModel<ICoin> {
       {
         $or: [{ spentHeight: { $gt: blockHeight } }, { spentHeight: SpentHeightIndicators.unspent }],
         mintHeight: { $lte: blockHeight }
-      },
-      {
-        hint: { wallets: 1, spentHeight: 1, value: 1 }
       },
       query
     );

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -118,9 +118,6 @@ class CoinModel extends BaseModel<ICoin> {
         $or: [{ spentHeight: { $gt: blockHeight } }, { spentHeight: SpentHeightIndicators.unspent }],
         mintHeight: { $lte: blockHeight }
       },
-      {
-        hint: { wallets: 1, spentHeight: 1, value: 1 }
-      },
       query
     );
     return this.getBalance({ query: combinedQuery });

--- a/packages/bitcore-node/src/models/coin.ts
+++ b/packages/bitcore-node/src/models/coin.ts
@@ -118,6 +118,9 @@ class CoinModel extends BaseModel<ICoin> {
         $or: [{ spentHeight: { $gt: blockHeight } }, { spentHeight: SpentHeightIndicators.unspent }],
         mintHeight: { $lte: blockHeight }
       },
+      {
+        hint: { wallets: 1, spentHeight: 1, value: 1 }
+      },
       query
     );
     return this.getBalance({ query: combinedQuery });

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -112,7 +112,8 @@ describe('Coin Model', function() {
           $lte: 123
         },
         wallets: new ObjectId('5c364e342ab5602e97a56f0e'),
-        'wallets.0': { $exists: true }
+        'wallets.0': { $exists: true },
+        hint: { wallets: 1, spentHeight: 1, value: 1 }
       };
 
       let blockModelHeight = { height: 123 };

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -105,9 +105,7 @@ describe('Coin Model', function() {
             }
           },
           {
-            spentHeight: {
-              $lt: 0
-            }
+            spentHeight: -2
           }
         ],
         mintHeight: {

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -108,12 +108,12 @@ describe('Coin Model', function() {
             spentHeight: -2
           }
         ],
+        hint: { wallets: 1, spentHeight: 1, value: 1 },
         mintHeight: {
           $lte: 123
         },
         wallets: new ObjectId('5c364e342ab5602e97a56f0e'),
-        'wallets.0': { $exists: true },
-        hint: { wallets: 1, spentHeight: 1, value: 1 }
+        'wallets.0': { $exists: true }
       };
 
       let blockModelHeight = { height: 123 };

--- a/packages/bitcore-node/test/unit/models/coin.unit.ts
+++ b/packages/bitcore-node/test/unit/models/coin.unit.ts
@@ -108,7 +108,6 @@ describe('Coin Model', function() {
             spentHeight: -2
           }
         ],
-        hint: { wallets: 1, spentHeight: 1, value: 1 },
         mintHeight: {
           $lte: 123
         },


### PR DESCRIPTION
- Added hint to aggregate $match query to use correct indexes of { wallets: 1, spentHeight: 1, value: 1}