### PR TITLE
Feature(BWS) - Add eth to explorers

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
@@ -29,7 +29,8 @@ export class BlockchainMonitor {
         (done) => {
           this.explorers = {
             btc: {},
-            bch: {}
+            bch: {},
+            eth: {}
           };
 
           const coinNetworkPairs = [];


### PR DESCRIPTION
- Adds ETH to `this.explorers` in `blockchainmonitor.ts` to enable websocket notifications for ETH.

`New Block` broadcasts every 10-20 seconds which makes `BLOCKHEIGHT_CACHE_TIME` irrelevant.