### PR TITLE
Switching back to splice, to avoid bloat and garbage collection time

### DIFF
--- a/packages/bitcore-node/src/models/events.ts
+++ b/packages/bitcore-node/src/models/events.ts
@@ -37,8 +37,18 @@ export class EventModel extends BaseModel<IEvent> {
     return this.collection.insertOne({ payload: tx, emitTime: new Date(), type: 'tx' });
   }
 
+  public signalTxs(txs: IEvent.TxEvent[]) {
+    this.collection.insertMany(txs.map(tx => ({ payload: tx, emitTime: new Date(), type: 'tx' as 'tx' })));
+  }
+
   public signalAddressCoin(payload: IEvent.CoinEvent) {
     return this.collection.insertOne({ payload, emitTime: new Date(), type: 'coin' });
+  }
+
+  public signalAddressCoins(coins: IEvent.CoinEvent[]) {
+    return this.collection.insertMany(
+      coins.map(coin => ({ payload: coin, emitTime: new Date(), type: 'coin' as 'coin' }))
+    );
   }
 
   public getBlockTail(lastSeen: Date) {

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -14,6 +14,11 @@ import { SpentHeightIndicators } from '../types/Coin';
 import { Config } from '../services/config';
 import { EventStorage } from './events';
 
+const { onlyWalletEvents } = Config.get().services.event;
+function shouldFire(obj: { wallets?: Array<ObjectID> }) {
+  return !onlyWalletEvents || (onlyWalletEvents && obj.wallets && obj.wallets.length > 0);
+}
+
 const Chain = require('../chain');
 
 export type ITransaction = {
@@ -121,6 +126,7 @@ export class TransactionModel extends BaseModel<ITransaction> {
   }) {
     const mintOps = await this.getMintOps(params);
     const spendOps = this.getSpendOps({ ...params, mintOps });
+    const txOps = await this.addTransactions({ ...params, mintOps });
     await this.pruneMempool({
       chain: params.chain,
       network: params.network,
@@ -131,9 +137,20 @@ export class TransactionModel extends BaseModel<ITransaction> {
     logger.debug('Minting Coins', mintOps.length);
     if (mintOps.length) {
       await Promise.all(
-        partition(mintOps, mintOps.length / Config.get().maxPoolSize).map(mintBatch =>
-          CoinStorage.collection.bulkWrite(mintBatch, { ordered: false })
-        )
+        partition(mintOps, mintOps.length / Config.get().maxPoolSize).map(async mintBatch => {
+          await CoinStorage.collection.bulkWrite(mintBatch, { ordered: false });
+          if (params.height < SpentHeightIndicators.minimum) {
+            EventStorage.signalAddressCoins(
+              mintBatch
+              .map(coinOp => {
+                const address = coinOp.updateOne.update.$set.address;
+                const coin = { ...coinOp.updateOne.update.$set, ...coinOp.updateOne.filter };
+                return { address, coin };
+              })
+              .filter(({ coin }) => shouldFire(coin))
+            );
+          }
+        })
       );
     }
 
@@ -146,36 +163,18 @@ export class TransactionModel extends BaseModel<ITransaction> {
       );
     }
 
-    if (mintOps) {
-      const txOps = await this.addTransactions({ ...params, mintOps });
+    if (txOps.length) {
       logger.debug('Writing Transactions', txOps.length);
       await Promise.all(
-        partition(txOps, txOps.length / Config.get().maxPoolSize).map(txBatch =>
-          this.collection.bulkWrite(txBatch, { ordered: false })
-        )
+        partition(txOps, txOps.length / Config.get().maxPoolSize).map(async txBatch => {
+          await this.collection.bulkWrite(txBatch, { ordered: false });
+          if (params.height < SpentHeightIndicators.minimum) {
+            EventStorage.signalTxs(
+              txBatch.map(op => ({ ...op.updateOne.update.$set, ...op.updateOne.filter })).filter(shouldFire)
+            );
+          }
+        })
       );
-
-      // Create events for mempool txs
-      const { onlyWalletEvents } = Config.get().services.event;
-      function shouldFire(obj: { wallets?: Array<ObjectID> }) {
-        return !onlyWalletEvents || (onlyWalletEvents && obj.wallets && obj.wallets.length > 0);
-      }
-      if (params.height < SpentHeightIndicators.minimum) {
-        for (let op of txOps) {
-          const filter = op.updateOne.filter;
-          const tx = { ...op.updateOne.update.$set, ...filter };
-          if (shouldFire(tx)) {
-            EventStorage.signalTx(tx);
-          }
-        }
-        for (const coinOp of mintOps) {
-          const address = coinOp.updateOne.update.$set.address;
-          const coin = { ...coinOp.updateOne.update.$set, ...coinOp.updateOne.filter };
-          if (shouldFire(coin)) {
-            EventStorage.signalAddressCoin({ address, coin });
-          }
-        }
-      }
     }
   }
 

--- a/packages/bitcore-node/src/utils/partition.ts
+++ b/packages/bitcore-node/src/utils/partition.ts
@@ -1,4 +1,4 @@
 export function partition<T>(array: T[], n: number): T[][] {
   n = n > 0 ? Math.ceil(n) : 1;
-  return array.length ? [array.splice(0, n)].concat(partition(array.splice(n), n)) : [];
+  return array.length ? [array.splice(0, n)].concat(partition(array, n)) : [];
 }

--- a/packages/bitcore-node/src/utils/partition.ts
+++ b/packages/bitcore-node/src/utils/partition.ts
@@ -1,4 +1,4 @@
 export function partition<T>(array: T[], n: number): T[][] {
   n = n > 0 ? Math.ceil(n) : 1;
-  return array.length ? [array.slice(0, n)].concat(partition(array.slice(n), n)) : [];
+  return array.length ? [array.splice(0, n)].concat(partition(array.splice(n), n)) : [];
 }

--- a/packages/bitcore-node/test/unit/utils/partition.unit.ts
+++ b/packages/bitcore-node/test/unit/utils/partition.unit.ts
@@ -13,28 +13,28 @@ describe('Partition', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 0);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(testArr).to.deep.equal([]);
   });
 
   it('should handle one', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 1);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(testArr).to.deep.equal([]);
   });
 
   it('should handle two', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 2);
     expect(partitioned).to.deep.equal([[1, 2], [3, 4], [5]]);
