### PR TITLE
Fix CWC.sign removed utils.toHex from txData

### DIFF
--- a/packages/crypto-wallet-core/src/transactions/eth/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth/index.ts
@@ -31,7 +31,7 @@ export class ETHTxProvider {
     const signature = signDigest(ethers.utils.keccak256(tx));
     const parsedTx = ethers.utils.parseTransaction(tx);
     const { nonce, gasPrice, gasLimit, to, value, data, chainId } = parsedTx;
-    const txData = { nonce: utils.toHex(nonce), gasPrice: utils.toHex(gasPrice), gasLimit: utils.toHex(gasLimit), to, value: utils.toHex(value), data, chainId };
+    const txData = { nonce, gasPrice, gasLimit, to, value, data, chainId };
     const signedTx = ethers.utils.serializeTransaction(txData, signature);
     return signedTx;
   }


### PR DESCRIPTION
nonce, gasLimit, gasPrice, and value was being pass into serializeTransaction as hex string.

Fixes error:
```
ERROR: 500 - "Returned error: Transaction cost exceeds current gas limit. Limit: 9992977, got: 41900420268743501727197304949355530691197. Try decreasing supplied gas."
```