### PR TITLE
Adds transform of block-before-time response for xrp to better match other currencies

### DIFF
--- a/packages/bitcore-node/src/modules/ripple/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ripple/api/csp.ts
@@ -93,7 +93,15 @@ export class RippleStateProvider extends InternalStateProvider implements CSP.IC
         if (err) {
           return reject(err);
         } else {
-          return resolve(body);
+          return resolve({
+            ...body.ledger,
+            chain: this.chain,
+            network,
+            hash: body.ledger.ledger_hash,
+            height: body.ledger.ledger_index,
+            previousBlockHash: body.ledger.parent_hash,
+            timeNormalized: new Date((body.ledger.close_time) * 1000)
+          });
         }
       });
     });


### PR DESCRIPTION
This commit transforms the ripple api response to be similar to BTC/BCH/ETH responses for block-before-time route.