### PR TITLE
Update Server maintenance for bws.

### DIFF
--- a/packages/bitcore-wallet-client/lib/errors/spec.js
+++ b/packages/bitcore-wallet-client/lib/errors/spec.js
@@ -25,6 +25,9 @@ var errorSpec = [{
   name: 'CONNECTION_ERROR',
   message: 'Wallet service connection error.'
 }, {
+  name: 'MAINTENANCE_ERROR',
+  message: 'Wallet service is under maintenance.',
+}, {
   name: 'NOT_FOUND',
   message: 'Wallet service not found.'
 }, {

--- a/packages/bitcore-wallet-client/lib/request.js
+++ b/packages/bitcore-wallet-client/lib/request.js
@@ -111,6 +111,7 @@ Request.prototype.doRequest = function(method, url, args, useSession, cb) {
       }));
 
     if (res.status !== 200) {
+      if (res.status === 503) return cb(new Errors.MAINTENANCE_ERROR);
       if (res.status === 404)
         return cb(new Errors.NOT_FOUND);
 

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -63,6 +63,9 @@ module.exports = {
     defaultProvider: 'BitPay',
     fetchInterval: 60, // in minutes
   },
+  maintenanceOpts: {
+    maintenanceMode: false,
+  },
   // To use email notifications uncomment this:
   // emailOpts: {
   //  host: 'localhost',

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -7,6 +7,7 @@ import { Stats } from './stats';
 
 const bodyParser = require('body-parser');
 const compression = require('compression');
+const config = require('../config');
 const RateLimit = require('express-rate-limit');
 const Common = require('./common');
 const Defaults = Common.Defaults;
@@ -74,6 +75,17 @@ export class ExpressApp {
         limit: POST_LIMIT
       })
     );
+
+    this.app.use((req, res, next) => {
+      if(config.maintenanceOpts.maintenanceMode === true) {
+        // send a 503 error, with a message to the bitpay status page
+        let errorCode = 503;
+        let errorMessage = 'BWS down for maintenance';
+        res.status(503).send({code: errorCode, message: errorMessage});
+      } else {
+        next();
+      }
+    });
 
     if (opts.disableLogs) {
       log.level = 'silent';


### PR DESCRIPTION
This PR adds better server maintenance to bws, by sending a 503 error code and message with a link to BitPay's status page any time Bitcoin Wallet Service is down for maintenance. 