### PR TITLE
Feature(CWC) - Add network param to CWC ETH transaction create for chainId

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/utils.ts
@@ -317,12 +317,11 @@ export class Utils {
 
       return t;
     } else {
-      const { outputs, amount, gasPrice } = txp;
+      const { outputs, amount } = txp;
       const rawTx = Transactions.create({
         ...txp,
         chain: coin.toUpperCase(),
-        recipients: [{ address: outputs[0].toAddress, amount }],
-        fee: gasPrice
+        recipients: [{ address: outputs[0].toAddress, amount }]
       });
       return { uncheckedSerialize: () => rawTx };
     }

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -269,8 +269,7 @@ export class TxProposal {
       const rawTx = Transactions.create({
         ...this,
         chain: this.coin.toUpperCase(),
-        recipients: [{ address: this.outputs[0].toAddress, amount: this.amount}],
-        fee: this.gasPrice
+        recipients: [{ address: this.outputs[0].toAddress, amount: this.amount}]
       });
       return {
         uncheckedSerialize: () => rawTx,

--- a/packages/crypto-wallet-core/src/transactions/erc20/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/erc20/index.ts
@@ -16,6 +16,7 @@ export class ERC20TxProvider extends ETHTxProvider {
     data: string;
     gasLimit: number;
     tokenAddress: string;
+    network: string;
     chainId?: number;
   }) {
     const { tokenAddress } = params;

--- a/packages/crypto-wallet-core/src/transactions/eth/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth/index.ts
@@ -8,10 +8,13 @@ export class ETHTxProvider {
     gasPrice: number;
     data: string;
     gasLimit: number;
+    network: string;
     chainId?: number;
   }) {
-    const { recipients, nonce, gasPrice, data, gasLimit, chainId = 1} = params;
+    const { recipients, nonce, gasPrice, data, gasLimit, network } = params;
     const { address, amount } = recipients[0];
+    let { chainId } = params;
+    chainId = chainId || this.getChainId(network);
     const txData = {
       nonce: utils.toHex(nonce),
       gasLimit: utils.toHex(gasLimit),
@@ -22,6 +25,26 @@ export class ETHTxProvider {
       chainId
     };
     return ethers.utils.serializeTransaction(txData);
+  }
+
+  getChainId(network: string) {
+    let chainId = 1;
+    switch (network) {
+      case 'testnet':
+      case 'kovan':
+        chainId = 42;
+        break;
+      case 'ropsten':
+        chainId = 3;
+        break;
+      case 'rinkeby':
+        chainId = 4;
+        break;
+      default:
+        chainId = 1;
+        break;
+    }
+    return chainId;
   }
 
   getSignatureObject (params: { tx: string; key: Key; }) {

--- a/packages/crypto-wallet-core/test/transactions.ts
+++ b/packages/crypto-wallet-core/test/transactions.ts
@@ -11,43 +11,87 @@ describe('Transaction Creation', () => {
     // TODO !!
   });
 
-
-  it('should be able to create an ETH tx', () => {
+  it('should be able to create a livenet ETH tx', () => {
     const rawEthTx = {
+      network: 'livenet',
       value: 3896000000000000,
       to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
       data:
         '0xb6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000',
       gasPrice: 20000000000
     };
-    const { value, to, data, gasPrice } = rawEthTx;
+    const { value, to } = rawEthTx;
     const recipients = [{ address: to, amount: value }];
     const cryptoTx = Transactions.create({
+      ...rawEthTx,
       chain: 'ETH',
       recipients,
-      gasPrice,
       nonce: 0,
-      data
     });
     const expectedTx =
       '0xf9014f808504a817c800809437d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a870dd764300b8000b90124b6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000018080';
     expect(cryptoTx).to.equal(expectedTx);
   });
 
-  it('should be able to create an ERC20 tx', () => {
+  it('should be able to create a testnet ETH tx', () => {
     const rawEthTx = {
+      network: 'testnet',
       value: 3896000000000000,
       to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      data:
+        '0xb6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000',
       gasPrice: 20000000000
     };
-    const { value, to, gasPrice } = rawEthTx;
+    const { value, to } = rawEthTx;
     const recipients = [{ address: to, amount: value }];
     const cryptoTx = Transactions.create({
+      ...rawEthTx,
+      chain: 'ETH',
+      recipients,
+      nonce: 0,
+    });
+    const expectedTx =
+      '0xf9014f808504a817c800809437d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a870dd764300b8000b90124b6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead1468056300000000000000000000000000000000000000000000000000000000000000002a8080';
+    expect(cryptoTx).to.equal(expectedTx);
+  });
+
+  it('should be able to create a kovan ETH tx', () => {
+    const rawEthTx = {
+      network: 'kovan',
+      value: 3896000000000000,
+      to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      data:
+        '0xb6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000',
+      gasPrice: 20000000000
+    };
+    const { value, to } = rawEthTx;
+    const recipients = [{ address: to, amount: value }];
+    const cryptoTx = Transactions.create({
+      ...rawEthTx,
+      chain: 'ETH',
+      recipients,
+      nonce: 0,
+    });
+    const expectedTx =
+      '0xf9014f808504a817c800809437d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a870dd764300b8000b90124b6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead1468056300000000000000000000000000000000000000000000000000000000000000002a8080';
+    expect(cryptoTx).to.equal(expectedTx);
+  });
+
+  it('should be able to create a livenet ERC20 tx', () => {
+    const rawEthTx = {
+      network: 'livenet',
+      value: 3896000000000000,
+      to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      gasPrice: 20000000000,
+      tokenAddress: '0x692a70d2e424a56d2c6c27aa97d1a86395877b3a'
+    };
+    const { value, to } = rawEthTx;
+    const recipients = [{ address: to, amount: value }];
+    const cryptoTx = Transactions.create({
+      ...rawEthTx,
       chain: 'ERC20',
       recipients,
-      gasPrice,
       nonce: 0,
-      tokenAddress: '0x692a70d2e424a56d2c6c27aa97d1a86395877b3a'
     });
     const expectedTx =
       '0xf867808504a817c8008094692a70d2e424a56d2c6c27aa97d1a86395877b3a80b844a9059cbb00000000000000000000000037d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a000000000000000000000000000000000000000000000000000dd764300b8000018080';
@@ -55,6 +99,74 @@ describe('Transaction Creation', () => {
     expect(cryptoTx).to.equal(expectedTx);
   });
 
+  it('should be able to create a testnet ERC20 tx', () => {
+    const rawEthTx = {
+      network: 'testnet',
+      value: 3896000000000000,
+      to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      gasPrice: 20000000000,
+      tokenAddress: '0x692a70d2e424a56d2c6c27aa97d1a86395877b3a'
+    };
+    const { value, to } = rawEthTx;
+    const recipients = [{ address: to, amount: value }];
+    const cryptoTx = Transactions.create({
+      ...rawEthTx,
+      chain: 'ERC20',
+      recipients,
+      nonce: 0,
+    });
+    const expectedTx =
+      '0xf867808504a817c8008094692a70d2e424a56d2c6c27aa97d1a86395877b3a80b844a9059cbb00000000000000000000000037d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a000000000000000000000000000000000000000000000000000dd764300b80002a8080';
+
+    expect(cryptoTx).to.equal(expectedTx);
+  });
+
+  it('should be able to create a kovan ERC20 tx', () => {
+    const rawEthTx = {
+      network: 'testnet',
+      value: 3896000000000000,
+      to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      gasPrice: 20000000000,
+      tokenAddress: '0x692a70d2e424a56d2c6c27aa97d1a86395877b3a'
+    };
+    const { value, to } = rawEthTx;
+    const recipients = [{ address: to, amount: value }];
+    const cryptoTx = Transactions.create({
+      ...rawEthTx,
+      chain: 'ERC20',
+      recipients,
+      nonce: 0,
+    });
+    const expectedTx =
+      '0xf867808504a817c8008094692a70d2e424a56d2c6c27aa97d1a86395877b3a80b844a9059cbb00000000000000000000000037d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a000000000000000000000000000000000000000000000000000dd764300b80002a8080';
+
+    expect(cryptoTx).to.equal(expectedTx);
+  });
+
+  it('should be only create a mainnet ETH tx with one recipient', () => {
+    const rawEthTx = {
+      network: 'mainnet',
+      value: 3896000000000000,
+      to: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A',
+      data:
+        '0xb6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000',
+      gasPrice: 20000000000
+    };
+    const { value, to } = rawEthTx;
+    const recipients = [{ address: to, amount: value }, { address: to, amount: value }];
+    const cryptoTx = Transactions.create({
+      ...rawEthTx,
+      chain: 'ETH',
+      recipients,
+      nonce: 0,
+    });
+    const expectedTx =
+      '0xf9014f808504a817c800809437d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a870dd764300b8000b90124b6b4af05000000000000000000000000000000000000000000000000000dd764300b800000000000000000000000000000000000000000000000000000000004a817c8000000000000000000000000000000000000000000000000000000016ada606a26050bb49a5a8228599e0dd48c1368abd36f4f14d2b74a015b2d168dbcab0773ce399393220df874bb22ca961f351e038acd2ba5cc8c764385c9f23707622cc435000000000000000000000000000000000000000000000000000000000000001c7e247d684a635813267b10a63f7f3ba88b28ca2790c909110b28236cf1b9bba03451e83d5834189f28d4c77802fc76b7c760a42bc8bebf8dd15e6ead146805630000000000000000000000000000000000000000000000000000000000000000018080';
+    expect(cryptoTx).to.equal(expectedTx);
+  });
+});
+
+describe('Transaction Sign', () => {
   it('should be able to getSignature an ETH tx', () => {
     const signature = Transactions.getSignature({
       chain: 'ETH',
@@ -113,8 +225,6 @@ describe('Transaction Creation', () => {
     expect(hash).to.equal(expectedHash);
   });
 
-
-
   it('should be throw using wrong privKey to sign an ETH tx', () => {
     let error
     try {
@@ -130,5 +240,27 @@ describe('Transaction Creation', () => {
     }
     expect(error.message).to.include('invalid hexidecimal string');
     expect(error).to.not.equal(undefined);
+  });
+});
+
+describe('ETH Transaction getChainId', () => {
+  it('should get the correct chainId per network', () => {
+    const mainnetId = Transactions.get({chain: 'ETH'}).getChainId('mainnet');
+    expect(mainnetId).to.equal(1);
+
+    const livenetId = Transactions.get({chain: 'ETH'}).getChainId('livenet');
+    expect(livenetId).to.equal(1);
+
+    const testId = Transactions.get({chain: 'ETH'}).getChainId('testnet');
+    expect(testId).to.equal(42);
+
+    const kovanId = Transactions.get({chain: 'ETH'}).getChainId('kovan');
+    expect(kovanId).to.equal(42);
+
+    const rinkebyId = Transactions.get({chain: 'ETH'}).getChainId('rinkeby');
+    expect(rinkebyId).to.equal(4);
+
+    const ropstenId = Transactions.get({chain: 'ETH'}).getChainId('ropsten');
+    expect(ropstenId).to.equal(3);
   });
 });


### PR DESCRIPTION
- Removed deprecated `fee: gasPrice`

In BWC/BWS, we are spreading `...txp` or `...this` to pass in `txp.network` or `this.network` into `CWC.Transactions.create`

**BWC:**
```
const { outputs, amount, gasPrice } = txp;
      const rawTx = Transactions.create({
        ...txp,
        chain: coin.toUpperCase(),
        recipients: [{ address: outputs[0].toAddress, amount }]
      });
      return { uncheckedSerialize: () => rawTx };
```

**BWS:**
```
const rawTx = Transactions.create({
        ...this,
        chain: this.coin.toUpperCase(),
        recipients: [{ address: this.outputs[0].toAddress, amount: this.amount}]
      });
```

CWC takes in network param to derive chainCode under the assumption testnet will always be Kovan network.