### PR TITLE
Server Maintenance for bws

### DIFF
--- a/packages/bitcore-wallet-client/lib/errors/spec.js
+++ b/packages/bitcore-wallet-client/lib/errors/spec.js
@@ -25,6 +25,9 @@ var errorSpec = [{
   name: 'CONNECTION_ERROR',
   message: 'Wallet service connection error.'
 }, {
+  name: 'MAINTENANCE_ERROR',
+  message: 'Wallet service is under maintenance.',
+}, {
   name: 'NOT_FOUND',
   message: 'Wallet service not found.'
 }, {

--- a/packages/bitcore-wallet-client/lib/request.js
+++ b/packages/bitcore-wallet-client/lib/request.js
@@ -111,6 +111,7 @@ Request.prototype.doRequest = function(method, url, args, useSession, cb) {
       }));
 
     if (res.status !== 200) {
+      if (res.status === 503) return cb(new Errors.MAINTENANCE_ERROR);
       if (res.status === 404)
         return cb(new Errors.NOT_FOUND);
 

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -48,7 +48,6 @@ module.exports = {
         // url: 'http://localhost:3000',
         url: 'https://api.bitcore.io',
       },
-
     },
   },
   pushNotificationsOpts: {
@@ -62,6 +61,9 @@ module.exports = {
   fiatRateServiceOpts: {
     defaultProvider: 'BitPay',
     fetchInterval: 60, // in minutes
+  },
+  maintenanceOpts: {
+    bwsIsLive: true,
   },
   // To use email notifications uncomment this:
   // emailOpts: {

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -33,25 +33,20 @@ module.exports = {
   blockchainExplorerOpts: {
     btc: {
       livenet: {
-        // url: 'https://api.bitcore.io',
-        url: 'http://localhost:3000',
+        url: 'https://api.bitcore.io',
       },
       testnet: {
-        // url: 'https://api.bitcore.io',
-        url: 'http://localhost:3000',
-        regtestEnabled: true,
+        url: 'https://api.bitcore.io',
+        regtestEnabled: false,
       },
     },
     bch: {
       livenet: {
-        // url: 'https://api.bitcore.io',
-        url: 'http://localhost:3000',
+        url: 'https://api.bitcore.io',
       },
       testnet: {
         // url: 'http://localhost:3000',
-        // url: 'https://api.bitcore.io',
-        url: 'http://localhost:3000',
-        regtestEnabled: true,
+         url: 'https://api.bitcore.io',
       },
     },
   },

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -33,20 +33,25 @@ module.exports = {
   blockchainExplorerOpts: {
     btc: {
       livenet: {
-        url: 'https://api.bitcore.io',
+        // url: 'https://api.bitcore.io',
+        url: 'http://localhost:3000',
       },
       testnet: {
-        url: 'https://api.bitcore.io',
-        regtestEnabled: false
+        // url: 'https://api.bitcore.io',
+        url: 'http://localhost:3000',
+        regtestEnabled: true,
       },
     },
     bch: {
       livenet: {
-        url: 'https://api.bitcore.io',
+        // url: 'https://api.bitcore.io',
+        url: 'http://localhost:3000',
       },
       testnet: {
         // url: 'http://localhost:3000',
-        url: 'https://api.bitcore.io',
+        // url: 'https://api.bitcore.io',
+        url: 'http://localhost:3000',
+        regtestEnabled: true,
       },
     },
   },
@@ -63,7 +68,7 @@ module.exports = {
     fetchInterval: 60, // in minutes
   },
   maintenanceOpts: {
-    bwsIsLive: true,
+    maintenanceMode: false,
   },
   // To use email notifications uncomment this:
   // emailOpts: {

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -7,6 +7,7 @@ import { Stats } from './stats';
 
 const bodyParser = require('body-parser');
 const compression = require('compression');
+const config = require('../config');
 const RateLimit = require('express-rate-limit');
 const Common = require('./common');
 const Defaults = Common.Defaults;
@@ -48,6 +49,17 @@ export class ExpressApp {
       res.setHeader('x-service-version', WalletService.getServiceVersion());
       next();
     });
+
+    this.app.use((req,res,next) => {
+      if((config.maintenanceOpts.bwsIsLive === false)) {
+        // send a 503 error, with a message to the bitpay status page
+        let errorCode = 503;
+        res.status(errorCode).json({code: errorCode, message: 'Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status.'}).end();
+      } else {
+        next();
+      }
+    });
+    
     const allowCORS = (req, res, next) => {
       if ('OPTIONS' == req.method) {
         res.sendStatus(200);

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -49,17 +49,7 @@ export class ExpressApp {
       res.setHeader('x-service-version', WalletService.getServiceVersion());
       next();
     });
-    this.app.use((req, res, next) => {
-      if((config.maintenanceOpts.maintenanceMode === true)) {
-        // send a 503 error, with a message to the bitpay status page
-        let errorCode = 503;
-        let errorMessage = 'Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status.';
-        let err = {code: errorCode, message: errorMessage };
-        res.status(errorCode).json(err).end();
-      } else {
-        next();
-      }
-    });
+    
     const allowCORS = (req, res, next) => {
       if ('OPTIONS' == req.method) {
         res.sendStatus(200);
@@ -86,6 +76,18 @@ export class ExpressApp {
         limit: POST_LIMIT
       })
     );
+
+    this.app.use((req, res, next) => {
+      if((config.maintenanceOpts.maintenanceMode === true)) {
+        // send a 503 error, with a message to the bitpay status page
+        let errorCode = 503;
+        let errorMessage = 'BWS down for maintenance';
+        let err = {code: errorCode, message: errorMessage};
+        res.status(503).send({code: errorCode, message: errorMessage});
+      } else {
+        next();
+      }
+    });
 
     if (opts.disableLogs) {
       log.level = 'silent';

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -49,9 +49,8 @@ export class ExpressApp {
       res.setHeader('x-service-version', WalletService.getServiceVersion());
       next();
     });
-
-    this.app.use((req,res,next) => {
-      if((config.maintenanceOpts.bwsIsLive === false)) {
+    this.app.use((req, res, next) => {
+      if ((config.maintenanceOpts.bwsIsLive === false)) {
         // send a 503 error, with a message to the bitpay status page
         let errorCode = 503;
         res.status(errorCode).json({code: errorCode, message: 'Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status.'}).end();
@@ -59,7 +58,6 @@ export class ExpressApp {
         next();
       }
     });
-    
     const allowCORS = (req, res, next) => {
       if ('OPTIONS' == req.method) {
         res.sendStatus(200);

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -50,10 +50,12 @@ export class ExpressApp {
       next();
     });
     this.app.use((req, res, next) => {
-      if ((config.maintenanceOpts.bwsIsLive === false)) {
+      if((config.maintenanceOpts.maintenanceMode === true)) {
         // send a 503 error, with a message to the bitpay status page
         let errorCode = 503;
-        res.status(errorCode).json({code: errorCode, message: 'Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status.'}).end();
+        let errorMessage = 'Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status.';
+        let err = {code: errorCode, message: errorMessage };
+        res.status(errorCode).json(err).end();
       } else {
         next();
       }

--- a/packages/bitcore-wallet-service/test/expressapp.js
+++ b/packages/bitcore-wallet-service/test/expressapp.js
@@ -298,6 +298,46 @@ describe('ExpressApp', function() {
             });
           });
         });
+
+        it('Server under maintenance check, should return 503 status code', function(done) {
+          var server = {
+            getStatus: sinon.stub().callsArgWith(1, null, {}),
+          };
+          var {ExpressApp: TestExpressApp} = proxyquire('../ts_build/lib/expressapp', {
+            './server': {
+              WalletService:  {
+                initialize: sinon.stub().callsArg(1),
+                getServiceVersion: WalletService.getServiceVersion,
+                getInstanceWithAuth: sinon.stub().callsArgWith(1, null, server),
+              }
+            }
+          });
+
+          start(TestExpressApp, function(err, data) {
+            
+            var requestOptions = {
+              //test link, for either a 503 or 200 code response
+              url: testHost + ':' + testPort + config.basePath + "/v2/wallets",
+              headers: {
+                'x-identity': 'identity',
+                'x-signature': 'signature'
+              }
+            };
+  
+            request(requestOptions, function(err,res,body){
+              if(config.maintenanceOpts.bwsIsLive === false) {
+                should.not.exist(err);
+                res.statusCode.should.equal(503);
+                body.should.equal(`{"code":503,"message":"Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status."}`);
+              } else {
+                should.not.exist(err);
+                res.statusCode.should.equal(200);
+              }
+              done();
+            });
+          });
+        });
+        
       });
     });
   });

--- a/packages/bitcore-wallet-service/test/expressapp.js
+++ b/packages/bitcore-wallet-service/test/expressapp.js
@@ -298,7 +298,6 @@ describe('ExpressApp', function() {
             });
           });
         });
