### PR TITLE
Spend a multisig address built from non-sorted public keys

### DIFF
--- a/packages/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib-cash/lib/transaction/input/multisigscripthash.js
@@ -29,7 +29,7 @@ function MultiSigScriptHashInput(input, pubkeys, threshold, signatures, opts) {
   } else  {
     this.publicKeys = _.sortBy(pubkeys, function(publicKey) { return publicKey.toString('hex'); });
   }
-  this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold);
+  this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold, opts);
   $.checkState(Script.buildScriptHashOut(this.redeemScript).equals(this.output.script),
                'Provided public keys don\'t hash to the provided output');
   this.publicKeyIndex = {};

--- a/packages/bitcore-lib-cash/test/transaction/input/multisigscripthash.js
+++ b/packages/bitcore-lib-cash/test/transaction/input/multisigscripthash.js
@@ -111,4 +111,24 @@ describe('MultiSigScriptHashInput', function() {
     var roundtrip = new MultiSigScriptHashInput(input.toObject());
     roundtrip.toObject().should.deep.equal(input.toObject());
   });
+  it('can build a redeem script from non-sorted public keys with a noSorting option', function() {
+    var nonSortedPublicKeys = [public1, public2, public3];
+    var threshold = 2;
+    var opts = { noSorting: true };
+    var nonSortedRedeemScript = Script.buildMultisigOut(nonSortedPublicKeys, threshold, opts);
+    var nonSortedAddress = Address.payingTo(nonSortedRedeemScript);
+
+    nonSortedAddress.toLegacyAddress().should.equal('HLEAcJ3iYF5sRGR4oSowZx5fuqigfD5Ah7');
+
+    var nonSortedOutput = Object.assign({}, output, {
+      address: nonSortedAddress.toLegacyAddress(),
+      script: new Script(nonSortedAddress)
+    });
+    var transaction = new Transaction()
+      .from(nonSortedOutput, nonSortedPublicKeys, threshold, opts)
+      .to(address, 1000000);
+    var input = transaction.inputs[0];
+
+    input.redeemScript.equals(nonSortedRedeemScript).should.equal(true);
+  });
 });


### PR DESCRIPTION
When you try to spend a multisig address built from non-sorted public keys by `bitcore-lib-cash`, you'll get the following error:
```
Invalid state: Provided public keys don't hash to the provided output
```
Source:
```
const bitcore = require('bitcore-lib-cash');

const Address = bitcore.Address;
const PublicKey = bitcore.PublicKey;
const Script = bitcore.Script;
const Transaction = bitcore.Transaction;

const pubkey1 = new PublicKey('025c95ec627038e85b5688a9b3d84d28c5ebe66e8c8d697d498e20fe96e3b1ab1d');
const pubkey2 = new PublicKey('02cdddfc974d41a62f1f80081deee70592feb7d6e6cf6739d6592edbe7946720e7');
const pubkey3 = new PublicKey('03c95924e02c240b5545089c69c6432447412b58be43fd671918bd184a50098343');
const pubkeys = [pubkey2, pubkey1, pubkey3];
const threshold = 2;
const opts = { noSorting: true };
const redeemScript = Script.buildMultisigOut(pubkeys, threshold, opts);
const address = Address.payingTo(redeemScript);
const output = {
  address: address,
  txId: '66e64ef8a3b384164b78453fa8c8194de9a473ba14f89485a0e433699daec140',
  outputIndex: 0,
  script: new Script(address),
  satoshis: 1000000
}
const transaction = new Transaction();

// Invalid state: Provided public keys don't hash to the provided output
transaction.from(output, pubkeys, threshold, opts);
```

This patch fixes the issue by passing a `noSorting` option to `Script.buildMultisigOut` when building a redeem script in  `MultiSigScriptHashInput`.