### PR TITLE
Automatically remove indexes if their name is not in an array of desi…

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -92,6 +92,15 @@ export class TransactionModel extends BaseModel<ITransaction> {
   ];
 
   onConnect() {
+    const desiredIndexes = [
+      '_id_',
+      'txid_1',
+      'chain_1_network_1_blockHeight_1',
+      'blockHash_1',
+      'chain_1_network_1_blockTimeNormalized_1',
+      'wallets_1_blockTimeNormalized_1',
+      'wallets_1_blockHeight_1'
+    ];
     this.collection.createIndex({ txid: 1 }, { background: true });
     this.collection.createIndex({ chain: 1, network: 1, blockHeight: 1 }, { background: true });
     this.collection.createIndex({ blockHash: 1 }, { background: true });
@@ -104,6 +113,22 @@ export class TransactionModel extends BaseModel<ITransaction> {
       { wallets: 1, blockHeight: 1 },
       { background: true, partialFilterExpression: { 'wallets.0': { $exists: true } } }
     );
+    this.collection.listIndexes()
+      .toArray()
+      .then((indexes) => {
+        const indexNamesToRemove = indexes
+          .map(index => index.name)
+          .filter(name => !desiredIndexes.includes(name))
+        for (let name of indexNamesToRemove) {
+          console.log(`dropping index - ${name}`);
+          this.collection.dropIndex(name)
+            .catch((err) => {
+              console.log(`Error dropping index ${name}`);
+              console.log(err);
+            })
+        }
+      })
+      .catch(err => console.log(err));
   }
 
   async batchImport(params: {


### PR DESCRIPTION
The motivation of this is if you have been running bitcore from the past, there are indexes that have changed.

This will remove indexes that are not explicitly defined in the `desiredIndexes` array.
I'm not sure myself if this is the best way to do this (perhaps we can define names from the list when creating the indexes), but something like this is nice to clean up old indexes