### PR TITLE
Convert only bch change address. Fix #2511

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -2781,7 +2781,7 @@ export class WalletService {
                   'NewTxProposal',
                   txp,
                   () => {
-                    if (opts.noCashAddr) {
+                    if (opts.noCashAddr && txp.coin == 'bch') {
                       if (txp.changeAddress) {
                         txp.changeAddress.address = BCHAddressTranslator.translate(
                           txp.changeAddress.address,


### PR DESCRIPTION
`noCashAddr` that is hard coded to `true` in `/v1/txproposals/:id/publish/` convert, in the wrong way,  the btc change address. The translation should be done only with bch transaction proposal.