### PR TITLE
add missing isActive index

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -129,6 +129,10 @@ export class Storage {
       copayerId: 1,
       txid: 1
     });
+    db.collection(collections.TX_CONFIRMATION_SUBS).createIndex({
+      isActive: 1,
+      copayerId: 1
+    });
     db.collection(collections.SESSIONS).createIndex({
       copayerId: 1
     });


### PR DESCRIPTION
fetchActiveTxConfirmationSubs is being called with `null` for copayerId in bcMonitor, causing the resultant query to do a collection scan.