### PR TITLE
rm "generate" rpc call

### DIFF
--- a/packages/bitcore-node/docs/test-guide.md
+++ b/packages/bitcore-node/docs/test-guide.md
@@ -1,0 +1,6 @@
+# Set up to run the tests.
+
+  1. copy ../../bitcore-test.config.json to ../../bitcore.config.json
+  2. run mongod
+  3. run bitcoin-code's bitcoind (tested with version v0.19) with:
+      `./bitcoind -regtest -rpcpassword=bitcorenodetest -rpcuser=local321 --rpcport=18332 --addresstype=legacy`

--- a/packages/bitcore-node/src/rpc.ts
+++ b/packages/bitcore-node/src/rpc.ts
@@ -141,10 +141,6 @@ export class AsyncRPC {
     return (await this.call('getblock', [hash, 2])) as RPCBlock<RPCTransaction>;
   }
 
-  async generate(n: number): Promise<string[]> {
-    return (await this.call('generate', [n])) as string[];
-  }
-
   async getnewaddress(account: string): Promise<string> {
     return (await this.call('getnewaddress', [account])) as string;
   }

--- a/packages/bitcore-node/src/rpc.ts
+++ b/packages/bitcore-node/src/rpc.ts
@@ -145,6 +145,17 @@ export class AsyncRPC {
     return (await this.call('getnewaddress', [account])) as string;
   }
 
