### PR TITLE
Fix(CWC) - Change bitpay/ripple-keypair commit to Buffer fix

### DIFF
--- a/packages/crypto-wallet-core/package-lock.json
+++ b/packages/crypto-wallet-core/package-lock.json
@@ -3049,8 +3049,8 @@
 			}
 		},
 		"ripple-keypairs": {
-			"version": "git+https://git@github.com/bitpay/ripple-keypairs.git#27ee0765486555cfe6a1fd60e207e32765a078bb",
-			"from": "git+https://git@github.com/bitpay/ripple-keypairs.git#27ee0765486555cfe6a1fd60e207e32765a078bb",
+			"version": "git+https://git@github.com/bitpay/ripple-keypairs.git#81db98a4034c0d897999d9c5d3c90b3d601c5fa8",
+			"from": "git+https://git@github.com/bitpay/ripple-keypairs.git#81db98a4034c0d897999d9c5d3c90b3d601c5fa8",
 			"requires": {
 				"babel-runtime": "^5.8.20",
 				"base-x": "3.0.4",

--- a/packages/crypto-wallet-core/package.json
+++ b/packages/crypto-wallet-core/package.json
@@ -26,7 +26,7 @@
     "bitcore-lib-cash": "^8.13.2",
     "ethers": "4.0.37",
     "ripple-binary-codec": "0.2.4",
-    "ripple-keypairs": "git+https://git@github.com/bitpay/ripple-keypairs.git#27ee0765486555cfe6a1fd60e207e32765a078bb",
+    "ripple-keypairs": "git+https://git@github.com/bitpay/ripple-keypairs.git#81db98a4034c0d897999d9c5d3c90b3d601c5fa8",
     "ripple-lib": "1.4.2",
     "web3": "1.2.1"
   },


### PR DESCRIPTION
https://github.com/bitpay/ripple-keypairs/pull/2

commit hash: #81db98a4034c0d897999d9c5d3c90b3d601c5fa8