-
         it('Server under maintenance check, should return 503 status code', function(done) {
           var server = {
             getStatus: sinon.stub().callsArgWith(1, null, {}),
@@ -312,9 +311,7 @@ describe('ExpressApp', function() {
               }
             }
           });
-
           start(TestExpressApp, function(err, data) {
-            
             var requestOptions = {
               //test link, for either a 503 or 200 code response
               url: testHost + ':' + testPort + config.basePath + "/v2/wallets",
@@ -323,7 +320,6 @@ describe('ExpressApp', function() {
                 'x-signature': 'signature'
               }
             };
-  
             request(requestOptions, function(err,res,body){
               if(config.maintenanceOpts.bwsIsLive === false) {
                 should.not.exist(err);
@@ -337,7 +333,6 @@ describe('ExpressApp', function() {
             });
           });
         });
-        
       });
     });
   });

--- a/packages/bitcore-wallet-service/test/expressapp.js
+++ b/packages/bitcore-wallet-service/test/expressapp.js
@@ -321,7 +321,7 @@ describe('ExpressApp', function() {
               }
             };
             request(requestOptions, function(err,res,body){
-              if(config.maintenanceOpts.bwsIsLive === false) {
+              if(config.maintenanceOpts.maintenanceMode === true) {
                 should.not.exist(err);
                 res.statusCode.should.equal(503);
                 body.should.equal(`{"code":503,"message":"Bitcore Wallet Service is currently under maintenance. Please periodically check https://status.bitpay.com/ to stay up to date with our current status."}`);


### PR DESCRIPTION
This PR adds better server maintenance to bws, by sending a 503 error code and message with a link to BitPay's status page any time Bitcoin Wallet Service is down for maintenance.