### PR TITLE
Create and spend from P2WPKH, P2SH-P2WPKH, and P2WSH

### DIFF
--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -44,11 +44,12 @@ var PublicKey = require('./publickey');
  *
  * @param {*} data - The encoded data in various formats
  * @param {Network|String|number=} network - The network: 'livenet' or 'testnet'
- * @param {string=} type - The type of address: 'script' or 'pubkey'
+ * @param {string=} type - The type of address: 'scripthash', 'pubkeyhash', witnessscripthash or 'witnesspubkeyhash'
+ * @param {string=} multisigType - The type of multisig: 'scripthash' or 'witnessscripthash'
  * @returns {Address} A new valid and frozen instance of an Address
  * @constructor
  */
-function Address(data, network, type) {
+function Address(data, network, type, multisigType) {
   /* jshint maxcomplexity: 12 */
   /* jshint maxstatements: 20 */
 
@@ -57,7 +58,7 @@ function Address(data, network, type) {
   }
 
   if (_.isArray(data) && _.isNumber(network)) {
-    return Address.createMultisig(data, network, type);
+    return Address.createMultisig(data, network, type, false, multisigType);
   }
 
   if (data instanceof Address) {
@@ -109,7 +110,7 @@ Address.prototype._classifyArguments = function(data, network, type) {
   } else if ((data instanceof Buffer || data instanceof Uint8Array) && data.length >= 21) {
     return Address._transformBuffer(data, network, type);
   } else if (data instanceof PublicKey) {
-    return Address._transformPublicKey(data);
+    return Address._transformPublicKey(data, network, type);
   } else if (data instanceof Script) {
     return Address._transformScript(data, network);
   } else if (typeof(data) === 'string') {
@@ -258,16 +259,24 @@ Address._transformBuffer = function(buffer, network, type) {
  * Internal function to transform a {@link PublicKey}
  *
  * @param {PublicKey} pubkey - An instance of PublicKey
+ * @param {string} type - Either 'pubkeyhash', 'witnesspubkeyhash', or 'scripthash'
  * @returns {Object} An object with keys: hashBuffer, type
  * @private
  */
-Address._transformPublicKey = function(pubkey) {
+Address._transformPublicKey = function(pubkey, network, type) {
   var info = {};
   if (!(pubkey instanceof PublicKey)) {
     throw new TypeError('Address must be an instance of PublicKey.');
   }
-  info.hashBuffer = Hash.sha256ripemd160(pubkey.toBuffer());
-  info.type = Address.PayToPublicKeyHash;
+  if (!pubkey.compressed && (type === Address.PayToScriptHash || type === Address.PayToWitnessPublicKeyHash)) {
+    throw new TypeError('Witness addresses must use compressed public keys.');
+  }
+  if (type === Address.PayToScriptHash) {
+    info.hashBuffer = Hash.sha256ripemd160(Script.buildWitnessV0Out(pubkey).toBuffer());
+  } else {
+    info.hashBuffer = Hash.sha256ripemd160(pubkey.toBuffer());
+  }
+  info.type = type || Address.PayToPublicKeyHash;
   return info;
 };
 
@@ -298,15 +307,24 @@ Address._transformScript = function(script, network) {
  * @param {number} threshold - the number of signatures needed to release the funds
  * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
  * @param {boolean=} nestedWitness - if the address uses a nested p2sh witness
+ * @param {string} type - Either 'scripthash' or 'witnessscripthash'. If nestedWitness is set, then this is ignored
  * @return {Address}
  */
-Address.createMultisig = function(publicKeys, threshold, network, nestedWitness) {
+Address.createMultisig = function(publicKeys, threshold, network, nestedWitness, type) {
   network = network || publicKeys[0].network || Networks.defaultNetwork;
+  if (nestedWitness || type === Address.PayToWitnessScriptHash) {
+    publicKeys = _.map(publicKeys, PublicKey);
+    for (var i = 0; i < publicKeys.length; i++) {
+      if (!publicKeys[i].compressed) {
+        throw new TypeError('Witness addresses must use compressed public keys.');
+      }
+    }
+  }
   var redeemScript = Script.buildMultisigOut(publicKeys, threshold);
   if (nestedWitness) {
     return Address.payingTo(Script.buildWitnessMultisigOutFromScript(redeemScript), network);
   }
-  return Address.payingTo(redeemScript, network);
+  return Address.payingTo(redeemScript, network, type);
 };
 
 /**
@@ -352,10 +370,11 @@ Address._transformString = function(data, network, type) {
  *
  * @param {PublicKey} data
  * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+ * @param {string} type - Either 'pubkeyhash', 'witnesspubkeyhash', or 'scripthash'
  * @returns {Address} A new valid and frozen instance of an Address
  */
-Address.fromPublicKey = function(data, network) {
-  var info = Address._transformPublicKey(data);
+Address.fromPublicKey = function(data, network, type) {
+  var info = Address._transformPublicKey(data, network, type);
   network = network || Networks.defaultNetwork;
   return new Address(info.hashBuffer, network, info.type);
 };
@@ -377,12 +396,17 @@ Address.fromPublicKeyHash = function(hash, network) {
  *
  * @param {Buffer} hash - An instance of buffer of the hash
  * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+ * @param {string} type - Either 'scripthash' or 'witnessscripthash'
  * @returns {Address} A new valid and frozen instance of an Address
  */
-Address.fromScriptHash = function(hash, network) {
+Address.fromScriptHash = function(hash, network, type) {
   $.checkArgument(hash, 'hash parameter is required');
   var info = Address._transformHash(hash);
-  return new Address(info.hashBuffer, network, Address.PayToScriptHash);
+  if (type === Address.PayToWitnessScriptHash && hash.length !== 32) {
+      throw new TypeError('Address hashbuffer must be exactly 32 bytes for v0 witness script hash.');
+  }
+  var type = type || Address.PayToScriptHash;
+  return new Address(info.hashBuffer, network, type);
 };
 
 /**
@@ -393,12 +417,20 @@ Address.fromScriptHash = function(hash, network) {
  *
  * @param {Script} script - An instance of Script
  * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+ * @param {string} type - Either 'scripthash' or 'witnessscripthash'
  * @returns {Address} A new valid and frozen instance of an Address
  */
-Address.payingTo = function(script, network) {
+Address.payingTo = function(script, network, type) {
   $.checkArgument(script, 'script is required');
   $.checkArgument(script instanceof Script, 'script must be instance of Script');
-  return Address.fromScriptHash(Hash.sha256ripemd160(script.toBuffer()), network);
+  var hash;
+  if (type === Address.PayToWitnessScriptHash) {
+    hash = Hash.sha256(script.toBuffer());
+  } else {
+    hash = Hash.sha256ripemd160(script.toBuffer());
+  }
+  var type = type || Address.PayToScriptHash;
+  return Address.fromScriptHash(hash, network, type);
 };
 
 /**

--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -268,6 +268,9 @@ Address._transformPublicKey = function(pubkey, network, type) {
   if (!(pubkey instanceof PublicKey)) {
     throw new TypeError('Address must be an instance of PublicKey.');
   }
+  if (type && type !== Address.PayToScriptHash && type !== Address.PayToWitnessPublicKeyHash && type !== Address.PayToPublicKeyHash) {
+    throw new TypeError('Type must be either pubkeyhash, witnesspubkeyhash, or scripthash to transform public key.');
+  }
   if (!pubkey.compressed && (type === Address.PayToScriptHash || type === Address.PayToWitnessPublicKeyHash)) {
     throw new TypeError('Witness addresses must use compressed public keys.');
   }
@@ -312,6 +315,9 @@ Address._transformScript = function(script, network) {
  */
 Address.createMultisig = function(publicKeys, threshold, network, nestedWitness, type) {
   network = network || publicKeys[0].network || Networks.defaultNetwork;
+  if (type && type !== Address.PayToScriptHash && type !== Address.PayToWitnessScriptHash) {
+    throw new TypeError('Type must be either scripthash or witnessscripthash to create multisig.');
+  }
   if (nestedWitness || type === Address.PayToWitnessScriptHash) {
     publicKeys = _.map(publicKeys, PublicKey);
     for (var i = 0; i < publicKeys.length; i++) {

--- a/packages/bitcore-lib/lib/privatekey.js
+++ b/packages/bitcore-lib/lib/privatekey.js
@@ -366,13 +366,14 @@ PrivateKey.prototype.toPublicKey = function(){
 /**
  * Will return an address for the private key
  * @param {Network=} network - optional parameter specifying
+ * @param {string} type - Either 'pubkeyhash', 'witnesspubkeyhash', or 'scripthash'
  * the desired network for the address
  *
  * @returns {Address} An address generated from the private key
  */
-PrivateKey.prototype.toAddress = function(network) {
+PrivateKey.prototype.toAddress = function(network, type) {
   var pubkey = this.toPublicKey();
-  return Address.fromPublicKey(pubkey, network || this.network);
+  return Address.fromPublicKey(pubkey, network || this.network, type);
 };
 
 /**

--- a/packages/bitcore-lib/lib/publickey.js
+++ b/packages/bitcore-lib/lib/publickey.js
@@ -363,11 +363,12 @@ PublicKey.prototype._getID = function _getID() {
  * Will return an address for the public key
  *
  * @param {String|Network=} network - Which network should the address be for
+ * @param {string} type - Either 'pubkeyhash', 'witnesspubkeyhash', or 'scripthash'
  * @returns {Address} An address generated from the public key
  */
-PublicKey.prototype.toAddress = function(network) {
+PublicKey.prototype.toAddress = function(network, type) {
   var Address = require('./address');
-  return Address.fromPublicKey(this, network || this.network);
+  return Address.fromPublicKey(this, network || this.network, type);
 };
 
 /**

--- a/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
@@ -8,6 +8,7 @@ var Input = require('./input');
 var Output = require('../output');
 var $ = require('../../util/preconditions');
 
+var Address = require('../../address');
 var Script = require('../../script');
 var Signature = require('../../crypto/signature');
 var Sighash = require('../sighash');
@@ -19,7 +20,7 @@ var TransactionSignature = require('../signature');
 /**
  * @constructor
  */
-function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWitness, opts) {
+function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
   /* jshint maxstatements:20 */
   opts = opts || {};
   Input.apply(this, arguments);
@@ -27,23 +28,32 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, nestedWi
   pubkeys = pubkeys || input.publicKeys;
   threshold = threshold || input.threshold;
   signatures = signatures || input.signatures;
-  this.nestedWitness = nestedWitness ? true : false;
   if (opts.noSorting) {
     this.publicKeys = pubkeys;
   } else  {
     this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
   }
   this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold, opts);
+  var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);
+  this.nestedWitness;
+  this.type;
+  if (nested.equals(this.output.script)) {
+    this.nestedWitness = false;
+    this.type = Address.PayToWitnessScriptHash;
+  } else if (Script.buildScriptHashOut(nested).equals(this.output.script)) {
+    this.nestedWitness = true;
+    this.type = Address.PayToScriptHash;
+  } else if (Script.buildScriptHashOut(this.redeemScript).equals(this.output.script)) {
+    this.nestedWitness = false;
+    this.type = Address.PayToScriptHash;
+  } else {
+    throw new Error('Provided public keys don\'t hash to the provided output');
+  }
+
   if (this.nestedWitness) {
-    var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);
-    $.checkState(Script.buildScriptHashOut(nested).equals(this.output.script),
-                 'Provided public keys don\'t hash to the provided output (nested witness)');
     var scriptSig = new Script();
     scriptSig.add(nested.toBuffer());
     this.setScript(scriptSig);
-  } else {
-    $.checkState(Script.buildScriptHashOut(this.redeemScript).equals(this.output.script),
-               'Provided public keys don\'t hash to the provided output');
   }
 
   this.publicKeyIndex = {};
@@ -97,7 +107,7 @@ MultiSigScriptHashInput.prototype.getScriptCode = function() {
 MultiSigScriptHashInput.prototype.getSighash = function(transaction, privateKey, index, sigtype) {
   var self = this;
   var hash;
-  if (self.nestedWitness) {
+  if (self.nestedWitness || self.type === Address.PayToWitnessScriptHash) {
     var scriptCode = self.getScriptCode();
     var satoshisBuffer = self.getSatoshisBuffer();
     hash = SighashWitness.sighash(transaction, sigtype, index, scriptCode, satoshisBuffer);
@@ -116,7 +126,7 @@ MultiSigScriptHashInput.prototype.getSignatures = function(transaction, privateK
   _.each(this.publicKeys, function(publicKey) {
     if (publicKey.toString() === privateKey.publicKey.toString()) {
       var signature;
-      if (self.nestedWitness) {
+      if (self.nestedWitness || self.type === Address.PayToWitnessScriptHash) {
         var scriptCode = self.getScriptCode();
         var satoshisBuffer = self.getSatoshisBuffer();
         signature = SighashWitness.sign(transaction, privateKey, sigtype, index, scriptCode, satoshisBuffer);
@@ -147,7 +157,7 @@ MultiSigScriptHashInput.prototype.addSignature = function(transaction, signature
 };
 
 MultiSigScriptHashInput.prototype._updateScript = function() {
-  if (this.nestedWitness) {
+  if (this.nestedWitness || this.type === Address.PayToWitnessScriptHash) {
     var stack = [
       new Buffer(0),
     ];
@@ -208,7 +218,7 @@ MultiSigScriptHashInput.prototype.publicKeysWithoutSignature = function() {
 };
 
 MultiSigScriptHashInput.prototype.isValidSignature = function(transaction, signature) {
-  if (this.nestedWitness) {
+  if (this.nestedWitness || this.type === Address.PayToWitnessScriptHash) {
     signature.signature.nhashtype = signature.sigtype;
     var scriptCode = this.getScriptCode();
     var satoshisBuffer = this.getSatoshisBuffer();
@@ -236,11 +246,20 @@ MultiSigScriptHashInput.prototype.isValidSignature = function(transaction, signa
 MultiSigScriptHashInput.OPCODES_SIZE = 7; // serialized size (<=3) + 0 .. N .. M OP_CHECKMULTISIG
 MultiSigScriptHashInput.SIGNATURE_SIZE = 74; // size (1) + DER (<=72) + sighash (1)
 MultiSigScriptHashInput.PUBKEY_SIZE = 34; // size (1) + DER (<=33)
+MultiSigScriptHashInput.REDEEM_SCRIPT_SIZE = 34; // OP_0 (1) + scriptHash (1 + 32)
 
 MultiSigScriptHashInput.prototype._estimateSize = function() {
-  return MultiSigScriptHashInput.OPCODES_SIZE +
+  var WITNESS_DISCOUNT = 4;
+  var witnessSize = MultiSigScriptHashInput.OPCODES_SIZE +
     this.threshold * MultiSigScriptHashInput.SIGNATURE_SIZE +
     this.publicKeys.length * MultiSigScriptHashInput.PUBKEY_SIZE;
+  if (this.type === Address.PayToWitnessScriptHash) {
+    return witnessSize / WITNESS_DISCOUNT;
+  } else if (this.nestedWitness) {
+    return witnessSize / WITNESS_DISCOUNT + MultiSigScriptHashInput.REDEEM_SCRIPT_SIZE;
+  } else {
+    return witnessSize;
+  }
 };
 
 module.exports = MultiSigScriptHashInput;

--- a/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib/lib/transaction/input/multisigscripthash.js
@@ -35,8 +35,6 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
   }
   this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold, opts);
   var nested = Script.buildWitnessMultisigOutFromScript(this.redeemScript);
-  this.nestedWitness;
-  this.type;
   if (nested.equals(this.output.script)) {
     this.nestedWitness = false;
     this.type = Address.PayToWitnessScriptHash;

--- a/packages/bitcore-lib/lib/transaction/input/publickeyhash.js
+++ b/packages/bitcore-lib/lib/transaction/input/publickeyhash.js
@@ -5,10 +5,14 @@ var inherits = require('inherits');
 var $ = require('../../util/preconditions');
 var BufferUtil = require('../../util/buffer');
 
+var Address = require('../../address');
 var Hash = require('../../crypto/hash');
 var Input = require('./input');
 var Output = require('../output');
 var Sighash = require('../sighash');
+var SighashWitness = require('../sighashwitness');
+var BufferWriter = require('../../encoding/bufferwriter');
+var BufferUtil = require('../../util/buffer');
 var Script = require('../../script');
 var Signature = require('../../crypto/signature');
 var TransactionSignature = require('../signature');
@@ -21,6 +25,39 @@ function PublicKeyHashInput() {
   Input.apply(this, arguments);
 }
 inherits(PublicKeyHashInput, Input);
+
+PublicKeyHashInput.prototype.getRedeemScript = function(publicKey) {
+  if (!this.redeemScript) {
+    var redeemScript = Script.buildWitnessV0Out(publicKey);
+    if (Script.buildScriptHashOut(redeemScript).equals(this.output.script)) {
+      var scriptSig = new Script();
+      scriptSig.add(redeemScript.toBuffer());
+      this.setScript(scriptSig);
+      this.redeemScript = redeemScript;
+    }
+  }
+  return this.redeemScript;
+};
+
+PublicKeyHashInput.prototype.getScriptCode = function(publicKey) {
+  var writer = new BufferWriter();
+  var script;
+  if (this.output.script.isScriptHashOut()) {
+    script = this.getRedeemScript(publicKey);
+  } else {
+    script = this.output.script;
+  }
+  var scriptBuffer = Script.buildPublicKeyHashOut(script.toAddress()).toBuffer();
+  writer.writeVarintNum(scriptBuffer.length);
+  writer.write(scriptBuffer);
+  return writer.toBuffer();
+};
+
+PublicKeyHashInput.prototype.getSighash = function(transaction, privateKey, index, sigtype) {
+  var scriptCode = this.getScriptCode(privateKey);
+  var satoshisBuffer = this.getSatoshisBuffer();
+  return SighashWitness.sighash(transaction, sigtype, index, scriptCode, satoshisBuffer);
+};
 
 /* jshint maxparams: 5 */
 /**
@@ -36,13 +73,29 @@ PublicKeyHashInput.prototype.getSignatures = function(transaction, privateKey, i
   hashData = hashData || Hash.sha256ripemd160(privateKey.publicKey.toBuffer());
   sigtype = sigtype || Signature.SIGHASH_ALL;
 
-  if (BufferUtil.equals(hashData, this.output.script.getPublicKeyHash())) {
+  var script;
+  if (this.output.script.isScriptHashOut()) {
+    script = this.getRedeemScript(privateKey.publicKey);
+  } else {
+    script = this.output.script;
+  }
+
+  if (script && BufferUtil.equals(hashData, script.getPublicKeyHash())) {
+    var signature;
+    if (script.isWitnessPublicKeyHashOut()) {
+      var satoshisBuffer = this.getSatoshisBuffer();
+      var scriptCode = this.getScriptCode(privateKey.publicKey);
+      signature = SighashWitness.sign(transaction, privateKey, sigtype, index, scriptCode, satoshisBuffer);
+    } else {
+      signature = Sighash.sign(transaction, privateKey, sigtype, index, this.output.script);
+    }
+
     return [new TransactionSignature({
       publicKey: privateKey.publicKey,
       prevTxId: this.prevTxId,
       outputIndex: this.outputIndex,
       inputIndex: index,
-      signature: Sighash.sign(transaction, privateKey, sigtype, index, this.output.script),
+      signature: signature,
       sigtype: sigtype
     })];
   }
@@ -61,11 +114,22 @@ PublicKeyHashInput.prototype.getSignatures = function(transaction, privateKey, i
  */
 PublicKeyHashInput.prototype.addSignature = function(transaction, signature) {
   $.checkState(this.isValidSignature(transaction, signature), 'Signature is invalid');
-  this.setScript(Script.buildPublicKeyHashIn(
-    signature.publicKey,
-    signature.signature.toDER(),
-    signature.sigtype
-  ));
+
+  if (this.output.script.isWitnessPublicKeyHashOut() || this.output.script.isScriptHashOut()) {
+    this.setWitnesses([
+      BufferUtil.concat([
+        signature.signature.toDER(),
+        BufferUtil.integerAsSingleByteBuffer(signature.sigtype)
+      ]),
+      signature.publicKey.toBuffer()
+    ]);
+  } else {
+    this.setScript(Script.buildPublicKeyHashIn(
+      signature.publicKey,
+      signature.signature.toDER(),
+      signature.sigtype
+    ));
+  }
   return this;
 };
 
@@ -75,6 +139,7 @@ PublicKeyHashInput.prototype.addSignature = function(transaction, signature) {
  */
 PublicKeyHashInput.prototype.clearSignatures = function() {
   this.setScript(Script.empty());
+  this.setWitnesses([]);
   return this;
 };
 
@@ -83,13 +148,48 @@ PublicKeyHashInput.prototype.clearSignatures = function() {
  * @return {boolean}
  */
 PublicKeyHashInput.prototype.isFullySigned = function() {
-  return this.script.isPublicKeyHashIn();
+  return this.script.isPublicKeyHashIn() || this.hasWitnesses();
 };
 
+PublicKeyHashInput.prototype.isValidSignature = function(transaction, signature) {
+  // FIXME: Refactor signature so this is not necessary
+  signature.signature.nhashtype = signature.sigtype;
+  if (this.output.script.isWitnessPublicKeyHashOut() || this.output.script.isScriptHashOut()) {
+    var scriptCode = this.getScriptCode();
+    var satoshisBuffer = this.getSatoshisBuffer();
+    return SighashWitness.verify(
+      transaction,
+      signature.signature,
+      signature.publicKey,
+      signature.inputIndex,
+      scriptCode,
+      satoshisBuffer
+    );
+  } else {
+    return Sighash.verify(
+      transaction,
+      signature.signature,
+      signature.publicKey,
+      signature.inputIndex,
+      this.output.script
+    );
+  }
+};
+
+
 PublicKeyHashInput.SCRIPT_MAX_SIZE = 73 + 34; // sigsize (1 + 72) + pubkey (1 + 33)
+PublicKeyHashInput.REDEEM_SCRIPT_SIZE = 22; // OP_0 (1) pubkeyhash (1 + 20)
 
 PublicKeyHashInput.prototype._estimateSize = function() {
-  return PublicKeyHashInput.SCRIPT_MAX_SIZE;
+  var WITNESS_DISCOUNT = 4;
+  const witnessSize = PublicKeyHashInput.SCRIPT_MAX_SIZE / WITNESS_DISCOUNT;
+  if (this.output.script.isWitnessPublicKeyHashOut()) {
+    return witnessSize;
+  } else if (this.output.script.isScriptHashOut()) {
+    return witnessSize + PublicKeyHashInput.REDEEM_SCRIPT_SIZE;
+  } else {
+    return PublicKeyHashInput.SCRIPT_MAX_SIZE;
+  }
 };
 
 module.exports = PublicKeyHashInput;

--- a/packages/bitcore-lib/lib/transaction/transaction.js
+++ b/packages/bitcore-lib/lib/transaction/transaction.js
@@ -433,12 +433,12 @@ Transaction.prototype.fromObject = function fromObject(arg, opts) {
     }
     var script = new Script(input.output.script);
     var txin;
-    if (script.isPublicKeyHashOut()) {
-      txin = new Input.PublicKeyHash(input);
-    } else if (script.isScriptHashOut() && input.publicKeys && input.threshold) {
+    if ((script.isScriptHashOut() || script.isWitnessScriptHashOut()) && input.publicKeys && input.threshold) {
       txin = new Input.MultiSigScriptHash(
-        input, input.publicKeys, input.threshold, input.signatures, null, opts
+        input, input.publicKeys, input.threshold, input.signatures, opts
       );
+    } else if (script.isPublicKeyHashOut() || script.isWitnessPublicKeyHashOut() || script.isScriptHashOut()) {
+      txin = new Input.PublicKeyHash(input);
     } else if (script.isPublicKeyOut()) {
       txin = new Input.PublicKey(input);
     } else {
@@ -605,16 +605,15 @@ Transaction.prototype._newTransaction = function() {
  * @param {(Array.<Transaction~fromObject>|Transaction~fromObject)} utxo
  * @param {Array=} pubkeys
  * @param {number=} threshold
- * @param {boolean=} nestedWitness - Indicates that the utxo is nested witness p2sh
  * @param {Object=} opts - Several options:
  *        - noSorting: defaults to false, if true and is multisig, don't
  *                      sort the given public keys before creating the script
  */
-Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness, opts) {
+Transaction.prototype.from = function(utxo, pubkeys, threshold, opts) {
   if (_.isArray(utxo)) {
     var self = this;
     _.each(utxo, function(utxo) {
-      self.from(utxo, pubkeys, threshold, nestedWitness, opts);
+      self.from(utxo, pubkeys, threshold, opts);
     });
     return this;
   }
@@ -626,7 +625,7 @@ Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness, o
     return this;
   }
   if (pubkeys && threshold) {
-    this._fromMultisigUtxo(utxo, pubkeys, threshold, nestedWitness, opts);
+    this._fromMultisigUtxo(utxo, pubkeys, threshold, opts);
   } else {
     this._fromNonP2SH(utxo);
   }
@@ -636,7 +635,7 @@ Transaction.prototype.from = function(utxo, pubkeys, threshold, nestedWitness, o
 Transaction.prototype._fromNonP2SH = function(utxo) {
   var clazz;
   utxo = new UnspentOutput(utxo);
-  if (utxo.script.isPublicKeyHashOut()) {
+  if (utxo.script.isPublicKeyHashOut() || utxo.script.isWitnessPublicKeyHashOut() || utxo.script.isScriptHashOut()) {
     clazz = PublicKeyHashInput;
   } else if (utxo.script.isPublicKeyOut()) {
     clazz = PublicKeyInput;
@@ -654,14 +653,14 @@ Transaction.prototype._fromNonP2SH = function(utxo) {
   }));
 };
 
-Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, nestedWitness, opts) {
+Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, opts) {
   $.checkArgument(threshold <= pubkeys.length,
     'Number of required signatures must be greater than the number of public keys');
   var clazz;
   utxo = new UnspentOutput(utxo);
   if (utxo.script.isMultisigOut()) {
     clazz = MultiSigInput;
-  } else if (utxo.script.isScriptHashOut()) {
+  } else if (utxo.script.isScriptHashOut() || utxo.script.isWitnessScriptHashOut()) {
     clazz = MultiSigScriptHashInput;
   } else {
     throw new Error("@TODO");
@@ -674,7 +673,7 @@ Transaction.prototype._fromMultisigUtxo = function(utxo, pubkeys, threshold, nes
     prevTxId: utxo.txId,
     outputIndex: utxo.outputIndex,
     script: Script.empty()
-  }, pubkeys, threshold, false, nestedWitness, opts));
+  }, pubkeys, threshold, false, opts));
 };
 
 /**

--- a/packages/bitcore-lib/test/address_witness.js
+++ b/packages/bitcore-lib/test/address_witness.js
@@ -16,6 +16,7 @@ describe('Witness Address', function() {
 
   var pubkeyhash = new Buffer('2a9540f5cd929bf742d16b4e1bf1b0e874c907c9', 'hex');
   var str = 'bc1q9225pawdj2dlwsk3dd8phudsap6vjp7fg3nwdl';
+  var wrappedStr = '3LfTZncZYsaxGBWYfDg8MTTFVKHmUHoZyA';
   var buf = Buffer.from(str, 'utf8');
 
   it('should throw an error because of bad network param', function() {
@@ -218,6 +219,62 @@ describe('Witness Address', function() {
       }).should.throw('Unknown network');
     });
 
+    it('should error because of incorrect format for script hash', function() {
+      (function() {
+        return new Address.fromScriptHash('notascript', null, Address.PayToWitnessScriptHash);
+      }).should.throw('Address supplied is not a buffer.');
+    });
+
+    it('should error because of incorrect type for pubkey transform', function() {
+      (function() {
+        return Address._transformPublicKey(new Buffer(20), null, Address.PayToWitnessPublicKeyHash);
+      }).should.throw('Address must be an instance of PublicKey.');
+      (function() {
+        return Address._transformPublicKey(new Buffer(20), null, Address.PayToScriptHash);
+      }).should.throw('Address must be an instance of PublicKey.');
+    });
+
+    it('should make this address from a compressed pubkey', function() {
+      var pubkey = new PublicKey('0285e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b004');
+      var address = Address.fromPublicKey(pubkey, 'livenet', Address.PayToWitnessPublicKeyHash);
+      address.toString().should.equal('bc1qtuh205nkztchej8r84k8vna9upsjh7q8dvy576');
+    });
+
+    it('should make this wrapped address from a compressed pubkey', function() {
+      var pubkey = new PublicKey('0285e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b004');
+      var address = Address.fromPublicKey(pubkey, 'livenet', Address.PayToScriptHash);
+      address.toString().should.equal('3GNVVBik6S9Ux5ccS6ymmEeQELXGJdP8p8');
+    });
+
+    it('should use the default network for pubkey', function() {
+      var pubkey = new PublicKey('0285e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b004');
+      var address = Address.fromPublicKey(pubkey, null, Address.PayToWitnessPublicKeyHash);
+      address.network.should.equal(Networks.defaultNetwork);
+    });
+
+    it('should use the default network for pubkey', function() {
+      var pubkey = new PublicKey('0285e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b004');
+      var address = Address.fromPublicKey(pubkey, null, Address.PayToScriptHash);
+      address.network.should.equal(Networks.defaultNetwork);
+    });
+
+    it('should fail to make an address with an uncompressed pubkey', function() {
+      var pubkey = new PublicKey('0485e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b00' +
+        '4833fef26c8be4c4823754869ff4e46755b85d851077771c220e2610496a29d98');
+      (function() {
+        return Address.fromPublicKey(pubkey, 'livenet', Address.PayToWitnessPublicKeyHash);
+      }).should.throw('Witness addresses must use compressed public keys.');
+    });
+
+    it('should fail to make a wrapped address with an uncompressed pubkey', function() {
+      var pubkey = new PublicKey('0485e9737a74c30a873f74df05124f2aa6f53042c2fc0a130d6cbd7d16b944b00' +
+        '4833fef26c8be4c4823754869ff4e46755b85d851077771c220e2610496a29d98');
+      (function() {
+        return Address.fromPublicKey(pubkey, 'livenet', Address.PayToScriptHash);
+      }).should.throw('Witness addresses must use compressed public keys.');
+    });
+
+
     it('should classify from a custom network', function() {
       var custom = {
         name: 'customnetwork2',
@@ -377,4 +434,35 @@ describe('Witness Address', function() {
     address.network.should.equal(Networks.defaultNetwork);
   });
 
+  describe('creating a P2WSH address from public keys', function() {
+
+    var public1 = '02da5798ed0c055e31339eb9b5cef0d3c0ccdec84a62e2e255eb5c006d4f3e7f5b';
+    var public2 = '0272073bf0287c4469a2a011567361d42529cd1a72ab0d86aa104ecc89342ffeb0';
+    var public3 = '02738a516a78355db138e8119e58934864ce222c553a5407cf92b9c1527e03c1a2';
+    var publics = [public1, public2, public3];
+
+    it('can create an address from a set of public keys', function() {
+      var address = Address.createMultisig(publics, 2, Networks.livenet, null, Address.PayToWitnessScriptHash);
+      address.toString().should.equal('bc1qukwqyzxcjdykr0cfxghwkrx9rkmdvapc08syez75q5ewg3j5umvsu5w9yf');
+      address = new Address(publics, 2, Networks.livenet, Address.PayToWitnessScriptHash);
+      address.toString().should.equal('bc1qukwqyzxcjdykr0cfxghwkrx9rkmdvapc08syez75q5ewg3j5umvsu5w9yf');
+    });
+
+    it('works on testnet also', function() {
+      var address = Address.createMultisig(publics, 2, Networks.testnet, null, Address.PayToWitnessScriptHash);
+      address.toString().should.equal('tb1qukwqyzxcjdykr0cfxghwkrx9rkmdvapc08syez75q5ewg3j5umvstuc27x');
+    });
+
+    it('can also be created by Address.createMultisig', function() {
+      var address = Address.createMultisig(publics, 2, null, null, Address.PayToWitnessScriptHash);
+      var address2 = Address.createMultisig(publics, 2, null, null, Address.PayToWitnessScriptHash);
+      address.toString().should.equal(address2.toString());
+    });
+
+    it('fails if invalid array is provided', function() {
+      expect(function() {
+        return Address.createMultisig([], 3, 'testnet', null, Address.PayToWitnessScriptHash);
+      }).to.throw('Number of required signatures must be less than or equal to the number of public keys');
+    });
+  });
 });

--- a/packages/bitcore-lib/test/privatekey.js
+++ b/packages/bitcore-lib/test/privatekey.js
@@ -5,6 +5,7 @@ var should = chai.should();
 var expect = chai.expect;
 
 var bitcore = require('..');
+var Address = bitcore.Address;
 var BN = bitcore.crypto.BN;
 var Point = bitcore.crypto.Point;
 var PrivateKey = bitcore.PrivateKey;
@@ -269,6 +270,42 @@ describe('PrivateKey', function() {
       var pk = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
       pk.toAddress(Networks.livenet).network.name.should.equal(Networks.livenet.name);
       pk.toAddress(Networks.testnet).network.name.should.equal(Networks.testnet.name);
+    });
+
+    it('should output this known livenet witness address correctly', function() {
+      var privkey = PrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
+      var address = privkey.toAddress(null, Address.PayToWitnessPublicKeyHash);
+      address.toString().should.equal('bc1qv0t45lutg37ghyg7lg22vgducs3d9hvuarwr89');
+    });
+
+    it('should output this known testnet witness address correctly', function() {
+      var privkey = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
+      var address = privkey.toAddress(null, Address.PayToWitnessPublicKeyHash);
+      address.toString().should.equal('tb1q363x8lv54fdsywyc9494upd6sp4rg6glhsyzk0');
+    });
+
+    it('creates network specific witness address', function() {
+      var pk = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
+      pk.toAddress(Networks.livenet, Address.PayToWitnessPublicKeyHash).network.name.should.equal(Networks.livenet.name);
+      pk.toAddress(Networks.testnet, Address.PayToWitnessPublicKeyHash).network.name.should.equal(Networks.testnet.name);
+    });
+
+    it('should output this known livenet wrapped witness address correctly', function() {
+      var privkey = PrivateKey.fromWIF('L3T1s1TYP9oyhHpXgkyLoJFGniEgkv2Jhi138d7R2yJ9F4QdDU2m');
+      var address = privkey.toAddress(null, Address.PayToScriptHash);
+      address.toString().should.equal('39wREM7dxb7KNMNR1py1W8nUheUtkPPA5r');
+    });
+
+    it('should output this known testnet wrapped witness address correctly', function() {
+      var privkey = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
+      var address = privkey.toAddress(null, Address.PayToScriptHash);
+      address.toString().should.equal('2NDgQSsQGdLDGoYvh4NTmesQ2wWgx6RGu3m');
+    });
+
+    it('creates network specific wrapped witness address', function() {
+      var pk = PrivateKey.fromWIF('cR4qogdN9UxLZJXCNFNwDRRZNeLRWuds9TTSuLNweFVjiaE4gPaq');
+      pk.toAddress(Networks.livenet, Address.PayToScriptHash).network.name.should.equal(Networks.livenet.name);
+      pk.toAddress(Networks.testnet, Address.PayToScriptHash).network.name.should.equal(Networks.testnet.name);
     });
 
   });

--- a/packages/bitcore-lib/test/publickey.js
+++ b/packages/bitcore-lib/test/publickey.js
@@ -346,6 +346,30 @@ describe('PublicKey', function() {
       address.toString().should.equal('mtX8nPZZdJ8d3QNLRJ1oJTiEi26Sj6LQXS');
     });
 
+    it('should output this known mainnet witness address correctly', function() {
+      var pk = new PublicKey('03c87bd0e162f26969da8509cafcb7b8c8d202af30b928c582e263dd13ee9a9781');
+      var address = pk.toAddress('livenet', Address.PayToWitnessPublicKeyHash);
+      address.toString().should.equal('bc1qv0t45lutg37ghyg7lg22vgducs3d9hvuarwr89');
+    });
+
+    it('should output this known testnet witness address correctly', function() {
+      var pk = new PublicKey('0293126ccc927c111b88a0fe09baa0eca719e2a3e087e8a5d1059163f5c566feef');
+      var address = pk.toAddress('testnet', Address.PayToWitnessPublicKeyHash);
+      address.toString().should.equal('tb1q363x8lv54fdsywyc9494upd6sp4rg6glhsyzk0');
+    });
+
+    it('should output this known mainnet wrapped witness address correctly', function() {
+      var pk = new PublicKey('03c87bd0e162f26969da8509cafcb7b8c8d202af30b928c582e263dd13ee9a9781');
+      var address = pk.toAddress('livenet', Address.PayToScriptHash);
+      address.toString().should.equal('39wREM7dxb7KNMNR1py1W8nUheUtkPPA5r');
+    });
+
+    it('should output this known testnet wrapped witness address correctly', function() {
+      var pk = new PublicKey('0293126ccc927c111b88a0fe09baa0eca719e2a3e087e8a5d1059163f5c566feef');
+      var address = pk.toAddress('testnet', Address.PayToScriptHash);
+      address.toString().should.equal('2NDgQSsQGdLDGoYvh4NTmesQ2wWgx6RGu3m');
+    });
+
   });
 
   describe('hashes', function() {

--- a/packages/bitcore-lib/test/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib/test/transaction/input/multisigscripthash.js
@@ -22,6 +22,7 @@ describe('MultiSigScriptHashInput', function() {
   var public2 = privateKey2.publicKey;
   var public3 = privateKey3.publicKey;
   var address = new Address('33zbk2aSZYdNbRsMPPt6jgy6Kq1kQreqeb');
+  var witnessAddress = new Address([public1, public2, public3], 2, null, Address.PayToWitnessScriptHash);
 
   var output = {
     address: '33zbk2aSZYdNbRsMPPt6jgy6Kq1kQreqeb',
@@ -30,6 +31,15 @@ describe('MultiSigScriptHashInput', function() {
     script: new Script(address),
     satoshis: 1000000
   };
+
+  var witnessOutput = {
+    address: 'bc1qd2kqrwpmz5m6lc42jmgn5vum3ggfkp0kateh6kzqle0jyldwmtxq7ghwrv',
+    txId: '66e64ef8a3b384164b78453fa8c8194de9a473ba14f89485a0e433699daec140',
+    outputIndex: 0,
+    script: new Script(witnessAddress),
+    satoshis: 1000000
+  };
+
   it('can count missing signatures', function() {
     var transaction = new Transaction()
       .from(output, [public1, public2, public3], 2)
@@ -142,6 +152,106 @@ describe('MultiSigScriptHashInput', function() {
     var input = transaction.inputs[0];
     var satoshisBuffer = input.getSatoshisBuffer();
     satoshisBuffer.toString('hex').should.equal('40420f0000000000');
+  });
+
+  describe('P2WSH', function() {
+    it('can count missing signatures', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      input.countSignatures().should.equal(0);
+
+      transaction.sign(privateKey1);
+      input.countSignatures().should.equal(1);
+      input.countMissingSignatures().should.equal(1);
+      input.isFullySigned().should.equal(false);
+
+      transaction.sign(privateKey2);
+      input.countSignatures().should.equal(2);
+      input.countMissingSignatures().should.equal(0);
+      input.isFullySigned().should.equal(true);
+    });
+    it('returns a list of public keys with missing signatures', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      _.every(input.publicKeysWithoutSignature(), function(publicKeyMissing) {
+        var serialized = publicKeyMissing.toString();
+        return serialized === public1.toString() ||
+                serialized === public2.toString() ||
+                serialized === public3.toString();
+      }).should.equal(true);
+      transaction.sign(privateKey1);
+      _.every(input.publicKeysWithoutSignature(), function(publicKeyMissing) {
+        var serialized = publicKeyMissing.toString();
+        return serialized === public2.toString() ||
+                serialized === public3.toString();
+      }).should.equal(true);
+    });
+    it('can clear all signatures', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000)
+        .sign(privateKey1)
+        .sign(privateKey2);
+
+      var input = transaction.inputs[0];
+      input.isFullySigned().should.equal(true);
+      input.clearSignatures();
+      input.isFullySigned().should.equal(false);
+    });
+    it('can estimate how heavy is the output going to be', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      input._estimateSize().should.equal(64.25);
+    });
+    it('uses SIGHASH_ALL by default', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var sigs = input.getSignatures(transaction, privateKey1, 0);
+      sigs[0].sigtype.should.equal(Signature.SIGHASH_ALL);
+    });
+    it('roundtrips to/from object', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000)
+        .sign(privateKey1);
+      var input = transaction.inputs[0];
+      var roundtrip = new MultiSigScriptHashInput(input.toObject());
+      roundtrip.toObject().should.deep.equal(input.toObject());
+    });
+    it('roundtrips to/from object when not signed', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var roundtrip = new MultiSigScriptHashInput(input.toObject());
+      roundtrip.toObject().should.deep.equal(input.toObject());
+    });
+    it('will get the scriptCode', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2, true)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var scriptCode = input.getScriptCode();
+      scriptCode.toString('hex').should.equal('695221025c95ec627038e85b5688a9b3d84d28c5ebe66e8c8d697d498e20fe96e3b1ab1d2102cdddfc974d41a62f1f80081deee70592feb7d6e6cf6739d6592edbe7946720e72103c95924e02c240b5545089c69c6432447412b58be43fd671918bd184a5009834353ae');
+    });
+    it('will get the satoshis buffer', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput, [public1, public2, public3], 2, true)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var satoshisBuffer = input.getSatoshisBuffer();
+      satoshisBuffer.toString('hex').should.equal('40420f0000000000');
+    });
   });
 
 });

--- a/packages/bitcore-lib/test/transaction/input/publickeyhash.js
+++ b/packages/bitcore-lib/test/transaction/input/publickeyhash.js
@@ -18,6 +18,8 @@ describe('PublicKeyHashInput', function() {
   var privateKey = new PrivateKey('KwF9LjRraetZuEjR8VqEq539z137LW5anYDUnVK11vM3mNMHTWb4');
   var publicKey = privateKey.publicKey;
   var address = new Address(publicKey, Networks.livenet);
+  var witnessAddress = new Address(publicKey, Networks.livenet, Address.PayToWitnessPublicKeyHash);
+  var wrappedAddress = new Address(publicKey, Networks.livenet, Address.PayToScriptHash);
 
   var output = {
     address: '33zbk2aSZYdNbRsMPPt6jgy6Kq1kQreqeb',
@@ -26,6 +28,23 @@ describe('PublicKeyHashInput', function() {
     script: new Script(address),
     satoshis: 1000000
   };
+
+  var witnessOutput = {
+    address: 'bc1q4fyv6yjgj6kjgv5ccnfhqcv0ydft2z6h9xf0xw',
+    txId: '66e64ef8a3b384164b78453fa8c8194de9a473ba14f89485a0e433699daec140',
+    outputIndex: 0,
+    script: new Script(witnessAddress),
+    satoshis: 1000000
+  };
+
+  var wrappedOutput = {
+    address: '3PgH5AzNZpoEsdhCpwufpo6xDDHqXsAjAR',
+    txId: '66e64ef8a3b384164b78453fa8c8194de9a473ba14f89485a0e433699daec140',
+    outputIndex: 0,
+    script: new Script(wrappedAddress),
+    satoshis: 1000000
+  };
+
   it('can count missing signatures', function() {
     var transaction = new Transaction()
       .from(output)
@@ -60,5 +79,113 @@ describe('PublicKeyHashInput', function() {
     var input = transaction.inputs[0];
     var signatures = input.getSignatures(transaction, new PrivateKey(), 0);
     signatures.length.should.equal(0);
+  });
+
+  describe('P2WPKH', function () {
+    it('can count missing signatures', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      input.isFullySigned().should.equal(false);
+      transaction.sign(privateKey);
+      input.isFullySigned().should.equal(true);
+    });
+    it('it\'s size can be estimated', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      input._estimateSize().should.equal(26.75);
+    });
+    it('it\'s signature can be removed', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      transaction.sign(privateKey);
+      input.clearSignatures();
+      input.isFullySigned().should.equal(false);
+    });
+    it('returns an empty array if private key mismatches', function() {
+      var transaction = new Transaction()
+        .from(witnessOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var signatures = input.getSignatures(transaction, new PrivateKey(), 0);
+      signatures.length.should.equal(0);
+    });
+    it('will get the scriptCode', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var scriptCode = input.getScriptCode(publicKey);
+      scriptCode.toString('hex').should.equal('1976a914aa48cd124896ad243298c4d370618f2352b50b5788ac');
+    });
+    it('will get the satoshis buffer', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var satoshisBuffer = input.getSatoshisBuffer();
+      satoshisBuffer.toString('hex').should.equal('40420f0000000000');
+    });
+  });
+
+  describe('P2SH-wrapped-P2WPKH', function () {
+    it('can count missing signatures', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      input.isFullySigned().should.equal(false);
+      transaction.sign(privateKey);
+      input.isFullySigned().should.equal(true);
+    });
+    it('it\'s size can be estimated', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      input._estimateSize().should.equal(48.75);
+    });
+    it('it\'s signature can be removed', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+
+      transaction.sign(privateKey);
+      input.clearSignatures();
+      input.isFullySigned().should.equal(false);
+    });
+    it('returns an empty array if private key mismatches', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var signatures = input.getSignatures(transaction, new PrivateKey(), 0);
+      signatures.length.should.equal(0);
+    });
+    it('will get the scriptCode', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var scriptCode = input.getScriptCode(publicKey);
+      scriptCode.toString('hex').should.equal('1976a914aa48cd124896ad243298c4d370618f2352b50b5788ac');
+    });
+    it('will get the satoshis buffer', function() {
+      var transaction = new Transaction()
+        .from(wrappedOutput)
+        .to(address, 1000000);
+      var input = transaction.inputs[0];
+      var satoshisBuffer = input.getSatoshisBuffer();
+      satoshisBuffer.toString('hex').should.equal('40420f0000000000');
+    });
   });
 });


### PR DESCRIPTION
This PR adds full support for generating and spending from P2WPKH, P2SH-wrapped-P2WPKH, and P2WSH multisig addresses.

Note, I removed the `nestedWitness` parameter for `MultiSigScriptHashInput` since it can be inferred by what the publickeys and threshold hash to. This makes it easier to create and spend from these addresses since the method of generating doesn't need to be stored.