### PR TITLE
Fix CWC.Transaction.sign to non async

### DIFF
--- a/packages/crypto-wallet-core/src/transactions/btc/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/btc/index.ts
@@ -28,8 +28,8 @@ export class BTCTxProvider {
     return filteredUtxos;
   }
 
-  async create({ recipients, utxos = [], change, wallet, fee = 20000 }) {
-    change = change || (await wallet.deriveAddress(wallet.addressIndex, true));
+  create({ recipients, utxos = [], change, wallet, fee = 20000 }) {
+    change = change || (wallet.deriveAddress(wallet.addressIndex, true));
 
     const filteredUtxos = this.selectCoins(recipients, utxos, fee);
     const btcUtxos = filteredUtxos.map(utxo => {
@@ -48,16 +48,16 @@ export class BTCTxProvider {
     return tx.uncheckedSerialize();
   }
 
-  async sign(params: { tx: string; keys: Array<Key>; utxos: any[] }) {
+  sign(params: { tx: string; keys: Array<Key>; utxos: any[] }) {
     const { tx, keys } = params;
     let utxos = params.utxos || [];
-    let inputAddresses = await this.getSigningAddresses({ tx, utxos });
+    let inputAddresses = this.getSigningAddresses({ tx, utxos });
     let bitcoreTx = new this.lib.Transaction(tx);
-    let applicableUtxos = await this.getRelatedUtxos({
+    let applicableUtxos = this.getRelatedUtxos({
       outputs: bitcoreTx.inputs,
       utxos
     });
-    const outputs = await this.getOutputsFromTx({ tx: bitcoreTx });
+    const outputs = this.getOutputsFromTx({ tx: bitcoreTx });
     let newTx = new this.lib.Transaction().from(applicableUtxos).to(outputs);
     const privKeys = _.uniq(keys.map(key => key.privKey.toString()));
     const signedTx = newTx.sign(privKeys).toString();

--- a/packages/crypto-wallet-core/src/transactions/eth/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth/index.ts
@@ -31,7 +31,6 @@ export class ETHTxProvider {
     const bufferKey = Buffer.from(key.privKey, 'hex');
     rawTx.sign(bufferKey);
     const serializedTx = rawTx.serialize();
-
     return '0x' + serializedTx.toString('hex');
   }
 }

--- a/packages/crypto-wallet-core/src/transactions/eth/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth/index.ts
@@ -2,7 +2,7 @@ import EthereumTx from 'ethereumjs-tx';
 import { Key } from '../../derivation';
 const utils = require('web3-utils');
 export class ETHTxProvider {
-  async create(params: {
+  create(params: {
     recipients: Array<{ address: string; amount: string }>;
     from: string;
     nonce: number;
@@ -24,17 +24,14 @@ export class ETHTxProvider {
     return rawTx;
   }
 
-  async sign(params: { tx: string; key: Key; from: string }) {
+  sign(params: { tx: string; key: Key; from: string }) {
     const { tx, key, from } = params;
     const rawTx = new EthereumTx(tx);
     const address = from.toLowerCase();
-    try {
-      const bufferKey = Buffer.from(key.privKey, 'hex');
-      rawTx.sign(bufferKey);
-      const serializedTx = rawTx.serialize();
-      return '0x' + serializedTx.toString('hex');
-    } catch (err) {
-      console.log(err);
-    }
+    const bufferKey = Buffer.from(key.privKey, 'hex');
+    rawTx.sign(bufferKey);
+    const serializedTx = rawTx.serialize();
+
+    return '0x' + serializedTx.toString('hex');
   }
 }

--- a/packages/crypto-wallet-core/src/transactions/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/index.ts
@@ -17,7 +17,7 @@ export class TransactionsProxy {
     return this.get(params).create(params);
   }
 
-  async sign(params): Promise<any> {
+  sign(params): string {
     return this.get(params).sign(params);
   }
 }


### PR DESCRIPTION
- Fix issue where `CWC.Transactions.sign` returns a Promise instead of a signed rawTx.

- changed sign to a non async function in CWC.Transactions