### PR TITLE
Revert web3 upgrade down to 1.2.1

### DIFF
--- a/packages/crypto-wallet-core/package.json
+++ b/packages/crypto-wallet-core/package.json
@@ -33,7 +33,7 @@
     "ripple-binary-codec": "0.2.6",
     "ripple-keypairs": "git+https://git@github.com/bitpay/ripple-keypairs.git#8d3a4643a8ddfce8222786e1e5a3e85a89a5b7f5",
     "ripple-lib": "1.4.2",
-    "web3": "1.2.4"
+    "web3": "1.2.1"
   },
   "devDependencies": {
     "@types/chai": "4.1.7",

--- a/packages/crypto-wallet-core/src/transactions/erc20/abi.ts
+++ b/packages/crypto-wallet-core/src/transactions/erc20/abi.ts
@@ -1,7 +1,4 @@
-import { Contract } from 'web3-eth-contract';
-export type ContractAbiInput = ConstructorParameters<typeof Contract>[0];
-
-export const ERC20Abi: ContractAbiInput = [
+export const ERC20Abi = [
   {
     constant: true,
     inputs: [],


### PR DESCRIPTION
fixes `BWC v8.16.0` browser error:

<img width="596" alt="Screen Shot 2020-02-14 at 10 26 09 AM" src="https://user-images.githubusercontent.com/23103037/75279392-88088180-57d9-11ea-9664-f0b3840013a6.png">

`secp256k1` is node only package and required by `ethereumjs` packages that were added as a dependency for `"web3": "^1.2.4"`.

related issue:

https://github.com/ethereumjs/ethereumjs-util/issues/240