### PR TITLE
Fix(Node) - BTC/BCH does not use chainTips cache

### DIFF
--- a/packages/bitcore-node/src/models/block.ts
+++ b/packages/bitcore-node/src/models/block.ts
@@ -84,7 +84,6 @@ export class BitcoinBlock extends BaseBlock<IBtcBlock> {
     }
 
     await this.collection.updateOne({ hash: convertedBlock.hash, chain, network }, { $set: { processed: true } });
-    this.updateCachedChainTip({ block: convertedBlock, chain, network });
   }
 
   async getBlockOp(params: { block: Bitcoin.Block; chain: string; network: string }) {
@@ -152,9 +151,7 @@ export class BitcoinBlock extends BaseBlock<IBtcBlock> {
       const prevBlock = await this.collection.findOne({ chain, network, hash: header.prevHash });
       if (prevBlock) {
         localTip = prevBlock;
-        this.updateCachedChainTip({ chain, network, block: prevBlock });
       } else {
-        delete this.chainTips[chain][network];
         logger.error(`Previous block isn't in the DB need to roll back until we have a block in common`);
       }
       logger.info(`Resetting tip to ${localTip.height - 1}`, { chain, network });

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -420,7 +420,7 @@ export class InternalStateProvider implements CSP.IChainStateService {
     }
     const tip = await this.getLocalTip(params);
     const tipHeight = tip ? tip.height : 0;
-    const utxoTransform = (c: ICoin): string => {
+    const utxoTransform = (c: Partial<ICoin>): string => {
       let confirmations = 0;
       if (c.mintHeight && c.mintHeight >= 0) {
         confirmations = tipHeight - c.mintHeight + 1;

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -541,11 +541,7 @@ export class InternalStateProvider implements CSP.IChainStateService {
   }
 
   async getLocalTip({ chain, network }) {
-    if (BitcoinBlockStorage.chainTips[chain] && BitcoinBlockStorage.chainTips[chain][network]) {
-      return BitcoinBlockStorage.chainTips[chain][network];
-    } else {
-      return BitcoinBlockStorage.getLocalTip({ chain, network });
-    }
+    return BitcoinBlockStorage.getLocalTip({ chain, network });
   }
 
   /**

--- a/packages/bitcore-node/test/unit/models/block.unit.ts
+++ b/packages/bitcore-node/test/unit/models/block.unit.ts
@@ -18,7 +18,8 @@ describe('Block Model', function() {
     network: 'regtest',
     block: TEST_BLOCK,
     height: 1355,
-    initialSyncComplete: false
+    initialSyncComplete: false,
+    processed: true
   };
 
   describe('addBlock', () => {
@@ -90,10 +91,11 @@ describe('Block Model', function() {
       sandbox.restore();
     });
     it('should return the new tip', async () => {
-      mockStorage(null);
+      let newBlock = Object.assign({ save: () => Promise.resolve() }, BitcoinBlockStorage, addBlockParams);
+      mockStorage(newBlock);
       const params = { chain: 'BTC', network: 'regtest' };
       const result = await ChainStateProvider.getLocalTip(params);
-      expect(result!.height).to.deep.equal(addBlockParams.height + 1);
+      expect(result!.height).to.deep.equal(addBlockParams.height);
       expect(result!.chain).to.deep.equal(addBlockParams.chain);
       expect(result!.network).to.deep.equal(addBlockParams.network);
     });


### PR DESCRIPTION
Using chainTips cache causes delays on accurate localTip `height`

`testnet` does not work with chainTips cache

ETH has never used the chainTips cache from the beginning.