### PR TITLE
Ignore bws broadcast error if paypro post succeeds

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,26 @@
-FROM amio/node-chrome
+FROM node:10
+
+# Install Chrome
+
+RUN echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' > /etc/apt/sources.list.d/chrome.list
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y \
+        google-chrome-stable
+
+ENV CHROME_BIN /usr/bin/google-chrome
+
+# Log versions
+
+RUN set -x \
+    && node -v \
+    && npm -v \
+    && google-chrome --version
+
+
 RUN npm i -g npm@6.4.1
 
 WORKDIR /bitcore

--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -1748,7 +1748,10 @@ export class API extends EventEmitter {
               log.debug('Merchant memo:', memo);
             }
             this._doBroadcast(txp, (err2, txp) => {
-              return cb(err2, txp, memo, err);
+              if (err2) {
+                log.error('Error broadcasting payment', err2);
+              }
+              return cb(null, txp, memo);
             });
           }
         );


### PR DESCRIPTION
If the merchant is ok with the transaction, let's treat it as successful even if the bws broadcast step returns an error.