### PR TITLE
Add mongo url support

### DIFF
--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -54,6 +54,7 @@ const Config = function(): ConfigType {
   let config: ConfigType = {
     maxPoolSize: 50,
     port: 3000,
+    dbUrl: process.env.DB_URL || '',
     dbHost: process.env.DB_HOST || '127.0.0.1',
     dbName: process.env.DB_NAME || 'bitcore',
     dbPort: process.env.DB_PORT || '27017',

--- a/packages/bitcore-node/src/services/storage.ts
+++ b/packages/bitcore-node/src/services/storage.ts
@@ -31,9 +31,9 @@ export class StorageService {
   start(args: Partial<ConfigType> = {}): Promise<MongoClient> {
     return new Promise((resolve, reject) => {
       let options = Object.assign({}, this.configService.get(), args);
-      let { dbName, dbHost, dbPort, dbUser, dbPass } = options;
+      let { dbUrl, dbName, dbHost, dbPort, dbUser, dbPass } = options;
       let auth = dbUser !== '' && dbPass !== '' ? `${dbUser}:${dbPass}@` : '';
-      const connectUrl = `mongodb://${auth}${dbHost}:${dbPort}/${dbName}?socketTimeoutMS=3600000&noDelay=true`;
+      const connectUrl = dbUrl ? dbUrl :`mongodb://${auth}${dbHost}:${dbPort}/${dbName}?socketTimeoutMS=3600000&noDelay=true`;
       let attemptConnect = async () => {
         return MongoClient.connect(
           connectUrl,

--- a/packages/bitcore-node/src/types/Config.d.ts
+++ b/packages/bitcore-node/src/types/Config.d.ts
@@ -1,6 +1,7 @@
 export interface ConfigType {
   maxPoolSize: number;
   port: number;
+  dbUrl: string;
   dbHost: string;
   dbName: string;
   dbPort: string;


### PR DESCRIPTION
In case when we working with mongo replica, need possibility to work with mongo url instead of concatenating different parts of environment variables.
ex. `DB_URL: mongodb://test:test@mongodb-0.mongodb:27017,mongodb-1.mongodb:27017,mongodb-2.mongodb:27017/bitcore`