### PR TITLE
fix(node): prevent ERR_BUFFER_OUT_OF_BOUNDS when handling large BCH blocks

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -1,5 +1,5 @@
 import { CoinStorage } from './coin';
-import { WalletAddressStorage } from './walletAddress';
+import { WalletAddressStorage, IWalletAddress } from './walletAddress';
 import { partition } from '../utils/partition';
 import { ObjectID } from 'bson';
 import { TransformOptions } from '../types/TransformOptions';
@@ -428,14 +428,25 @@ export class TransactionModel extends BaseModel<ITransaction> {
 
     const walletConfig = Config.for('api').wallets;
     if (initialSyncComplete || (walletConfig && walletConfig.allowCreationBeforeCompleteSync)) {
-      let mintOpsAddresses = {};
+      let mintOpsAddressesSet = {};
       for (const mintOp of mintOps) {
-        mintOpsAddresses[mintOp.updateOne.update.$set.address] = true;
+        mintOpsAddressesSet[mintOp.updateOne.update.$set.address] = true;
       }
-      let wallets = await WalletAddressStorage.collection
-        .find({ address: { $in: Object.keys(mintOpsAddresses) }, chain, network }, { batchSize: 100 })
-        .project({ wallet: 1, address: 1 })
-        .toArray();
+      let mintOpsAddresses = Object.keys(mintOpsAddressesSet);
+
+      let wallets: IWalletAddress[] = [];
+
+      await Promise.all(
+        partition(mintOpsAddresses, mintOpsAddresses.length / Config.get().maxPoolSize).map(async addressesBatch => {
+          let partialWallets = await WalletAddressStorage.collection
+            .find({ address: { $in: addressesBatch }, chain, network }, { batchSize: 100 })
+            .project({ wallet: 1, address: 1 })
+            .toArray();
+
+          wallets = wallets.concat(partialWallets);
+        })
+      );
+
       if (wallets.length) {
         mintOps = mintOps.map(mintOp => {
           let transformedWallets = wallets


### PR DESCRIPTION
This is one of the fixes addressed in #2375. It works by splitting the mongo `find` query based on `mintOpsAddresses` to prevent an `ERR_BUFFER_OUT_OF_BOUNDS` that's caused by a very large list of `mintOpsAddresses`.

Please check #2375 for more details on the problem and feel free to suggest other alternative solutions