### PR TITLE
Fix(BWS) - customFee for Eth

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -66,27 +66,30 @@ module.exports = {
       {
         name: 'urgent',
         nbBlocks: 10, // < 2 min
-        defaultValue: 3000000000
+        multiplier: 1.1,
+        defaultValue: 30000000000
       },
       {
         name: 'priority',
         nbBlocks: 15, // 3 min
-        defaultValue: 2000000000
+        defaultValue: 25000000000
       },
       {
         name: 'normal',
         nbBlocks: 25, // 5 min
-        defaultValue: 1000000000
+        defaultValue: 20000000000
       },
       {
         name: 'economy',
         nbBlocks: 50, // 10 minutes
-        defaultValue: 1000000000
+        multiplier: 0.9,
+        defaultValue: 15000000000
       },
       {
         name: 'superEconomy',
         nbBlocks: 75, // 15 minutes
-        defaultValue: 1000000000
+        multiplier: 0.8,
+        defaultValue: 10000000000
       }
     ]
   },

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -2568,14 +2568,6 @@ export class WalletService {
               );
           }
 
-          if (_.isNumber(opts.feePerKb)) {
-            if (
-              opts.feePerKb < Defaults.MIN_FEE_PER_KB ||
-              opts.feePerKb > Defaults.MAX_FEE_PER_KB
-            )
-              return next(new ClientError('Invalid fee per KB'));
-          }
-
           if (_.isNumber(opts.fee) && _.isEmpty(opts.inputs))
             return next(
               new ClientError('fee can only be set when inputs are specified')


### PR DESCRIPTION
- Add multipliers to ETH fee to allow a range of fees
- remove MAX.FEE_PER_KB check

depends on:
https://github.com/bitpay/copay/pull/10177