### PR TITLE
Fees cannot be calculated, since spends haven't been processed

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -174,28 +174,6 @@ export class TransactionModel extends BaseModel<ITransaction> {
           }
         })
       );
-
-      // Create events for mempool txs
-      const { onlyWalletEvents } = Config.get().services.event;
-      function shouldFire(obj: { wallets?: Array<ObjectID> }) {
-        return !onlyWalletEvents || (onlyWalletEvents && obj.wallets && obj.wallets.length > 0);
-      }
-      if (params.height < SpentHeightIndicators.minimum) {
-        for (let op of txOps) {
-          const filter = op.updateOne.filter;
-          const tx = { ...op.updateOne.update.$set, ...filter };
-          if (shouldFire(tx)) {
-            EventStorage.signalTx(tx);
-          }
-        }
-        for (const coinOp of mintOps) {
-          const address = coinOp.updateOne.update.$set.address;
-          const coin = { ...coinOp.updateOne.update.$set, ...coinOp.updateOne.filter };
-          if (shouldFire(coin)) {
-            EventStorage.signalAddressCoin({ address, coin });
-          }
-        }
-      }
     }
   }
 

--- a/packages/bitcore-node/src/utils/partition.ts
+++ b/packages/bitcore-node/src/utils/partition.ts
@@ -1,4 +1,4 @@
 export function partition<T>(array: T[], n: number): T[][] {
   n = n > 0 ? Math.ceil(n) : 1;
-  return array.length ? [array.splice(0, n)].concat(partition(array, n)) : [];
+  return array.length ? [array.slice(0, n)].concat(partition(array.slice(n), n)) : [];
 }

--- a/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
+++ b/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
@@ -84,6 +84,7 @@ async function checkWalletReceived(wallet: IWallet, txid: string, address: strin
   const broadcastedTransaction = await TransactionStorage.collection.findOne({ chain, network, txid });
   expect(broadcastedTransaction!.txid).to.eq(txid);
   expect(broadcastedTransaction!.fee).gt(0);
+  expect(broadcastedTransaction!.wallets[0].toHexString()).to.eq(wallet!._id!.toHexString());
 }
 
 describe('Wallet Benchmark', function() {

--- a/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
+++ b/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
@@ -15,6 +15,7 @@ import { Wallet } from 'bitcore-client';
 import { ICoin, CoinStorage } from '../../src/models/coin';
 import { MongoBound } from '../../src/models/base';
 import { ObjectId } from 'mongodb';
+import { TransactionStorage } from '../../src/models/transaction';
 
 const chain = 'BTC';
 const network = 'regtest';
@@ -79,6 +80,10 @@ async function checkWalletReceived(wallet: IWallet, txid: string, address: strin
   expect(broadcastedOutput!.address).to.eq(address);
   expect(broadcastedOutput!.wallets.length).to.eq(1);
   expect(broadcastedOutput!.wallets[0].toHexString()).to.eq(wallet!._id!.toHexString());
+
+  const broadcastedTransaction = await TransactionStorage.collection.findOne({ chain, network, txid });
+  expect(broadcastedTransaction!.txid).to.eq(txid);
+  expect(broadcastedTransaction!.fee).gt(0);
 }
 
 describe('Wallet Benchmark', function() {

--- a/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
+++ b/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
@@ -84,7 +84,10 @@ async function checkWalletReceived(wallet: IWallet, txid: string, address: strin
   const broadcastedTransaction = await TransactionStorage.collection.findOne({ chain, network, txid });
   expect(broadcastedTransaction!.txid).to.eq(txid);
   expect(broadcastedTransaction!.fee).gt(0);
-  expect(broadcastedTransaction!.wallets[0].toHexString()).to.eq(wallet!._id!.toHexString());
+
+  const txWallets = broadcastedTransaction!.wallets.map(w => w.toHexString());
+  expect(txWallets).to.eq(2);
+  expect(txWallets).to.include(wallet!._id!.toHexString());
 }
 
 describe('Wallet Benchmark', function() {

--- a/packages/bitcore-node/test/unit/utils/partition.unit.ts
+++ b/packages/bitcore-node/test/unit/utils/partition.unit.ts
@@ -51,7 +51,7 @@ describe('Partition', () => {
       if (!lastBatch) {
         console.error('Array partition fails with length', randomLen);
       }
-      expect(randomArr).to.deep.equal([]);
+      expect(randomArr.length).to.deep.equal(randomLen);
     }
   });
 });

--- a/packages/bitcore-node/test/unit/utils/partition.unit.ts
+++ b/packages/bitcore-node/test/unit/utils/partition.unit.ts
@@ -7,34 +7,35 @@ describe('Partition', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 5);
     expect(partitioned).to.deep.equal([[1, 2, 3, 4, 5]]);
+    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
   it('should handle 0', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 0);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([]);
+    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
   it('should handle one', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 1);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([]);
+    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
   it('should handle two', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 2);
     expect(partitioned).to.deep.equal([[1, 2], [3, 4], [5]]);
-    expect(testArr).to.deep.equal([]);
+    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
   it('should handle between one and zero', () => {
     let testArr = [1, 2, 3, 4, 5];
     let partitioned = partition(testArr, 0.15);
     expect(partitioned).to.deep.equal([[1], [2], [3], [4], [5]]);
-    expect(testArr).to.deep.equal([]);
+    expect(testArr).to.deep.equal([1, 2, 3, 4, 5]);
   });
 
   it('should handle different sizes of arrays', () => {


### PR DESCRIPTION
#2245 uncovered an error related to the previous splice change, where fees cannot be calculated until after spends have been processed.

For us to calculate fees, transactions must be processed after mints and spends.
Unfortunately we cannot use splice, since it would clear out the array of mints after partition was called.

We could use splice if we changed addTransaction to query for mints instead of referencing params.mintOps, but that would add an additional db query, which I feel would reduce the gains made from using splice in the first place.

We could also clone the mints, but I feel that would be replicating what slice is doing.