+  async signrawtx(txs: string): Promise<any> {
+    try {
+      const ret =  await this.call('signrawtransactionwithwallet', [txs]);
+      return ret;
+    } catch (e) {
+      if (!e.code || e.code != -32601) return Promise.reject(e);
+      return  await this.call('signrawtransaction', [txs]);
+    }
+  };
+
+
   async transaction(txid: string, block?: string): Promise<RPCTransaction> {
     const args = [txid, true];
     if (block) {

--- a/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
+++ b/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
@@ -92,7 +92,7 @@ async function checkWalletReceived(receivingWallet: IWallet, txid: string, addre
 }
 
 describe('Wallet Benchmark', function() {
-  this.timeout(50000);
+  this.timeout(500000);
   before(async () => {
     await resetDatabase();
   });
@@ -122,34 +122,43 @@ describe('Wallet Benchmark', function() {
 
       const address1 = await rpc.getnewaddress('');
       const address2 = await rpc.getnewaddress('');
-      await rpc.call('generatetoaddress', [1, address1]);
-      await rpc.call('generatetoaddress', [1, address2]);
-      await rpc.generate(100);
-      await p2pWorker.syncDone();
-      const wallet1 = await createWallet([address1], 0, network);
-      const wallet2 = await createWallet([address2], 1, network);
-      const dbWallet1 = await checkWalletExists(wallet1.authPubKey, address1);
-      const dbWallet2 = await checkWalletExists(wallet2.authPubKey, address2);
-      const utxos = await checkWalletUtxos(wallet1, address1);
-      await checkWalletUtxos(wallet2, address2);
-      const tx = await rpc.call('createrawtransaction', [
-        utxos.map(utxo => ({ txid: utxo.mintTxid, vout: utxo.mintIndex })),
-        { [address1]: 0.1, [address2]: 0.1 }
-      ]);
-      const fundedTx = await rpc.call('fundrawtransaction', [tx]);
-      const signedTx = await rpc.call('signrawtransaction', [fundedTx.hex]);
-      const broadcastedTx = await rpc.call('sendrawtransaction', [signedTx.hex]);
-      while (!seenCoins.has(broadcastedTx)) {
+      const anAddress = 'mkzAfSHtmTh5Xsc352jf6TBPj55Lne5g21';
+
+      try {
+        await rpc.call('generatetoaddress', [1, address1]);
+        await rpc.call('generatetoaddress', [1, address2]);
+        await rpc.call('generatetoaddress', [100, anAddress]);
+        await p2pWorker.syncDone();
+
+        const wallet1 = await createWallet([address1], 0, network);
+        const wallet2 = await createWallet([address2], 1, network);
+        const dbWallet1 = await checkWalletExists(wallet1.authPubKey, address1);
+        const dbWallet2 = await checkWalletExists(wallet2.authPubKey, address2);
+        const utxos = await checkWalletUtxos(wallet1, address1);
+        await checkWalletUtxos(wallet2, address2);
+        const tx = await rpc.call('createrawtransaction', [
+          utxos.map(utxo => ({ txid: utxo.mintTxid, vout: utxo.mintIndex })),
+          { [address1]: 0.1, [address2]: 0.1 }
+        ]);
+        const fundedTx = await rpc.call('fundrawtransaction', [tx]);
+        const signedTx = await rpc.call('signrawtransactionwithwallet', [fundedTx.hex]);
+        const broadcastedTx = await rpc.call('sendrawtransaction', [signedTx.hex]);
+        while (!seenCoins.has(broadcastedTx)) {
+          console.log('...WAITING...'); // TODO
+          await wait(1000);
+        }
+        await verifyCoinSpent(utxos[0], broadcastedTx, dbWallet1!);
+        await checkWalletReceived(dbWallet1!, broadcastedTx, address1, dbWallet2!);
+        await checkWalletReceived(dbWallet2!, broadcastedTx, address2, dbWallet1!);
         await wait(1000);
+        await socket.disconnect();
+        await p2pWorker.stop();
+        await Event.stop();
+        await Api.stop();
+      } catch (e) {
+        console.log('Error : ', e);
+        expect(e).to.be.undefined;
       }
-      await verifyCoinSpent(utxos[0], broadcastedTx, dbWallet1!);
-      await checkWalletReceived(dbWallet1!, broadcastedTx, address1, dbWallet2!);
-      await checkWalletReceived(dbWallet2!, broadcastedTx, address2, dbWallet1!);
-      await wait(1000);
-      await socket.disconnect();
-      await p2pWorker.stop();
-      await Event.stop();
-      await Api.stop();
     });
 
     it('should import all addresses and verify in database while below 300 mb of heapUsed memory', async () => {
@@ -160,20 +169,22 @@ describe('Wallet Benchmark', function() {
       let mediumAddressBatch = new Array<string>();
       let largeAddressBatch = new Array<string>();
 
+      console.log('Generating small batch of addresses');
       for (let i = 0; i < 10; i++) {
         let address = await rpc.getnewaddress('');
         smallAddressBatch.push(address);
       }
 
+      console.log('Generating medium batch of addresses');
       expect(smallAddressBatch.length).to.deep.equal(10);
 
       for (let i = 0; i < 100; i++) {
         let address = await rpc.getnewaddress('');
         mediumAddressBatch.push(address);
       }
-
       expect(mediumAddressBatch.length).to.deep.equal(100);
 
+      console.log('Generating large batch of addresses');
       for (let i = 0; i < 1000; i++) {
         let address = await rpc.getnewaddress('');
         largeAddressBatch.push(address);
@@ -181,6 +192,7 @@ describe('Wallet Benchmark', function() {
 
       expect(largeAddressBatch.length).to.deep.equal(1000);
 
+      console.log('Checking');
       const importedWallet1 = await createWallet(smallAddressBatch, 0, network);
       const importedWallet2 = await createWallet(mediumAddressBatch, 1, network);
       const importedWallet3 = await createWallet(largeAddressBatch, 2, network);

--- a/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
+++ b/packages/bitcore-node/test/integration/wallet-benchmark.integration.ts
@@ -141,7 +141,7 @@ describe('Wallet Benchmark', function() {
           { [address1]: 0.1, [address2]: 0.1 }
         ]);
         const fundedTx = await rpc.call('fundrawtransaction', [tx]);
-        const signedTx = await rpc.call('signrawtransactionwithwallet', [fundedTx.hex]);
+        const signedTx = await rpc.signrawtx(fundedTx.hex);
         const broadcastedTx = await rpc.call('sendrawtransaction', [signedTx.hex]);
         while (!seenCoins.has(broadcastedTx)) {
           console.log('...WAITING...'); // TODO

--- a/packages/bitcore-node/test/integration/websocket.integration.ts
+++ b/packages/bitcore-node/test/integration/websocket.integration.ts
@@ -14,6 +14,7 @@ const network = 'regtest';
 const chainConfig = config.chains[chain][network];
 const creds = chainConfig.rpc;
 const rpc = new AsyncRPC(creds.username, creds.password, creds.host, creds.port);
+const anAddress = 'mkzAfSHtmTh5Xsc352jf6TBPj55Lne5g21';
 
 let p2pWorker: P2pWorker;
 
@@ -42,15 +43,15 @@ describe('Websockets', function() {
   it('should get a new block when one is generated', async () => {
     await p2pWorker.start();
 
-    await rpc.generate(5);
+    await rpc.call('generatetoaddress', [5, anAddress]);
     await p2pWorker.syncDone();
     const beforeGenTip = await BlockStorage.getLocalTip({ chain, network });
     expect(beforeGenTip).to.not.eq(null);
 
     if (beforeGenTip && beforeGenTip.height && beforeGenTip.height < 100) {
-      await rpc.generate(100);
+      await rpc.call('generatetoaddress', [100, anAddress]);
     }
-    await rpc.generate(1);
+    await rpc.call('generatetoaddress', [1, anAddress]);
     await p2pWorker.syncDone();
     await wait(1000);
     const afterGenTip = await BlockStorage.getLocalTip({ chain, network });
@@ -88,7 +89,7 @@ describe('Websockets', function() {
     });
 
     await p2pWorker.start();
-    await rpc.generate(1);
+    await rpc.call('generatetoaddress', [1, anAddress]);
     await sawEvents;
     await p2pWorker.stop();
     await socket.disconnect();


### PR DESCRIPTION
  - Removes `generate` RPC call to make tests run with bitcoin-core v0.19 (and still runs with older versions).
  - adds small test doc
