### PR TITLE
[bitcore-node] make ratelimiting configurable

### DIFF
--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -57,6 +57,7 @@ const Config = function(): ConfigType {
     dbHost: process.env.DB_HOST || '127.0.0.1',
     dbName: process.env.DB_NAME || 'bitcore',
     dbPort: process.env.DB_PORT || '27017',
+    ratelimit: process.env.RATE_LIMIT == 'true' || true,
     numWorkers: cpus().length,
     chains: {},
     services: {

--- a/packages/bitcore-node/src/routes/index.ts
+++ b/packages/bitcore-node/src/routes/index.ts
@@ -58,8 +58,9 @@ function getRouterFromFile(path) {
 app.use(cors());
 app.use(LogMiddleware());
 app.use(CacheMiddleware(CacheTimes.Second));
-app.use(RateLimiter('GLOBAL', 10, 200, 4000));
 app.use('/api', getRouterFromFile('status'));
+if (config.ratelimit)
+  app.use(RateLimiter('GLOBAL', 10, 200, 4000));
 
 app.use('/api/:chain/:network', (req: Request, resp: Response, next: any) => {
   let { chain, network } = req.params;

--- a/packages/bitcore-node/src/types/Config.d.ts
+++ b/packages/bitcore-node/src/types/Config.d.ts
@@ -4,6 +4,7 @@ export interface ConfigType {
   dbHost: string;
   dbName: string;
   dbPort: string;
+  ratelimit: boolean | undefined;
   numWorkers: number;
 
   chains: {


### PR DESCRIPTION
Allowing turning off the application level rate limiting when in deployments where there is a load balancer with it's own rate limiting capability