### PR TITLE
Bug/fee cache

### DIFF
--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -379,7 +379,6 @@ console.log('[v8.js.328:url:] CHECKING ADDRESS ACTIVITY',url); //TODO
       return cb(null, ret !== '[]');
     })
       .catch((err) => {
-console.log('[v8.js.335:err:]',err); //TODO
         return cb(err);
       } );
 };
@@ -394,7 +393,14 @@ V8.prototype.estimateFee = function(nbBlocks, cb) {
     self.request.get(url, {})
       .then( (ret) => {
         try {
-          ret = JSON.parse(ret); 
+          ret = JSON.parse(ret);
+
+          // only process right responses.
+          if (ret.blocks != x)  {
+            log.info(`Ignoring response for ${x}:`+ JSON.stringify(ret));
+            return icb();
+          }
+
           result[x] = ret.feerate;
         }
         catch (e) {};

--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -403,15 +403,11 @@ V8.prototype.estimateFee = function(nbBlocks, cb) {
 
           result[x] = ret.feerate;
         }
-        catch (e) {
-
-console.log('[v8.js.407]',e); //TODO
-        };
+        catch (e) { };
 
         return icb();
       })
       .catch((err) => {
-console.log('[v8.js.410:err:]',err); //TODO
         return icb(err)
       } );
   }, function(err) {

--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -403,11 +403,17 @@ V8.prototype.estimateFee = function(nbBlocks, cb) {
 
           result[x] = ret.feerate;
         }
-        catch (e) {};
+        catch (e) {
+
+console.log('[v8.js.407]',e); //TODO
+        };
 
         return icb();
       })
-      .catch((err) => {return icb(err)} );
+      .catch((err) => {
+console.log('[v8.js.410:err:]',err); //TODO
+        return icb(err)
+      } );
   }, function(err) {
     if (err) {
       return cb(err);

--- a/packages/bitcore-wallet-service/lib/common/defaults.js
+++ b/packages/bitcore-wallet-service/lib/common/defaults.js
@@ -98,7 +98,7 @@ Defaults.BALANCE_CACHE_DURATION = 10;
 Defaults.BLOCKHEIGHT_CACHE_TIME = 30 * 60 * 1000;
 
 // Cache time fee levels (in ms)
-Defaults.FEE_LEVEL_CACHE_DURATION = 30 * 60 * 1000;
+Defaults.FEE_LEVEL_CACHE_DURATION = 6 * 60 * 1000;
 
 // Max allowed timespan for notification queries in seconds
 Defaults.MAX_NOTIFICATIONS_TIMESPAN = 60 * 60 * 24 * 14; // ~ 2 weeks

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -510,7 +510,6 @@ ExpressApp.prototype.start = function(opts, cb) {
     var opts = {};
     if (req.query.coin) opts.coin = req.query.coin;
     if (req.query.network) opts.network = req.query.network;
-console.log('[expressapp.js.512:opts:]',opts); //TODO
 
     var server;
     try {

--- a/packages/bitcore-wallet-service/lib/expressapp.js
+++ b/packages/bitcore-wallet-service/lib/expressapp.js
@@ -505,10 +505,12 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
-  router.get('/v2/feelevels/', estimateFeeLimiter, function(req, res) {
+//  router.get('/v2/feelevels/', estimateFeeLimiter, function(req, res) {
+  router.get('/v2/feelevels/',function(req, res) {
     var opts = {};
     if (req.query.coin) opts.coin = req.query.coin;
     if (req.query.network) opts.network = req.query.network;
+console.log('[expressapp.js.512:opts:]',opts); //TODO
 
     var server;
     try {

--- a/packages/bitcore-wallet-service/test/integration/helpers.js
+++ b/packages/bitcore-wallet-service/test/integration/helpers.js
@@ -434,11 +434,22 @@ helpers.stubCheckData = function(bc, server, isBCH, cb) {
 };
 
 
-helpers.stubFeeLevels = function(levels) {
+// fill => fill intermediary levels
+helpers.stubFeeLevels = function(levels, fill) {
   blockchainExplorer.estimateFee = function(nbBlocks, cb) {
     var result = _.fromPairs(_.map(_.pick(levels, nbBlocks), function(fee, n) {
       return [+n, fee > 0 ? fee / 1e8 : fee];
     }));
+
+    if (fill) {
+      let last;
+      _.each(nbBlocks, (n) => { 
+        if (result[n]) {
+          last = result[n];
+        }
+        result[n] = last;
+      });
+    }
     return cb(null, result);
   };
 };

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -2174,7 +2174,7 @@ describe('Wallet service', function() {
     });
   });
 
-  describe.only('#getFeeLevels', function() {
+  describe('#getFeeLevels', function() {
     var server, wallet, levels;
     before(function() {
       levels = Defaults.FEE_LEVELS;
@@ -2404,6 +2404,7 @@ describe('Wallet service', function() {
       let x = Defaults.FEE_LEVEL_CACHE_DURATION;
       Defaults.FEE_LEVEL_CACHE_DURATION = 100;
 
+      //  not given values will fail
       helpers.stubFeeLevels({
         6: 200,
         24: 101,

--- a/packages/bitcore-wallet-service/test/v8.js
+++ b/packages/bitcore-wallet-service/test/v8.js
@@ -173,4 +173,53 @@ describe('V8', () => {
     });
   });
 
+  describe('#estimateFee', () => {
+    it('should estimate fee', (done) => {
+
+      let fakeRequest = {
+        get: sinon.stub().resolves('{"feerate":0.00017349,"blocks":5}'),
+      };
+
+      var be = new V8({
+        coin: 'bch',
+        network: 'livenet',
+        url: 'http://dummy/',
+        apiPrefix: 'dummyPath',
+        userAgent: 'testAgent',
+        request: fakeRequest,
+      });
+
+      be.estimateFee([5], (err, levels) => {
+        should.not.exist(err);
+        should.exist(levels);
+        // should ignore non-matching results
+        levels.should.deep.equal({ '5': 0.00017349 });
+        return done();
+      });
+    });
+ 
+    it('should ignore non-matching results from estimate fee', (done) => {
+
+      let fakeRequest = {
+        get: sinon.stub().resolves('{"feerate":0.00017349,"blocks":4}'),
+      };
+
+      var be = new V8({
+        coin: 'bch',
+        network: 'livenet',
+        url: 'http://dummy/',
+        apiPrefix: 'dummyPath',
+        userAgent: 'testAgent',
+        request: fakeRequest,
+      });
+
+      be.estimateFee([1,2,3,4,5], (err, levels) => {
+        should.not.exist(err);
+        should.exist(levels);
+        // should ignore non-matching results
+        levels.should.deep.equal({ '4': 0.00017349 });
+        return done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Better handle of fee rate cache:

1- decrease duration from 30  to 6 minutes
2- ignore bitcore results if response's nBlock does not match query
3- do not cache results with missing responses. 