### PR TITLE
BWC exposes crypto-wallet-core

### DIFF
--- a/packages/bitcore-wallet-client/lib/index.js
+++ b/packages/bitcore-wallet-client/lib/index.js
@@ -7,7 +7,7 @@
  * Client API.
  * @alias module:Client.API
  */
-var client = module.exports = require('./api');
+var client = (module.exports = require('./api'));
 
 /**
  * Verifier module.
@@ -20,3 +20,4 @@ client.sjcl = require('sjcl');
 // Expose bitcore
 client.Bitcore = require('bitcore-lib');
 client.BitcoreCash = require('bitcore-lib-cash');
+client.Core = require('crypto-wallet-core');

--- a/packages/bitcore-wallet-client/package.json
+++ b/packages/bitcore-wallet-client/package.json
@@ -29,6 +29,7 @@
     "bip38": "^1.3.0",
     "bitcore-lib": "^8.3.4",
     "bitcore-lib-cash": "^8.3.4",
+    "crypto-wallet-core": "^8.3.4",
     "bitcore-mnemonic": "^8.3.4",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.11",


### PR DESCRIPTION
BWC exposes Crypto-Wallet-Core through client.Core for bwcProvider in Copay.

This can be used for address derivation, transaction creation/signing, valid address checking that is current missing as there is no bitcore-lib equivalent of ETH.

This allows us to implement ETH related functions without touching bitcore-lib.