### PR TITLE
Fix(BWS) - Duplicate Txps

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -41,9 +41,9 @@ export class EthChain implements IChain {
       if (err) {
         return cb(err);
       }
-      server.getPendingTxs({}, (err, txps) => {
+      server.getPendingTxs(opts, (err, txps) => {
         if (err) return cb(err);
-        const lockedSum = _.sumBy(txps, 'amount');
+        const lockedSum = _.sumBy(txps, 'amount') || 0;
         const convertedBalance = this.convertBitcoreBalance(balance, lockedSum);
         server.storage.fetchAddresses(
           server.walletId,

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -770,7 +770,7 @@ export class WalletService {
           });
         },
         (next) => {
-          this.getPendingTxs({}, (err, pendingTxps) => {
+          this.getPendingTxs(opts, (err, pendingTxps) => {
             if (err) return next(err);
             status.pendingTxps = pendingTxps;
             next();
@@ -3227,6 +3227,9 @@ export class WalletService {
    * @returns {TxProposal[]} Transaction proposal.
    */
   getPendingTxs(opts, cb) {
+    if (opts.tokenAddress) {
+      return cb();
+    }
     this.storage.fetchPendingTxs(this.walletId, (err, txps) => {
       if (err) return cb(err);
 


### PR DESCRIPTION
If token wallet:
- do not assign token wallet.pendingTxs causing duplicate txps

Problem:
ETH and token wallets share the same `this.walletId`

So `this.getPendingTxs` is being assigned twice both to ETH and Token wallet.