### PR TITLE
Bitcore-Client: Fix Register to work with URL without /api

### DIFF
--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -46,7 +46,7 @@ export class Wallet {
   constructor(params: Wallet | Wallet.WalletObj) {
     Object.assign(this, params);
     if (!this.baseUrl) {
-      this.baseUrl = `https://api.bitcore.io/api`;
+      this.baseUrl = `https://api.bitcore.io`;
     }
     this.client = new Client({
       apiUrl: this.getApiUrl(),
@@ -55,7 +55,7 @@ export class Wallet {
   }
 
   getApiUrl() {
-    return `${this.baseUrl}/${this.chain}/${this.network}`;
+    return `${this.baseUrl}/api/${this.chain}/${this.network}`;
   }
 
   saveWallet() {


### PR DESCRIPTION
We really should only need to pass in api.bitcore.io without /api