### PR TITLE
Fixed small issue of opts not propagating for multisig noSorting

### DIFF
--- a/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
@@ -29,11 +29,11 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWi
   signatures = signatures || input.signatures;
   this.nestedWitness = nestedWitness ? true : false;
   if (opts.noSorting) {
-    this.publicKeys = pubkeys
+    this.publicKeys = pubkeys;
   } else  {
     this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
   }
-  this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold);
+  this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold, opts);
   if (this.nestedWitness) {
     var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);
     $.checkState(Script.buildScriptHashOut(nested).equals(this.output.script),


### PR DESCRIPTION
Fixed a very small issue with noSorting opts param not propagating to a buildMultisigOut call.