### PR TITLE
xversion placeholder to maintain compatibility with BUcash1.5.1

### DIFF
--- a/packages/bitcore-p2p-cash/lib/messages/builder.js
+++ b/packages/bitcore-p2p-cash/lib/messages/builder.js
@@ -58,7 +58,8 @@ function builder(options) {
       getblocks: 'GetBlocks',
       getheaders: 'GetHeaders',
       mempool: 'MemPool',
-      getaddr: 'GetAddr'
+      getaddr: 'GetAddr',
+      xversion: 'Xversion'
     },
     commands: {}
   };

--- a/packages/bitcore-p2p-cash/lib/messages/commands/xversion.js
+++ b/packages/bitcore-p2p-cash/lib/messages/commands/xversion.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var Message = require('../message');
+var inherits = require('util').inherits;
+var bitcore = require('bitcore-lib-cash');
+var BufferUtil = bitcore.util.buffer;
+
+/**
+ * Transports a generic key-value map that holds the configuration and version parameters.
+ * https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/release/doc/xversionmessage.md
+ * Placeholder until it's actually made use of
+ * @extends Message
+ * @constructor
+ */
+function XversionMessage(arg, options) {
+  Message.call(this, options);
+  this.command = 'Xversion';
+}
+inherits(XversionMessage, Message);
+
+XversionMessage.prototype.setPayload = function() {};
+
+XversionMessage.prototype.getPayload = function() {
+  return BufferUtil.EMPTY_BUFFER;
+};
+
+module.exports = XversionMessage;


### PR DESCRIPTION
xversion is a new message type in BUCash 1.5.1, this patch prevents bitcore error when used with it.