### PR TITLE
Generate Blockchain explorers urls from config

### DIFF
--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -21,42 +21,45 @@ module.exports = {
 
   storageOpts: {
     mongoDb: {
-      uri: 'mongodb://localhost:27017/bws',
-    },
+      uri: 'mongodb://localhost:27017/bws'
+    }
   },
   messageBrokerOpts: {
     //  To use message broker server, uncomment this:
     messageBrokerServer: {
-      url: 'http://localhost:3380',
-    },
+      url: 'http://localhost:3380'
+    }
   },
   blockchainExplorerOpts: {
-    btc: {
-      livenet: {
-        url: 'https://api.bitcore.io',
+    chains: {
+      btc: {
+        livenet: {
+          url: 'https://api.bitcore.io'
+        },
+        testnet: {
+          url: 'https://api.bitcore.io',
+          regtestEnabled: false
+        }
       },
-      testnet: {
-        url: 'https://api.bitcore.io',
-        regtestEnabled: false
+      bch: {
+        livenet: {
+          url: 'https://api.bitcore.io'
+        },
+        testnet: {
+          url: 'https://api.bitcore.io'
+        }
       },
+      eth: {
+        livenet: {
+          url: 'https://api-eth.bitcore.io'
+        },
+        testnet: {
+          url: 'https://api-eth.bitcore.io'
+        }
+      }
     },
-    bch: {
-      livenet: {
-        url: 'https://api.bitcore.io',
-      },
-      testnet: {
-        url: 'https://api.bitcore.io',
-      },
-    },
-    eth: {
-      livenet: {
-        url: 'https://api-eth.bitcore.io',
-      },
-      testnet: {
-        url: 'https://api-eth.bitcore.io',
-      },
-    },
-    socketApiKey: 'socketApiKey'
+    socketApiKey:
+    '785bc59c8e1a7f6be7b35281c4138b62a0c53262eb96ea1713df1693f870af0b'
   },
   pushNotificationsOpts: {
     templatePath: 'templates',
@@ -64,15 +67,15 @@ module.exports = {
     defaultUnit: 'btc',
     subjectPrefix: '',
     pushServerUrl: 'https://fcm.googleapis.com/fcm',
-    authorizationKey: 'You_have_to_put_something_here',
+    authorizationKey: 'You_have_to_put_something_here'
   },
   fiatRateServiceOpts: {
     defaultProvider: 'BitPay',
-    fetchInterval: 60, // in minutes
+    fetchInterval: 60 // in minutes
   },
   maintenanceOpts: {
-    maintenanceMode: false,
-  },
+    maintenanceMode: false
+  }
   // simplex: {
   //   sandbox: {
   //     apiKey: 'simplex_sandbox_api_key_here',

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { V8 } from './blockchainexplorers/v8';
 import { ChainService } from './chain/index';
+const config = require('../config');
 
 const $ = require('preconditions').singleton();
 const Common = require('./common');
@@ -8,21 +9,19 @@ const Defaults = Common.Defaults;
 let log = require('npmlog');
 log.debug = log.verbose;
 
-const PROVIDERS = {
-  v8: {
-    btc: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
-    },
-    bch: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
-    },
-    eth: {
-      livenet: 'https://api-eth.bitcore.io',
-      testnet: 'https://api-eth.bitcore.io'
+const v8Providers = Object.keys(config.blockchainExplorerOpts.chains).reduce(
+  (obj, chain) => {
+    obj[chain] = {};
+    const networks = Object.keys(config.blockchainExplorerOpts.chains[chain]);
+    for (const network of networks) {
+      obj[chain][network] = config.blockchainExplorerOpts.chains[chain][network].url;
     }
-  }
+    return obj;
+  },
+  {}
+);
+const PROVIDERS = {
+  v8: v8Providers
 };
 
 export function BlockChainExplorer(opts) {

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -25,7 +25,7 @@ function v8network(bwsNetwork) {
   if (bwsNetwork == 'livenet') return 'mainnet';
   if (
     bwsNetwork == 'testnet' &&
-    config.blockchainExplorerOpts.btc.testnet.regtestEnabled
+    config.blockchainExplorerOpts.chains.btc.testnet.regtestEnabled
   ) {
     return 'regtest';
   }

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1528,10 +1528,11 @@ export class WalletService {
     if (this.blockchainExplorer) return this.blockchainExplorer;
     if (this.blockchainExplorerOpts) {
       if (
-        this.blockchainExplorerOpts[coin] &&
-        this.blockchainExplorerOpts[coin][network]
+        this.blockchainExplorerOpts.chains &&
+        this.blockchainExplorerOpts.chains[coin] &&
+        this.blockchainExplorerOpts.chains[coin][network]
       ) {
-        opts = this.blockchainExplorerOpts[coin][network];
+        opts = this.blockchainExplorerOpts.chains[coin][network];
         provider = opts.provider;
       } else if (this.blockchainExplorerOpts[network]) {
         opts = this.blockchainExplorerOpts[network];


### PR DESCRIPTION
Currently when developing, if you were to point BWS to your local bitcore-node, you'd need to change it in both config.ts, and the blockchain explorers file.

This pull request aims to remove the need to modify the blockchain explorers file.