### PR TITLE
use fee results is nblocks is not present

### DIFF
--- a/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
+++ b/packages/bitcore-wallet-service/lib/blockchainexplorers/v8.js
@@ -396,14 +396,16 @@ V8.prototype.estimateFee = function(nbBlocks, cb) {
           ret = JSON.parse(ret);
 
           // only process right responses.
-          if (ret.blocks != x)  {
+          if (!_.isUndefined(ret.blocks) && ret.blocks != x)  {
             log.info(`Ignoring response for ${x}:`+ JSON.stringify(ret));
             return icb();
           }
 
           result[x] = ret.feerate;
         }
-        catch (e) { };
+        catch (e) { 
+          log.warn('fee error:', e);
+        };
 
         return icb();
       })

--- a/packages/bitcore-wallet-service/test/v8.js
+++ b/packages/bitcore-wallet-service/test/v8.js
@@ -221,5 +221,33 @@ describe('V8', () => {
         return done();
       });
     });
+
+    it('should use results from estimate fee is blocks is not present', (done) => {
+
+      let fakeRequest = {
+        get: sinon.stub().resolves('{"feerate":0.00017349}'),
+      };
+
+      var be = new V8({
+        coin: 'bch',
+        network: 'livenet',
+        url: 'http://dummy/',
+        apiPrefix: 'dummyPath',
+        userAgent: 'testAgent',
+        request: fakeRequest,
+      });
+
+      be.estimateFee([1,2,3,4,5], (err, levels) => {
+        should.not.exist(err);
+        should.exist(levels);
+        levels.should.deep.equal({ '1': 0.00017349,
+          '2': 0.00017349,
+          '3': 0.00017349,
+          '4': 0.00017349,
+          '5': 0.00017349 });
+        return done();
+      });
+    });
+
   });
 });


### PR DESCRIPTION
this is for handling BCH responses:
https://api.bitcore.io/api/BCH/mainnet/fee/9

which contains no `nblocks:` in the response
BTC: https://api.bitcore.io/api/BTC/mainnet/fee/9