### PR TITLE
Allow web3 provider options for bitcore.config.js

### DIFF
--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -69,6 +69,7 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
       const protocol = provider.protocol || 'http';
       const portString = provider.port || '8545';
       const connUrl = `${protocol}://${host}:${portString}`;
+      const providerOptions = provider.options || {}; 
       let ProviderType;
       switch (provider.protocol) {
         case 'ws':
@@ -79,7 +80,7 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
           ProviderType = Web3.providers.HttpProvider;
           break;
       }
-      ETHStateProvider.web3[network] = new Web3(new ProviderType(connUrl));
+      ETHStateProvider.web3[network] = new Web3(new ProviderType(connUrl, providerOptions));
     }
     return ETHStateProvider.web3[network];
   }


### PR DESCRIPTION
There's web3 provider issue when rpc result is too big it fails to keep connection (especially **WS provider**)
For example, 

- a lot of transactions (ex: ropsten 599275th block)
- a lot of trace_block

For this issue, we can pass Web3 constructor's options when initiate Web3.
I edited small amount of codes which can allow web3 can have options.
Now we can append options to Web3 like below.
![image](https://user-images.githubusercontent.com/5516480/75756400-f0280c00-5d73-11ea-9b74-bb50cd8f1f80.png)


FYI, here's my original issue #2735 
And here's web3 issue about clientConfig https://github.com/ethereum/web3.js/issues/1217#issuecomment-425956862

Always, thank you @micahriggan  :) 