### PR TITLE
New endpoint - /block/:blockHeight/coins

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/index.ts
+++ b/packages/bitcore-node/src/providers/chain-state/index.ts
@@ -11,8 +11,8 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return services[chain];
   }
 
-  streamUnspentsByBlock(params: CSP.GetUnspentsFromBlockParams) {
-    return this.get(params).streamUnspentsByBlock(params);
+  streamCoinsByBlock(params: CSP.StreamCoinsByBlockParams) {
+    return this.get(params).streamCoinsByBlock(params);
   }
 
   streamAddressUtxos(params: CSP.StreamAddressUtxosParams) {

--- a/packages/bitcore-node/src/providers/chain-state/index.ts
+++ b/packages/bitcore-node/src/providers/chain-state/index.ts
@@ -11,6 +11,10 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return services[chain];
   }
 
+  streamUnspentsByBlock(params: CSP.GetUnspentsFromBlockParams) {
+    return this.get(params).streamUnspentsByBlock(params);
+  }
+
   streamAddressUtxos(params: CSP.StreamAddressUtxosParams) {
     return this.get(params).streamAddressUtxos(params);
   }

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -565,6 +565,24 @@ export class InternalStateProvider implements CSP.IChainStateService {
     }
   }
 
+  streamUnspentsByBlock(params: CSP.GetUnspentsFromBlockParams) {
+    const { req, res, args } = params;
+    const { limit, since, paging } = args;
+
+
+    if (typeof params.blockHeight !== 'number' || !params.chain || !params.network)
+      throw 'Missing required param';
+
+    let query = {
+      chain: params.chain,
+      network: params.network,
+      mintHeight: params.blockHeight
+    };
+    let searchOptions = { limit, since, paging: paging ? paging : '_id' };
+
+    Storage.apiStreamingFind(CoinStorage, query, searchOptions, req, res);
+  }
+
   private isValidBlockOrTx(inputValue: string): boolean {
     const regexp = /^[0-9a-fA-F]{64}$/;
     if (regexp.test(inputValue)) {

--- a/packages/bitcore-node/src/routes/api/block.ts
+++ b/packages/bitcore-node/src/routes/api/block.ts
@@ -79,6 +79,26 @@ router.get('/before-time/:time', async function(req: Request, res: Response) {
   }
 });
 
+
+router.get('/:blockId/coins', async function(req: Request, res: Response) {
+  let { blockId, chain, network } = req.params;
+  let { limit = 10, since, paging = '_id' } = req.query;
+  let payload = {
+    chain,
+    network,
+    blockHeight: Number(blockId),
+    req,
+    res,
+    args: { limit, since, paging }
+  };
+  try {
+    return ChainStateProvider.streamUnspentsByBlock(payload);
+  }
+  catch(err) {
+    return res.status(500).send(err);
+  }
+});
+
 module.exports = {
   router: router,
   path: '/block'

--- a/packages/bitcore-node/src/routes/api/block.ts
+++ b/packages/bitcore-node/src/routes/api/block.ts
@@ -82,17 +82,17 @@ router.get('/before-time/:time', async function(req: Request, res: Response) {
 
 router.get('/:blockId/coins', async function(req: Request, res: Response) {
   let { blockId, chain, network } = req.params;
-  let { limit = 10, since, paging = '_id' } = req.query;
+  let { limit = 10, since, paging = '_id', onlyUnspent = false } = req.query;
   let payload = {
     chain,
     network,
     blockHeight: Number(blockId),
     req,
     res,
-    args: { limit, since, paging }
+    args: { limit, since, paging, onlyUnspent }
   };
   try {
-    return ChainStateProvider.streamUnspentsByBlock(payload);
+    return ChainStateProvider.streamCoinsByBlock(payload);
   }
   catch(err) {
     return res.status(500).send(err);

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -121,12 +121,12 @@ export declare namespace CSP {
     input: string;
   }
 
-  export type GetUnspentsFromBlockArgs = { unspent: boolean; };
-  export type GetUnspentsFromBlockParams = ChainNetwork & {
+  export type StreamCoinsByBlockArgs = { onlyUnspent: boolean; };
+  export type StreamCoinsByBlockParams = ChainNetwork & {
     blockHeight: number;
     req: Request;
     res: Response;
-    args: Partial<GetUnspentsFromBlockArgs & StreamingFindOptions<ICoin> & any>;
+    args: Partial<StreamCoinsByBlockArgs & StreamingFindOptions<ICoin> & any>;
   };
 
 
@@ -164,7 +164,7 @@ export declare namespace CSP {
     getLocalTip(params): Promise<IBlock | null>;
     getLocatorHashes(params): Promise<any>;
     isValid(params: isValidParams): {isValid: boolean, type:string};
-    streamUnspentsByBlock(params: GetUnspentsFromBlockParams): any;
+    streamCoinsByBlock(params: StreamCoinsByBlockParams): any;
   }
 
   type ChainStateServices = { [key: string]: IChainStateService };

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -121,6 +121,15 @@ export declare namespace CSP {
     input: string;
   }
 
+  export type GetUnspentsFromBlockArgs = { unspent: boolean; };
+  export type GetUnspentsFromBlockParams = ChainNetwork & {
+    blockHeight: number;
+    req: Request;
+    res: Response;
+    args: Partial<GetUnspentsFromBlockArgs & StreamingFindOptions<ICoin> & any>;
+  };
+
+
   export type Provider<T> = { get(params: { chain: string }): T };
   export type ChainStateProvider = Provider<IChainStateService> & IChainStateService;
   export interface IChainStateService {
@@ -155,6 +164,7 @@ export declare namespace CSP {
     getLocalTip(params): Promise<IBlock | null>;
     getLocatorHashes(params): Promise<any>;
     isValid(params: isValidParams): {isValid: boolean, type:string};
+    streamUnspentsByBlock(params: GetUnspentsFromBlockParams): any;
   }
 
   type ChainStateServices = { [key: string]: IChainStateService };


### PR DESCRIPTION
-Added a new endpoint to bitcore-node: /block/:blockHeight/coins, which returns all the coins from a blockHeight