-    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(testArr).to.deep.equal([]);
   });
 
   it('should handle between one and zero', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 0.15);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
+    expect(testArr).to.deep.equal([]);
   });
 
   it('should handle different sizes of arrays', () => {
@@ -50,7 +50,7 @@ describe('Partition', () => {
       if (!lastBatch) {
         console.error('Array partition fails with length', randomLen);
       }
-      expect(randomArr[randomArr.length - 1]).to.equal(lastBatch[lastBatch.length - 1]);
+      expect(randomArr).to.deep.equal([]);
     }
   });
 });


### PR DESCRIPTION
Memory usage is likely higher for 32 MB blocks due to not using splice. 
This MR reverts that, and makes the changes required to preserve the logic while using splice

# Before 
1028M/1569M+
```
Restting database
Generating blocks
Adding blocks
................................................................................
Benchmark for 80 (1 MB) blocks completed after 53.387 s
1.498492142281829 MB/s
0.6673375 Seconds/Block
Restting database
Generating blocks
Adding blocks
.....
Benchmark for 5 (32 MB) blocks completed after 88.812 s
1.801558347970995 MB/s
17.7624 Seconds/Block
```

# After 
```
Restting database
Generating blocks
Adding blocks
................................................................................
Benchmark for 80 (1 MB) blocks completed after 42.136 s
1.8986140117714068 MB/s
0.5267000000000001 Seconds/Block
Restting database
Generating blocks
Adding blocks
.....
Benchmark for 5 (32 MB) blocks completed after 88.958 s
1.7986015872659007 MB/s
17.7916 Seconds/Block
```