### PR TITLE
support BIP68

### DIFF
--- a/packages/bitcore-build/package-lock.json
+++ b/packages/bitcore-build/package-lock.json
@@ -2551,7 +2551,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2569,11 +2570,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2586,15 +2589,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2697,7 +2703,8 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2707,6 +2714,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2719,17 +2727,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -2746,6 +2757,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2826,7 +2838,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2836,6 +2849,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2911,7 +2925,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2941,6 +2956,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2958,6 +2974,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2996,11 +3013,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/bitcore-lib-cash/lib/errors/spec.js
+++ b/packages/bitcore-lib-cash/lib/errors/spec.js
@@ -66,7 +66,14 @@ module.exports = [{
     }, {
       name: 'MissingPreviousOutput',
       message: 'No previous output information.'
-    }]
+    }, {
+      name: 'BlockHeightOutOfRange',
+      message: 'Block Height can only be between 0 and 65535'
+    } , {
+      name: 'LockTimeRange',
+      message: 'Seconds needs to be more that 0 and less that 33553920'
+    }
+    ]
   }, {
     name: 'NeedMoreInfo',
     message: '{0}'

--- a/packages/bitcore-lib-cash/lib/transaction/input/input.js
+++ b/packages/bitcore-lib-cash/lib/transaction/input/input.js
@@ -15,6 +15,14 @@ var MAXINT = 0xffffffff; // Math.pow(2, 32) - 1;
 var DEFAULT_RBF_SEQNUMBER = MAXINT - 2;
 var DEFAULT_SEQNUMBER = MAXINT;
 var DEFAULT_LOCKTIME_SEQNUMBER = MAXINT - 1;
+const SEQUENCE_LOCKTIME_DISABLE_FLAG =  Math.pow(2,31); // (1 << 31);
+const SEQUENCE_LOCKTIME_TYPE_FLAG = Math.pow(2,22); // (1 << 22);
+const SEQUENCE_LOCKTIME_MASK = 0xffff;
+const SEQUENCE_LOCKTIME_GRANULARITY = 512; // 512 seconds
+const SEQUENCE_BLOCKDIFF_LIMIT = Math.pow(2,16)-1; // 16 bits 
+
+
+
 
 function Input(params) {
   if (!(this instanceof Input)) {
@@ -29,6 +37,7 @@ Input.MAXINT = MAXINT;
 Input.DEFAULT_SEQNUMBER = DEFAULT_SEQNUMBER;
 Input.DEFAULT_LOCKTIME_SEQNUMBER = DEFAULT_LOCKTIME_SEQNUMBER;
 Input.DEFAULT_RBF_SEQNUMBER = DEFAULT_RBF_SEQNUMBER;
+Input.SEQUENCE_LOCKTIME_TYPE_FLAG = SEQUENCE_LOCKTIME_TYPE_FLAG;
 
 Object.defineProperty(Input.prototype, 'script', {
   configurable: false,
@@ -200,5 +209,68 @@ Input.prototype.isNull = function() {
 Input.prototype._estimateSize = function() {
   return this.toBufferWriter().toBuffer().length;
 };
+
+
+/**
+ * Sets sequence number so that transaction is not valid until the desired seconds
+ *  since the transaction is mined
+ *
+ * @param {Number} time in seconds
+ * @return {Transaction} this
+ */
+Input.prototype.lockForSeconds = function(seconds) {
+  $.checkArgument(_.isNumber(seconds));
+  if (seconds < 0 ||  seconds >= SEQUENCE_LOCKTIME_GRANULARITY * SEQUENCE_LOCKTIME_MASK) {
+    throw new errors.Transaction.Input.LockTimeRange();
+  }
+  seconds = parseInt(Math.floor(seconds / SEQUENCE_LOCKTIME_GRANULARITY));
+
+  // SEQUENCE_LOCKTIME_DISABLE_FLAG = 1 
+  this.sequenceNumber = seconds | SEQUENCE_LOCKTIME_TYPE_FLAG ;
+  return this;
+};
+
+/**
+ * Sets sequence number so that transaction is not valid until the desired block height differnece since the tx is mined
+ *
+ * @param {Number} height
+ * @return {Transaction} this
+ */
+Input.prototype.lockUntilBlockHeight = function(heightDiff) {
+  $.checkArgument(_.isNumber(heightDiff));
+  if (heightDiff < 0 || heightDiff >= SEQUENCE_BLOCKDIFF_LIMIT) {
+    throw new errors.Transaction.Input.BlockHeightOutOfRange();
+  }
+  // SEQUENCE_LOCKTIME_TYPE_FLAG = 0
+  // SEQUENCE_LOCKTIME_DISABLE_FLAG = 0
+  this.sequenceNumber = heightDiff ;
+  return this;
+};
+
+
+/**
+ *  Returns a semantic version of the input's sequence nLockTime.
+ *  @return {Number|Date}
+ *  If sequence lock is disabled  it returns null,
+ *  if is set to block height lock, returns a block height (number)
+ *  else it returns a Date object.
+ */
+Input.prototype.getLockTime = function() {
+  if (this.sequenceNumber & SEQUENCE_LOCKTIME_DISABLE_FLAG) {
+    return null;
+  }
+
+  if (this.sequenceNumber & SEQUENCE_LOCKTIME_TYPE_FLAG) {
+    var seconds = SEQUENCE_LOCKTIME_GRANULARITY * (this.sequenceNumber & SEQUENCE_LOCKTIME_MASK);
+    return seconds;
+    return s;
+  } else {
+    var blockHeight = this.sequenceNumber & SEQUENCE_LOCKTIME_MASK;
+    return blockHeight;
+  }
+};
+
+
+
 
 module.exports = Input;

--- a/packages/bitcore-lib-cash/lib/transaction/input/input.js
+++ b/packages/bitcore-lib-cash/lib/transaction/input/input.js
@@ -263,7 +263,6 @@ Input.prototype.getLockTime = function() {
   if (this.sequenceNumber & SEQUENCE_LOCKTIME_TYPE_FLAG) {
     var seconds = SEQUENCE_LOCKTIME_GRANULARITY * (this.sequenceNumber & SEQUENCE_LOCKTIME_MASK);
     return seconds;
-    return s;
   } else {
     var blockHeight = this.sequenceNumber & SEQUENCE_LOCKTIME_MASK;
     return blockHeight;

--- a/packages/bitcore-lib-cash/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/lib/transaction/transaction.js
@@ -58,7 +58,7 @@ function Transaction(serialized) {
   }
 }
 
-var CURRENT_VERSION = 1;
+var CURRENT_VERSION = 2;
 var DEFAULT_NLOCKTIME = 0;
 var MAX_BLOCK_SIZE = 1000000;
 
@@ -1226,5 +1226,15 @@ Transaction.prototype.verify = function() {
 Transaction.prototype.isCoinbase = function() {
   return (this.inputs.length === 1 && this.inputs[0].isNull());
 };
+
+
+Transaction.prototype.setVersion = function(version) {
+  $.checkArgument(
+    JSUtil.isNaturalNumber(version) && version <= CURRENT_VERSION, 
+    'Wrong version number');
+  this.version = version;
+  return this;
+};
+
 
 module.exports = Transaction;

--- a/packages/bitcore-lib-cash/package-lock.json
+++ b/packages/bitcore-lib-cash/package-lock.json
@@ -65,7 +65,7 @@
 		},
 		"ansi-colors": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
 			"dev": true,
 			"requires": {
@@ -1379,7 +1379,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1400,12 +1401,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1420,17 +1423,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1547,7 +1553,8 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1559,6 +1566,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1573,6 +1581,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1580,12 +1589,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1604,6 +1615,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1693,7 +1705,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1705,6 +1718,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1790,7 +1804,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1826,6 +1841,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1845,6 +1861,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1888,12 +1905,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -2531,7 +2550,7 @@
 		},
 		"magic-string": {
 			"version": "0.22.5",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+			"resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
 			"dev": true,
 			"requires": {
@@ -2721,7 +2740,7 @@
 		},
 		"next-tick": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
 			"dev": true
 		},
@@ -2924,7 +2943,7 @@
 		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
@@ -3325,7 +3344,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -3702,7 +3721,7 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"requires": {
@@ -4091,7 +4110,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {

--- a/packages/bitcore-lib-cash/test/script/interpreter.js
+++ b/packages/bitcore-lib-cash/test/script/interpreter.js
@@ -241,6 +241,7 @@ describe('Interpreter', function() {
     var hashbuf = Buffer.alloc(32);
     hashbuf.fill(0);
     var credtx = new Transaction();
+    credtx.setVersion(1);
     credtx.uncheckedAddInput(new Transaction.Input({
       prevTxId: '0000000000000000000000000000000000000000000000000000000000000000',
       outputIndex: 0xffffffff,
@@ -254,6 +255,7 @@ describe('Interpreter', function() {
     var idbuf = credtx.id;
 
     var spendtx = new Transaction();
+    spendtx.setVersion(1);
     spendtx.uncheckedAddInput(new Transaction.Input({
       prevTxId: idbuf.toString('hex'),
       outputIndex: 0,
@@ -323,6 +325,7 @@ describe('Interpreter', function() {
           });
 
           var tx = new Transaction(txhex);
+          tx.setVersion(1);
           var allInputsVerified = true;
           tx.inputs.forEach(function(txin, j) {
             if (txin.isNull()) {

--- a/packages/bitcore-lib-cash/test/transaction/input/input.js
+++ b/packages/bitcore-lib-cash/test/transaction/input/input.js
@@ -96,4 +96,40 @@ describe('Transaction.Input', function() {
     var input = new Input(output);
     input._estimateSize().should.equal(66);
   });
+
+  describe('handling the BIP68 (sequenceNumber locktime)', function() {
+    var blockHeight = 3434;
+    it('handles a null locktime', function() {
+      var input = new Input(output);
+      expect(input.getLockTime()).to.equal(null);
+    });
+    it('handles a simple seconds example', function() {
+      var input = new Input()
+        .lockForSeconds(1e5);
+
+      var expected = (parseInt(1e5 / 512) * 512) ;
+      input.getLockTime().should.deep.equal(expected);
+
+      expected = (Math.floor(expected/512) ) | Input.SEQUENCE_LOCKTIME_TYPE_FLAG;
+      input.sequenceNumber.should.equal(expected | Input.SEQUENCE_LOCKTIME_TYPE_FLAG);
+    });
+    it('accepts a block height', function() {
+      var input = new Input()
+        .lockUntilBlockHeight(blockHeight);
+
+      input.sequenceNumber.should.equal(blockHeight);
+      input.getLockTime().should.deep.equal(blockHeight);
+    });
+    it('fails if the block height is too high', function() {
+      expect(function() {
+        return new Input().lockUntilBlockHeight(5e8);
+      }).to.throw(errors.Transaction.Input.BlockHeightOutOfRange);
+    });
+    it('fails if the block height is negative', function() {
+      expect(function() {
+        return new Input().lockUntilBlockHeight(-1);
+      }).to.throw(errors.Transaction.Input.BlockHeightOutOfRange);
+    });
+  });
+
 });

--- a/packages/bitcore-lib-cash/test/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/test/transaction/transaction.js
@@ -183,7 +183,7 @@ describe('Transaction', function() {
       index++;
       it('case ' + index, function() {
         var i = 0;
-        var transaction = new Transaction();
+        var transaction = (new Transaction()).setVersion(1);
         while (i < vector.length) {
           var command = vector[i];
           var args = vector[i + 1];
@@ -1217,7 +1217,7 @@ describe('Transaction', function() {
 });
 
 
-var tx_empty_hex = '01000000000000000000';
+var tx_empty_hex = '02000000000000000000';
 
 /* jshint maxlen: 1000 */
 var tx_1_hex = '01000000015884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4000000006a473044022013fa3089327b50263029265572ae1b022a91d10ac80eb4f32f291c914533670b02200d8a5ed5f62634a7e1a0dc9188a3cc460a986267ae4d58faf50c79105431327501210223078d2942df62c45621d209fab84ea9a7a23346201b7727b9b45a29c4e76f5effffffff0150690f00000000001976a9147821c0a3768aa9d1a37e16cf76002aef5373f1a888ac00000000';

--- a/packages/bitcore-lib/lib/errors/spec.js
+++ b/packages/bitcore-lib/lib/errors/spec.js
@@ -66,7 +66,14 @@ module.exports = [{
     }, {
       name: 'MissingPreviousOutput',
       message: 'No previous output information.'
-    }]
+    }, {
+        name: 'BlockHeightOutOfRange',
+        message: 'Block Height can only be between 0 and 1e16'
+      } , {
+        name: 'LockTimeTooEarly',
+        message: 'Timestamp needs to be more that 1432851240'
+      }
+    ]
   }, {
     name: 'NeedMoreInfo',
     message: '{0}'

--- a/packages/bitcore-lib/lib/errors/spec.js
+++ b/packages/bitcore-lib/lib/errors/spec.js
@@ -67,12 +67,12 @@ module.exports = [{
       name: 'MissingPreviousOutput',
       message: 'No previous output information.'
     }, {
-        name: 'BlockHeightOutOfRange',
-        message: 'Block Height can only be between 0 and 1e16'
-      } , {
-        name: 'LockTimeTooEarly',
-        message: 'Timestamp needs to be more that 1432851240'
-      }
+      name: 'BlockHeightOutOfRange',
+      message: 'Block Height can only be between 0 and 65535'
+    } , {
+      name: 'LockTimeRange',
+      message: 'Seconds needs to be more that 0 and less that 33553920'
+    }
     ]
   }, {
     name: 'NeedMoreInfo',

--- a/packages/bitcore-lib/lib/transaction/input/input.js
+++ b/packages/bitcore-lib/lib/transaction/input/input.js
@@ -276,7 +276,6 @@ Input.prototype.getLockTime = function() {
   if (this.sequenceNumber & SEQUENCE_LOCKTIME_TYPE_FLAG) {
     var seconds = SEQUENCE_LOCKTIME_GRANULARITY * (this.sequenceNumber & SEQUENCE_LOCKTIME_MASK);
     return seconds;
-    return s;
   } else {
     var blockHeight = this.sequenceNumber & SEQUENCE_LOCKTIME_MASK;
     return blockHeight;

--- a/packages/bitcore-lib/lib/transaction/transaction.js
+++ b/packages/bitcore-lib/lib/transaction/transaction.js
@@ -58,7 +58,7 @@ function Transaction(serialized, opts) {
     this._newTransaction();
   }
 }
-var CURRENT_VERSION = 1;
+var CURRENT_VERSION = 2;
 var DEFAULT_NLOCKTIME = 0;
 var MAX_BLOCK_SIZE = 1000000;
 
@@ -1352,5 +1352,15 @@ Transaction.prototype.enableRBF = function() {
   }
   return this;
 };
+
+Transaction.prototype.setVersion = function(version) {
+  $.checkArgument(
+    JSUtil.isNaturalNumber(version) && version <= CURRENT_VERSION, 
+    'Wrong version number');
+  this.version = version;
+  return this;
+};
+
+
 
 module.exports = Transaction;

--- a/packages/bitcore-lib/package-lock.json
+++ b/packages/bitcore-lib/package-lock.json
@@ -4,6 +4,28 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@kollavarsham/gulp-coveralls": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@kollavarsham/gulp-coveralls/-/gulp-coveralls-0.2.12.tgz",
+			"integrity": "sha512-jM0ORWB40gorDA94e9TJyuJ2Xdkep9f7mvvhf7ZcWXdVqiqdJaWlX2RjtG5bsytRLyvIP1+zudqrbUyUw1OdjA==",
+			"dev": true,
+			"requires": {
+				"coveralls": "^3.0.2",
+				"plugin-error": "^1.0.1",
+				"through2": "^3.0.0"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2 || 3"
+					}
+				}
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.7.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -40,6 +62,32 @@
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
 		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			}
+		},
+		"abbrev": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
+		},
+		"accepts": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+			"dev": true,
+			"requires": {
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
+			}
+		},
 		"acorn": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -63,13 +111,47 @@
 			"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
 			"dev": true
 		},
+		"after": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+			"dev": true
+		},
+		"ajv": {
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+			"integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true,
+			"optional": true
+		},
 		"ansi-colors": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
 			"dev": true,
 			"requires": {
 				"ansi-wrap": "^0.1.0"
+			}
+		},
+		"ansi-cyan": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
 			}
 		},
 		"ansi-gray": {
@@ -81,11 +163,29 @@
 				"ansi-wrap": "0.1.0"
 			}
 		},
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"ansi-wrap": {
 			"version": "0.1.0",
@@ -125,6 +225,15 @@
 			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
 			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
 		},
 		"arr-diff": {
 			"version": "4.0.0",
@@ -240,6 +349,59 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
+		"arraybuffer.slice": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+			"dev": true
+		},
+		"asn1": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": "~2.1.0"
+			}
+		},
+		"asn1.js": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"assert": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.1",
+				"util": "0.10.3"
+			},
+			"dependencies": {
+				"util": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+					"dev": true,
+					"requires": {
+						"inherits": "2.0.1"
+					}
+				}
+			}
+		},
+		"assert-plus": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
+		},
 		"assertion-error": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -251,6 +413,15 @@
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
+		},
+		"async": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.14"
+			}
 		},
 		"async-done": {
 			"version": "1.3.2",
@@ -270,6 +441,12 @@
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
+		"async-limiter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+			"dev": true
+		},
 		"async-settle": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz",
@@ -279,10 +456,28 @@
 				"async-done": "^1.2.2"
 			}
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
+		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"aws-sign2": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
+		},
+		"aws4": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
 		},
 		"bach": {
@@ -301,6 +496,12 @@
 				"async-settle": "^1.0.0",
 				"now-and-later": "^2.0.0"
 			}
+		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -371,10 +572,46 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"base64-arraybuffer": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+			"dev": true
+		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
+		},
+		"base64id": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+			"dev": true
+		},
+		"bcrypt-pbkdf": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
+			"requires": {
+				"tweetnacl": "^0.14.3"
+			}
+		},
 		"bech32": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
 			"integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+		},
+		"better-assert": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+			"dev": true,
+			"requires": {
+				"callsite": "1.0.0"
+			}
 		},
 		"binary-extensions": {
 			"version": "1.13.1",
@@ -392,10 +629,71 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"bitcore-build": {
+			"version": "8.16.2",
+			"resolved": "https://registry.npmjs.org/bitcore-build/-/bitcore-build-8.16.2.tgz",
+			"integrity": "sha512-RXQvk8+aKffuu6hqhkI8HlghJOs88A2gBmPwbJkgWbbp0n54ZVhOthKNurAmV3xdAjeQqSB1hDDxDx5Mu0QS8A==",
+			"dev": true,
+			"requires": {
+				"@kollavarsham/gulp-coveralls": "^0.2.2",
+				"brfs": "^2.0.1",
+				"browserify": "^16.2.3",
+				"chai": "^4.2.0",
+				"gulp": "^4.0.0",
+				"gulp-mocha": "^7.0.1",
+				"gulp-rename": "^1.4.0",
+				"gulp-shell": "^0.6.5",
+				"gulp-terser": "^1.1.7",
+				"istanbul": "^0.4.5",
+				"karma": "^4.2.0",
+				"karma-chrome-launcher": "^3.1.0",
+				"karma-mocha": "^1.3.0",
+				"lodash": "^4.17.15",
+				"mocha": "^6.2.0"
+			}
+		},
+		"blob": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+			"dev": true
+		},
+		"bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"dev": true
+		},
 		"bn.js": {
 			"version": "4.11.8",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+		},
+		"body-parser": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.1.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"on-finished": "~2.3.0",
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
+			},
+			"dependencies": {
+				"qs": {
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+					"dev": true
+				}
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -453,6 +751,178 @@
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
+		"browser-pack": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+			"integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.3",
+				"combine-source-map": "~0.8.0",
+				"defined": "^1.0.0",
+				"safe-buffer": "^5.1.1",
+				"through2": "^2.0.0",
+				"umd": "^3.0.0"
+			}
+		},
+		"browser-resolve": {
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+			"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+			"dev": true,
+			"requires": {
+				"resolve": "1.1.7"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				}
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"browserify": {
+			"version": "16.5.1",
+			"resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.1.tgz",
+			"integrity": "sha512-EQX0h59Pp+0GtSRb5rL6OTfrttlzv+uyaUVlK6GX3w11SQ0jKPKyjC/54RhPR2ib2KmfcELM06e8FxcI5XNU2A==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.3",
+				"assert": "^1.4.0",
+				"browser-pack": "^6.0.1",
+				"browser-resolve": "^1.11.0",
+				"browserify-zlib": "~0.2.0",
+				"buffer": "~5.2.1",
+				"cached-path-relative": "^1.0.0",
+				"concat-stream": "^1.6.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "~1.0.0",
+				"crypto-browserify": "^3.0.0",
+				"defined": "^1.0.0",
+				"deps-sort": "^2.0.0",
+				"domain-browser": "^1.2.0",
+				"duplexer2": "~0.1.2",
+				"events": "^2.0.0",
+				"glob": "^7.1.0",
+				"has": "^1.0.0",
+				"htmlescape": "^1.1.0",
+				"https-browserify": "^1.0.0",
+				"inherits": "~2.0.1",
+				"insert-module-globals": "^7.0.0",
+				"labeled-stream-splicer": "^2.0.0",
+				"mkdirp-classic": "^0.5.2",
+				"module-deps": "^6.0.0",
+				"os-browserify": "~0.3.0",
+				"parents": "^1.0.1",
+				"path-browserify": "~0.0.0",
+				"process": "~0.11.0",
+				"punycode": "^1.3.2",
+				"querystring-es3": "~0.2.0",
+				"read-only-stream": "^2.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.1.4",
+				"shasum": "^1.0.0",
+				"shell-quote": "^1.6.1",
+				"stream-browserify": "^2.0.0",
+				"stream-http": "^3.0.0",
+				"string_decoder": "^1.1.1",
+				"subarg": "^1.0.0",
+				"syntax-error": "^1.1.1",
+				"through2": "^2.0.0",
+				"timers-browserify": "^1.0.1",
+				"tty-browserify": "0.0.1",
+				"url": "~0.11.0",
+				"util": "~0.10.1",
+				"vm-browserify": "^1.0.0",
+				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				}
+			}
+		},
+		"browserify-aes": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+			"dev": true,
+			"requires": {
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"browserify-cipher": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
+			}
+		},
+		"browserify-des": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+			"integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"browserify-rsa": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
+			}
+		},
+		"browserify-sign": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
+			}
+		},
+		"browserify-zlib": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+			"dev": true,
+			"requires": {
+				"pako": "~1.0.5"
+			}
+		},
 		"bs58": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
@@ -460,6 +930,32 @@
 			"requires": {
 				"base-x": "^3.0.2"
 			}
+		},
+		"buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+			"integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+			"dev": true,
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
+		},
+		"buffer-alloc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+			"dev": true,
+			"requires": {
+				"buffer-alloc-unsafe": "^1.1.0",
+				"buffer-fill": "^1.0.0"
+			}
+		},
+		"buffer-alloc-unsafe": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+			"dev": true
 		},
 		"buffer-compare": {
 			"version": "1.1.1",
@@ -472,10 +968,34 @@
 			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
 			"dev": true
 		},
+		"buffer-fill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+			"dev": true
+		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"buffer-xor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+			"dev": true
+		},
+		"builtin-status-codes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+			"dev": true
+		},
+		"bytes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cache-base": {
@@ -495,10 +1015,28 @@
 				"unset-value": "^1.0.0"
 			}
 		},
+		"cached-path-relative": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+			"integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
+			"dev": true
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"dev": true
+		},
 		"camelcase": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+			"dev": true
+		},
+		"caseless": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 			"dev": true
 		},
 		"chai": {
@@ -513,6 +1051,17 @@
 				"get-func-name": "^2.0.0",
 				"pathval": "^1.1.0",
 				"type-detect": "^4.0.5"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"check-error": {
@@ -553,6 +1102,16 @@
 					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"dev": true
 				}
+			}
+		},
+		"cipher-base": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"class-utils": {
@@ -645,16 +1204,90 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
 		"color-support": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
 		},
+		"colors": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+			"dev": true
+		},
+		"combine-source-map": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+			"integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "~1.1.0",
+				"inline-source-map": "~0.6.0",
+				"lodash.memoize": "~3.0.3",
+				"source-map": "~0.5.3"
+			},
+			"dependencies": {
+				"convert-source-map": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+					"integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
+		"component-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+			"dev": true
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
+		},
+		"component-inherit": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
 		},
 		"concat-map": {
@@ -683,6 +1316,36 @@
 				}
 			}
 		},
+		"connect": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.2",
+				"parseurl": "~1.3.3",
+				"utils-merge": "1.0.1"
+			}
+		},
+		"console-browserify": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+			"dev": true
+		},
+		"constants-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+			"dev": true
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
 		"convert-source-map": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -699,6 +1362,12 @@
 					"dev": true
 				}
 			}
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"dev": true
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -722,6 +1391,103 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true
 		},
+		"coveralls": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.11.tgz",
+			"integrity": "sha512-LZPWPR2NyGKyaABnc49dR0fpeP6UqhvGq4B5nUrTQ1UBy55z96+ga7r+/ChMdMJUwBgyJDXBi88UBgz2rs9IiQ==",
+			"dev": true,
+			"requires": {
+				"js-yaml": "^3.13.1",
+				"lcov-parse": "^1.0.0",
+				"log-driver": "^1.2.7",
+				"minimist": "^1.2.5",
+				"request": "^2.88.0"
+			}
+		},
+		"create-ecdh": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
+			}
+		},
+		"create-hash": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
+			}
+		},
+		"create-hmac": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+			"dev": true,
+			"requires": {
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"cross-spawn": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+			"integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"dependencies": {
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
+		"crypto-browserify": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
+			}
+		},
+		"custom-event": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+			"integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+			"dev": true
+		},
 		"d": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -732,10 +1498,31 @@
 				"type": "^1.0.1"
 			}
 		},
+		"dargs": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+			"dev": true
+		},
 		"dash-ast": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
 			"integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+			"dev": true
+		},
+		"dashdash": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"date-format": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+			"integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
 			"dev": true
 		},
 		"debug": {
@@ -847,16 +1634,102 @@
 				}
 			}
 		},
+		"defined": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+			"dev": true
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"deps-sort": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+			"integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.3",
+				"shasum-object": "^1.0.0",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0"
+			}
+		},
+		"des.js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+			"integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
 		},
+		"detective": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+			"integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+			"dev": true,
+			"requires": {
+				"acorn-node": "^1.6.1",
+				"defined": "^1.0.0",
+				"minimist": "^1.1.1"
+			}
+		},
+		"di": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+			"integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+			"dev": true
+		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
+		"diffie-hellman": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
+			}
+		},
+		"dom-serialize": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+			"integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+			"dev": true,
+			"requires": {
+				"custom-event": "~1.0.0",
+				"ent": "~2.2.0",
+				"extend": "^3.0.0",
+				"void-elements": "^2.0.0"
+			}
+		},
+		"domain-browser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+			"integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
 			"dev": true
 		},
 		"duplexer2": {
@@ -890,6 +1763,22 @@
 				"object.defaults": "^1.1.0"
 			}
 		},
+		"ecc-jsbn": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
+			"requires": {
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
 		"elliptic": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -904,6 +1793,18 @@
 				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true
+		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -913,6 +1814,86 @@
 				"once": "^1.4.0"
 			}
 		},
+		"engine.io": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
+			"integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.4",
+				"base64id": "1.0.0",
+				"cookie": "0.3.1",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.0",
+				"ws": "~3.3.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"engine.io-client": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+			"integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "1.2.1",
+				"component-inherit": "0.0.3",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.1",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"ws": "~3.3.1",
+				"xmlhttprequest-ssl": "~1.5.4",
+				"yeast": "0.1.2"
+			},
+			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"engine.io-parser": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+			"integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+			"dev": true,
+			"requires": {
+				"after": "0.8.2",
+				"arraybuffer.slice": "~0.0.7",
+				"base64-arraybuffer": "0.1.5",
+				"blob": "0.0.5",
+				"has-binary2": "~1.0.2"
+			}
+		},
+		"ent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+			"integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+			"dev": true
+		},
 		"error-ex": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -920,6 +1901,44 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.17.5",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-regex": "^1.0.5",
+				"object-inspect": "^1.7.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.0",
+				"string.prototype.trimleft": "^2.1.1",
+				"string.prototype.trimright": "^2.1.1"
+			},
+			"dependencies": {
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+					"dev": true
+				}
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
 			}
 		},
 		"es5-ext": {
@@ -1005,6 +2024,18 @@
 				"es6-symbol": "^3.1.1"
 			}
 		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
 		"escodegen": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
@@ -1050,6 +2081,45 @@
 			"requires": {
 				"d": "1",
 				"es5-ext": "~0.10.14"
+			}
+		},
+		"eventemitter3": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+			"dev": true
+		},
+		"events": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+			"integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+			"dev": true
+		},
+		"evp_bytestokey": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+			"dev": true,
+			"requires": {
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
+			}
+		},
+		"execa": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+			"integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^3.0.0",
+				"onetime": "^5.1.0",
+				"p-finally": "^2.0.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
 			}
 		},
 		"expand-brackets": {
@@ -1205,6 +2275,12 @@
 				}
 			}
 		},
+		"extsprintf": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
+		},
 		"fancy-log": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -1217,10 +2293,28 @@
 				"time-stamp": "^1.0.0"
 			}
 		},
+		"fast-deep-equal": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
 			"dev": true
 		},
 		"file-uri-to-path": {
@@ -1251,6 +2345,21 @@
 						"is-extendable": "^0.1.0"
 					}
 				}
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
 			}
 		},
 		"find-up": {
@@ -1294,6 +2403,29 @@
 			"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
 			"dev": true
 		},
+		"flat": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "~2.0.3"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+					"dev": true
+				}
+			}
+		},
+		"flatted": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+			"integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+			"dev": true
+		},
 		"flush-write-stream": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -1308,6 +2440,32 @@
 					"version": "2.0.4",
 					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				}
+			}
+		},
+		"follow-redirects": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+			"integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				}
 			}
@@ -1327,6 +2485,23 @@
 				"for-in": "^1.0.1"
 			}
 		},
+		"forever-agent": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
+		},
+		"form-data": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.6",
+				"mime-types": "^2.1.12"
+			}
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1334,6 +2509,17 @@
 			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
+			}
+		},
+		"fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
 			}
 		},
 		"fs-mkdirp-stream": {
@@ -1373,7 +2559,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1394,12 +2581,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1414,17 +2603,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1541,7 +2733,8 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1553,6 +2746,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1567,6 +2761,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1574,12 +2769,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1598,6 +2795,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1687,7 +2885,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1699,6 +2898,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1784,7 +2984,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1820,6 +3021,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1839,6 +3041,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1882,12 +3085,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -1915,11 +3120,41 @@
 			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
 			"dev": true
 		},
+		"get-stream": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+			"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			},
+			"dependencies": {
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				}
+			}
+		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
+		},
+		"getpass": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0"
+			}
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -2027,6 +3262,12 @@
 			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
 		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
 		"gulp": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
@@ -2067,6 +3308,142 @@
 				}
 			}
 		},
+		"gulp-mocha": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/gulp-mocha/-/gulp-mocha-7.0.2.tgz",
+			"integrity": "sha512-ZXBGN60TXYnFhttr19mfZBOtlHYGx9SvCSc+Kr/m2cMIGloUe176HBPwvPqlakPuQgeTGVRS47NmcdZUereKMQ==",
+			"dev": true,
+			"requires": {
+				"dargs": "^7.0.0",
+				"execa": "^2.0.4",
+				"mocha": "^6.2.0",
+				"plugin-error": "^1.0.1",
+				"supports-color": "^7.0.0",
+				"through2": "^3.0.1"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"through2": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2 || 3"
+					}
+				}
+			}
+		},
+		"gulp-rename": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
+			"integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==",
+			"dev": true
+		},
+		"gulp-shell": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.6.5.tgz",
+			"integrity": "sha512-f3m1WcS0o2B72/PGj1Jbv9zYR9rynBh/EQJv64n01xQUo7j7anols0eww9GG/WtDTzGVQLrupVDYkifRFnj5Zg==",
+			"dev": true,
+			"requires": {
+				"async": "^2.1.5",
+				"chalk": "^2.3.0",
+				"fancy-log": "^1.3.2",
+				"lodash": "^4.17.4",
+				"lodash.template": "^4.4.0",
+				"plugin-error": "^0.1.2",
+				"through2": "^2.0.3"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.0.1",
+						"array-slice": "^0.2.3"
+					}
+				},
+				"arr-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+					"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+					"dev": true
+				},
+				"array-slice": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+					"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+					"dev": true
+				},
+				"extend-shallow": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^1.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+					"dev": true
+				},
+				"plugin-error": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+					"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+					"dev": true,
+					"requires": {
+						"ansi-cyan": "^0.1.1",
+						"ansi-red": "^0.1.1",
+						"arr-diff": "^1.0.1",
+						"arr-union": "^2.0.1",
+						"extend-shallow": "^1.1.2"
+					}
+				}
+			}
+		},
+		"gulp-terser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gulp-terser/-/gulp-terser-1.2.0.tgz",
+			"integrity": "sha512-lf+jE2DALg2w32p0HRiYMlFYRYelKZPNunHp2pZccCYrrdCLOs0ItbZcN63yr2pbz116IyhUG9mD/QbtRO1FKA==",
+			"dev": true,
+			"requires": {
+				"plugin-error": "^1.0.1",
+				"terser": "^4.0.0",
+				"through2": "^3.0.1",
+				"vinyl-sourcemaps-apply": "^0.2.1"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2 || 3"
+					}
+				}
+			}
+		},
 		"gulplog": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
@@ -2074,6 +3451,35 @@
 			"dev": true,
 			"requires": {
 				"glogg": "^1.0.0"
+			}
+		},
+		"handlebars": {
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			}
+		},
+		"har-schema": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
+		},
+		"har-validator": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
+			"requires": {
+				"ajv": "^6.5.5",
+				"har-schema": "^2.0.0"
 			}
 		},
 		"has": {
@@ -2084,6 +3490,29 @@
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
+		},
+		"has-binary2": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+			"dev": true,
+			"requires": {
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				}
+			}
+		},
+		"has-cors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+			"dev": true
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -2129,6 +3558,16 @@
 				}
 			}
 		},
+		"hash-base": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"hash.js": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -2144,6 +3583,12 @@
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 				}
 			}
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -2170,6 +3615,82 @@
 			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
 			"dev": true
 		},
+		"htmlescape": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+			"integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+			"dev": true
+		},
+		"http-errors": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
+			}
+		},
+		"http-proxy": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"http-signature": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
+			}
+		},
+		"https-browserify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+			"dev": true
+		},
+		"iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+			"dev": true
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2190,6 +3711,41 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
+		},
+		"inline-source-map": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+			"integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+			"dev": true,
+			"requires": {
+				"source-map": "~0.5.3"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"insert-module-globals": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.0.tgz",
+			"integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.3",
+				"acorn-node": "^1.5.2",
+				"combine-source-map": "^0.8.0",
+				"concat-stream": "^1.6.1",
+				"is-buffer": "^1.1.0",
+				"path-is-absolute": "^1.0.1",
+				"process": "~0.11.0",
+				"through2": "^2.0.0",
+				"undeclared-identifiers": "^1.1.2",
+				"xtend": "^4.0.0"
+			}
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -2215,7 +3771,7 @@
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
@@ -2254,9 +3810,15 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
 		},
+		"is-callable": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"dev": true
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
@@ -2273,6 +3835,12 @@
 					}
 				}
 			}
+		},
+		"is-date-object": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"dev": true
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -2358,6 +3926,15 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"is-regex": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
 		"is-relative": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
@@ -2366,6 +3943,27 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
+		},
+		"is-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"is-typedarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-unc-path": {
 			"version": "1.0.0",
@@ -2400,6 +3998,15 @@
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
+		"isbinaryfile": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+			"integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+			"dev": true,
+			"requires": {
+				"buffer-alloc": "^1.2.0"
+			}
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2412,11 +4019,200 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
+		"isstream": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
+		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.x",
+				"async": "1.x",
+				"escodegen": "1.8.x",
+				"esprima": "2.7.x",
+				"glob": "^5.0.15",
+				"handlebars": "^4.0.1",
+				"js-yaml": "3.x",
+				"mkdirp": "0.5.x",
+				"nopt": "3.x",
+				"once": "1.x",
+				"resolve": "1.1.x",
+				"supports-color": "^3.1.0",
+				"which": "^1.1.1",
+				"wordwrap": "^1.0.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"dev": true
+				},
+				"escodegen": {
+					"version": "1.8.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+					"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+					"dev": true,
+					"requires": {
+						"esprima": "^2.7.1",
+						"estraverse": "^1.9.1",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.2.0"
+					}
+				},
+				"esprima": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"dev": true
+				},
+				"estraverse": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+					"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+					"dev": true
+				},
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"dependencies": {
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				}
+			}
+		},
+		"jsbn": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
+		},
+		"json-schema": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
+		},
+		"json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+			"integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+			"dev": true,
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
 		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true
+		},
+		"jsprim": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.2.3",
+				"verror": "1.10.0"
+			}
 		},
 		"just-debounce": {
 			"version": "1.0.0",
@@ -2430,11 +4226,188 @@
 			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
 			"dev": true
 		},
+		"karma": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
+			"integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.3.0",
+				"body-parser": "^1.16.1",
+				"braces": "^3.0.2",
+				"chokidar": "^3.0.0",
+				"colors": "^1.1.0",
+				"connect": "^3.6.0",
+				"di": "^0.0.1",
+				"dom-serialize": "^2.2.0",
+				"flatted": "^2.0.0",
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.2",
+				"http-proxy": "^1.13.0",
+				"isbinaryfile": "^3.0.0",
+				"lodash": "^4.17.14",
+				"log4js": "^4.0.0",
+				"mime": "^2.3.1",
+				"minimatch": "^3.0.2",
+				"optimist": "^0.6.1",
+				"qjobs": "^1.1.4",
+				"range-parser": "^1.2.0",
+				"rimraf": "^2.6.0",
+				"safe-buffer": "^5.0.1",
+				"socket.io": "2.1.1",
+				"source-map": "^0.6.1",
+				"tmp": "0.0.33",
+				"useragent": "2.3.0"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+					"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"binary-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+					"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+					"dev": true
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chokidar": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+					"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+					"dev": true,
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.2",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.3.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"fsevents": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+					"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+					"dev": true,
+					"optional": true
+				},
+				"glob-parent": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-binary-path": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+					"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+					"dev": true,
+					"requires": {
+						"binary-extensions": "^2.0.0"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"readdirp": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+					"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+					"dev": true,
+					"requires": {
+						"picomatch": "^2.0.7"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
+		"karma-chrome-launcher": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+			"integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+			"dev": true,
+			"requires": {
+				"which": "^1.2.1"
+			}
+		},
+		"karma-mocha": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
+			"integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8=",
+			"dev": true,
+			"requires": {
+				"minimist": "1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
 			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
 			"dev": true
+		},
+		"labeled-stream-splicer": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+			"integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"stream-splicer": "^2.0.0"
+			}
 		},
 		"last-run": {
 			"version": "1.1.1",
@@ -2463,6 +4436,12 @@
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
+		},
+		"lcov-parse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+			"integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+			"dev": true
 		},
 		"lead": {
 			"version": "1.0.0",
@@ -2512,16 +4491,120 @@
 				"strip-bom": "^2.0.0"
 			}
 		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"dependencies": {
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				}
+			}
+		},
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"lodash._reinterpolate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+			"dev": true
+		},
+		"lodash.memoize": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+			"integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+			"dev": true
+		},
+		"lodash.template": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.templatesettings": "^4.0.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "^3.0.0"
+			}
+		},
+		"log-driver": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+			"dev": true
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1"
+			}
+		},
+		"log4js": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
+			"integrity": "sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==",
+			"dev": true,
+			"requires": {
+				"date-format": "^2.0.0",
+				"debug": "^4.1.1",
+				"flatted": "^2.0.0",
+				"rfdc": "^1.1.4",
+				"streamroller": "^1.0.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"lolex": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
 			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
 			"dev": true
+		},
+		"lru-cache": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+			"dev": true,
+			"requires": {
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
+			}
 		},
 		"magic-string": {
 			"version": "0.22.5",
@@ -2591,6 +4674,23 @@
 				}
 			}
 		},
+		"md5.js": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
+		},
 		"merge-source-map": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
@@ -2607,6 +4707,12 @@
 					"dev": true
 				}
 			}
+		},
+		"merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "3.1.10",
@@ -2628,6 +4734,43 @@
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
 			}
+		},
+		"miller-rabin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
+			}
+		},
+		"mime": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+			"dev": true
+		},
+		"mime-db": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"dev": true,
+			"requires": {
+				"mime-db": "1.43.0"
+			}
+		},
+		"mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
@@ -2675,6 +4818,242 @@
 				}
 			}
 		},
+		"mkdirp": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+			"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"mkdirp-classic": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+			"dev": true
+		},
+		"mocha": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+			"integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.4",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.3.2",
+				"yargs-parser": "13.1.2",
+				"yargs-unparser": "1.6.0"
+			},
+			"dependencies": {
+				"ansi-colors": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"module-deps": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.2.tgz",
+			"integrity": "sha512-a9y6yDv5u5I4A+IPHTnqFxcaKr4p50/zxTjcQJaX2ws9tN/W6J6YXnEKhqRyPhl494dkcxx951onSKVezmI+3w==",
+			"dev": true,
+			"requires": {
+				"JSONStream": "^1.0.3",
+				"browser-resolve": "^1.7.0",
+				"cached-path-relative": "^1.0.2",
+				"concat-stream": "~1.6.0",
+				"defined": "^1.0.0",
+				"detective": "^5.2.0",
+				"duplexer2": "^0.1.2",
+				"inherits": "^2.0.1",
+				"parents": "^1.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.4.0",
+				"stream-combiner2": "^1.1.1",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0",
+				"xtend": "^4.0.0"
+			}
+		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2713,6 +5092,18 @@
 				"to-regex": "^3.0.1"
 			}
 		},
+		"negotiator": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+			"dev": true
+		},
+		"neo-async": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
+		},
 		"next-tick": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -2741,6 +5132,25 @@
 						"@sinonjs/commons": "^1.7.0"
 					}
 				}
+			}
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+			"dev": true,
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -2773,10 +5183,37 @@
 				"once": "^1.3.2"
 			}
 		},
+		"npm-run-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+			"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.0.0"
+			}
+		},
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"oauth-sign": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-component": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
 			"dev": true
 		},
 		"object-copy": {
@@ -2855,6 +5292,16 @@
 				"isobject": "^3.0.0"
 			}
 		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			}
+		},
 		"object.map": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
@@ -2884,6 +5331,15 @@
 				"make-iterator": "^1.0.0"
 			}
 		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2891,6 +5347,39 @@
 			"dev": true,
 			"requires": {
 				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+			"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+			"dev": true,
+			"requires": {
+				"mimic-fn": "^2.1.0"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				},
+				"wordwrap": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+					"dev": true
+				}
 			}
 		},
 		"optionator": {
@@ -2916,13 +5405,84 @@
 				"readable-stream": "^2.0.1"
 			}
 		},
+		"os-browserify": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+			"integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+			"dev": true
+		},
 		"os-locale": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"dev": true,
 			"requires": {
 				"lcid": "^1.0.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-finally": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+			"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+			"dev": true
+		},
+		"p-limit": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
+		},
+		"pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
+		},
+		"parents": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+			"integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+			"dev": true,
+			"requires": {
+				"path-platform": "~0.11.15"
+			}
+		},
+		"parse-asn1": {
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"dev": true,
+			"requires": {
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"parse-filepath": {
@@ -2957,10 +5517,40 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
+		"parseqs": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+			"dev": true,
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseuri": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+			"dev": true,
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true
+		},
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
+		"path-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+			"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 			"dev": true
 		},
 		"path-dirname": {
@@ -2984,10 +5574,22 @@
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-platform": {
+			"version": "0.11.15",
+			"resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+			"integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
 			"dev": true
 		},
 		"path-root": {
@@ -3039,6 +5641,31 @@
 			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
 			"dev": true
 		},
+		"pbkdf2": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"dev": true,
+			"requires": {
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
+			}
+		},
+		"performance-now": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
+		},
+		"picomatch": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"dev": true
+		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3060,6 +5687,18 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"plugin-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+			"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^1.0.1",
+				"arr-diff": "^4.0.0",
+				"arr-union": "^3.1.0",
+				"extend-shallow": "^3.0.2"
+			}
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -3078,11 +5717,43 @@
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
 			"dev": true
 		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
+		},
+		"pseudomap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+			"dev": true
+		},
+		"psl": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"dev": true
+		},
+		"public-encrypt": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+			"integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1",
+				"safe-buffer": "^5.1.2"
+			}
 		},
 		"pump": {
 			"version": "2.0.1",
@@ -3113,6 +5784,36 @@
 				}
 			}
 		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
+		},
+		"qjobs": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+			"integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+			"dev": true
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
+		},
+		"querystring-es3": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+			"integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+			"dev": true
+		},
 		"quote-stream": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
@@ -3122,6 +5823,52 @@
 				"buffer-equal": "0.0.1",
 				"minimist": "^1.1.3",
 				"through2": "^2.0.0"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"randomfill": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"dev": true
+		},
+		"raw-body": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			}
+		},
+		"read-only-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+			"integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"read-pkg": {
@@ -3260,6 +6007,34 @@
 				"remove-trailing-separator": "^1.1.0"
 			}
 		},
+		"request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3270,6 +6045,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
 			"dev": true
 		},
 		"resolve": {
@@ -3312,6 +6093,31 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
+		"rfdc": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+			"integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"ripemd160": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
+			"requires": {
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -3325,6 +6131,12 @@
 			"requires": {
 				"ret": "~0.1.10"
 			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"scope-analyzer": {
 			"version": "2.1.1",
@@ -3385,10 +6197,78 @@
 				}
 			}
 		},
+		"setprototypeof": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
+		"sha.js": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"shallow-copy": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
 			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
+			"dev": true
+		},
+		"shasum": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+			"integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+			"dev": true,
+			"requires": {
+				"json-stable-stringify": "~0.0.0",
+				"sha.js": "~2.4.4"
+			}
+		},
+		"shasum-object": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+			"integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+			"dev": true,
+			"requires": {
+				"fast-safe-stringify": "^2.0.7"
+			}
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"shell-quote": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
+		},
+		"simple-concat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
 			"dev": true
 		},
 		"sinon": {
@@ -3519,12 +6399,115 @@
 				}
 			}
 		},
+		"socket.io": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+			"integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+			"dev": true,
+			"requires": {
+				"debug": "~3.1.0",
+				"engine.io": "~3.2.0",
+				"has-binary2": "~1.0.2",
+				"socket.io-adapter": "~1.1.0",
+				"socket.io-client": "2.1.1",
+				"socket.io-parser": "~3.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"socket.io-adapter": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+			"integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
+			"dev": true
+		},
+		"socket.io-client": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+			"integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+			"dev": true,
+			"requires": {
+				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
+				"component-bind": "1.0.0",
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"engine.io-client": "~3.2.0",
+				"has-binary2": "~1.0.2",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"socket.io-parser": "~3.2.0",
+				"to-array": "0.1.4"
+			},
+			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+			"integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				}
+			}
+		},
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -3537,6 +6520,16 @@
 				"resolve-url": "^0.2.1",
 				"source-map-url": "^0.4.0",
 				"urix": "^0.1.0"
+			}
+		},
+		"source-map-support": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"source-map-url": {
@@ -3590,6 +6583,29 @@
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"sshpk": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
+			"requires": {
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"safer-buffer": "^2.0.2",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stack-trace": {
@@ -3671,17 +6687,116 @@
 				"through2": "~2.0.3"
 			}
 		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
+		},
+		"stream-browserify": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+			"integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+			"dev": true,
+			"requires": {
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+			"dev": true,
+			"requires": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"stream-exhaust": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
 			"integrity": "sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==",
 			"dev": true
 		},
+		"stream-http": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+			"integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+			"dev": true,
+			"requires": {
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.0.6",
+				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					},
+					"dependencies": {
+						"inherits": {
+							"version": "2.0.4",
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+							"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
 			"integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
 			"dev": true
+		},
+		"stream-splicer": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+			"integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"streamroller": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.6.tgz",
+			"integrity": "sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==",
+			"dev": true,
+			"requires": {
+				"async": "^2.6.2",
+				"date-format": "^2.0.0",
+				"debug": "^3.2.6",
+				"fs-extra": "^7.0.1",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				}
+			}
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -3692,6 +6807,48 @@
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
 				"strip-ansi": "^3.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+			"integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5",
+				"string.prototype.trimstart": "^1.0.0"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5",
+				"string.prototype.trimend": "^1.0.0"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+			"integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
 			}
 		},
 		"string_decoder": {
@@ -3729,6 +6886,27 @@
 				"is-utf8": "^0.2.0"
 			}
 		},
+		"strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"subarg": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.1.0"
+			}
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3747,6 +6925,32 @@
 				"es6-iterator": "^2.0.1",
 				"es6-symbol": "^3.1.1"
 			}
+		},
+		"syntax-error": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+			"integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+			"dev": true,
+			"requires": {
+				"acorn-node": "^1.2.0"
+			}
+		},
+		"terser": {
+			"version": "4.6.10",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
+			"integrity": "sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.20.0",
+				"source-map": "~0.6.1",
+				"source-map-support": "~0.5.12"
+			}
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -3774,6 +6978,24 @@
 			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
 			"dev": true
 		},
+		"timers-browserify": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+			"integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+			"dev": true,
+			"requires": {
+				"process": "~0.11.0"
+			}
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
+		},
 		"to-absolute-glob": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -3783,6 +7005,12 @@
 				"is-absolute": "^1.0.0",
 				"is-negated-glob": "^1.0.0"
 			}
+		},
+		"to-array": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+			"dev": true
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -3835,6 +7063,43 @@
 				"through2": "^2.0.3"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
+		"tough-cookie": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
+			"requires": {
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
+			}
+		},
+		"tty-browserify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+			"integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+			"dev": true
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"tweetnacl": {
+			"version": "0.14.5",
+			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
+		},
 		"type": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -3856,10 +7121,43 @@
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
 		},
+		"type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"dev": true,
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			}
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+			"integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.20.3",
+				"source-map": "~0.6.1"
+			}
+		},
+		"ultron": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+			"dev": true
+		},
+		"umd": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+			"integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
 			"dev": true
 		},
 		"unc-path-regex": {
@@ -3867,6 +7165,19 @@
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
 			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
 			"dev": true
+		},
+		"undeclared-identifiers": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+			"integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+			"dev": true,
+			"requires": {
+				"acorn-node": "^1.3.0",
+				"dash-ast": "^1.0.0",
+				"get-assigned-identifiers": "^1.2.0",
+				"simple-concat": "^1.0.0",
+				"xtend": "^4.0.1"
+			}
 		},
 		"undertaker": {
 			"version": "1.2.1",
@@ -3912,6 +7223,18 @@
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"through2-filter": "^3.0.0"
 			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
 		},
 		"unset-value": {
 			"version": "1.0.0",
@@ -3959,11 +7282,38 @@
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
 		},
+		"uri-js": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
+		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"dev": true,
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+					"dev": true
+				}
+			}
 		},
 		"use": {
 			"version": "3.1.1",
@@ -3971,10 +7321,49 @@
 			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
 			"dev": true
 		},
+		"useragent": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+			"integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "4.1.x",
+				"tmp": "0.0.x"
+			}
+		},
+		"util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"dev": true,
+			"requires": {
+				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
+		"uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8flags": {
@@ -4001,6 +7390,17 @@
 			"resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
 			"integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
 			"dev": true
+		},
+		"verror": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
+			"requires": {
+				"assert-plus": "^1.0.0",
+				"core-util-is": "1.0.2",
+				"extsprintf": "^1.2.0"
+			}
 		},
 		"vinyl": {
 			"version": "2.2.0",
@@ -4056,10 +7456,39 @@
 				"vinyl": "^2.0.0"
 			}
 		},
+		"vinyl-sourcemaps-apply": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.5.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
 		"vlq": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
 			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+			"dev": true
+		},
+		"vm-browserify": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+			"integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+			"dev": true
+		},
+		"void-elements": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
 			"dev": true
 		},
 		"which": {
@@ -4077,15 +7506,30 @@
 			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
 			"dev": true
 		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
+		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
@@ -4099,6 +7543,31 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
 		},
+		"ws": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0",
+				"ultron": "~1.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
+		"xmlhttprequest-ssl": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+			"dev": true
+		},
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -4109,6 +7578,12 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
 			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 			"dev": true
 		},
 		"yargs": {
@@ -4140,6 +7615,146 @@
 			"requires": {
 				"camelcase": "^3.0.0"
 			}
+		},
+		"yargs-unparser": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+			"dev": true,
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.15",
+				"yargs": "^13.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"yeast": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+			"dev": true
 		}
 	}
 }

--- a/packages/bitcore-lib/test/script/interpreter.js
+++ b/packages/bitcore-lib/test/script/interpreter.js
@@ -334,6 +334,7 @@ describe('Interpreter', function() {
     var hashbuf = Buffer.alloc(32);
     hashbuf.fill(0);
     var credtx = new Transaction();
+    credtx.setVersion(1);
     credtx.uncheckedAddInput(new Transaction.Input({
       prevTxId: '0000000000000000000000000000000000000000000000000000000000000000',
       outputIndex: 0xffffffff,
@@ -347,6 +348,7 @@ describe('Interpreter', function() {
     var idbuf = credtx.id;
 
     var spendtx = new Transaction();
+    spendtx.setVersion(1);
     spendtx.uncheckedAddInput(new Transaction.Input({
       prevTxId: idbuf.toString('hex'),
       outputIndex: 0,
@@ -357,6 +359,7 @@ describe('Interpreter', function() {
       script: new Script(),
       satoshis: amount,
     }));
+
 
     var interp = new Interpreter();
     var verified = interp.verify(scriptSig, scriptPubkey, spendtx, 0, flags, witness, amount);

--- a/packages/bitcore-lib/test/transaction/transaction.js
+++ b/packages/bitcore-lib/test/transaction/transaction.js
@@ -210,8 +210,16 @@ describe('Transaction', function() {
 
   it('serializes an empty transaction', function() {
     var transaction = new Transaction();
+    transaction.setVersion(1);
     transaction.uncheckedSerialize().should.equal(tx_empty_hex);
   });
+
+  it('serializes an empty transaction v2', function() {
+    var transaction = new Transaction();
+    transaction.uncheckedSerialize().should.equal(tx_empty_hexV2);
+  });
+
+
 
   it('serializes and deserializes correctly', function() {
     var transaction = new Transaction(tx_1_hex);
@@ -226,6 +234,7 @@ describe('Transaction', function() {
       it('case ' + index, function() {
         var i = 0;
         var transaction = new Transaction();
+        transaction.setVersion(1);
         while (i < vector.length) {
           var command = vector[i];
           var args = vector[i + 1];
@@ -1864,6 +1873,7 @@ describe('Transaction', function() {
 
       it('will sign with nested p2sh witness program', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(nestedUtxo, [publicKey1], 1)
           .to([{address: 'n3LsXgyStG2CkS2CnWZtDqxTfCnXB8PvD9', satoshis: 50000}])
           .fee(150000)
@@ -1875,6 +1885,7 @@ describe('Transaction', function() {
       });
       it('will sign with p2wpkh witness program', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(simpleWitnessUtxoWith1BTC)
           .to([{address: 'n3LsXgyStG2CkS2CnWZtDqxTfCnXB8PvD9', satoshis: 50000}])
           .fee(150000)
@@ -1886,6 +1897,7 @@ describe('Transaction', function() {
       });
       it('will sign with p2sh-wrapped-p2wpkh witness program', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(simpleWrappedWitnessUtxoWith1BTC)
           .to([{address: 'n3LsXgyStG2CkS2CnWZtDqxTfCnXB8PvD9', satoshis: 50000}])
           .fee(150000)
@@ -1897,6 +1909,7 @@ describe('Transaction', function() {
       });
       it('will sign with p2wsh witness program', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(witnessUtxo, [publicKey1], 1)
           .to([{address: 'n3LsXgyStG2CkS2CnWZtDqxTfCnXB8PvD9', satoshis: 50000}])
           .fee(150000)
@@ -1908,6 +1921,7 @@ describe('Transaction', function() {
       });
       it('will sign with p2wsh, p2sh, and nested p2sh', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(witnessUtxo, [publicKey1], 1)
           .from(utxo, [publicKey1], 1)
           .from(nestedUtxo, [publicKey1], 1)
@@ -1920,6 +1934,7 @@ describe('Transaction', function() {
       });
       it('will sign with p2pkh, p2wpkh, and wrapped p2wpkh', function() {
         var tx = new Transaction()
+          .setVersion(1)
           .from(simpleUtxoWith1BTC)
           .from(simpleWitnessUtxoWith1BTC)
           .from(simpleWrappedWitnessUtxoWith1BTC)
@@ -1937,6 +1952,7 @@ describe('Transaction', function() {
 
 
 var tx_empty_hex = '01000000000000000000';
+var tx_empty_hexV2 = '02000000000000000000';
 
 /* jshint maxlen: 1000 */
 var tx_1_hex = '01000000015884e5db9de218238671572340b207ee85b628074e7e467096c267266baf77a4000000006a473044022013fa3089327b50263029265572ae1b022a91d10ac80eb4f32f291c914533670b02200d8a5ed5f62634a7e1a0dc9188a3cc460a986267ae4d58faf50c79105431327501210223078d2942df62c45621d209fab84ea9a7a23346201b7727b9b45a29c4e76f5effffffff0150690f00000000001976a9147821c0a3768aa9d1a37e16cf76002aef5373f1a888ac00000000';

--- a/packages/bitcore-p2p-cash/package-lock.json
+++ b/packages/bitcore-p2p-cash/package-lock.json
@@ -1235,7 +1235,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1256,12 +1257,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1276,17 +1279,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1403,7 +1409,8 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1415,6 +1422,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1429,6 +1437,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1436,12 +1445,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1460,6 +1471,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1549,7 +1561,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1561,6 +1574,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1646,7 +1660,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1682,6 +1697,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1701,6 +1717,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1744,12 +1761,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/bitcore-p2p/package-lock.json
+++ b/packages/bitcore-p2p/package-lock.json
@@ -1235,7 +1235,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1256,12 +1257,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1276,17 +1279,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -1403,7 +1409,8 @@
 				"inherits": {
 					"version": "2.0.4",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -1415,6 +1422,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -1429,6 +1437,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -1436,12 +1445,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -1460,6 +1471,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -1549,7 +1561,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -1561,6 +1574,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -1646,7 +1660,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1682,6 +1697,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1701,6 +1717,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1744,12 +1761,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -1236,15 +1236,17 @@ export class API extends EventEmitter {
   // * @param {number} opts.fee - Optional. Use an fixed fee for this TX (only when opts.inputs is specified)
   // * @param {Boolean} opts.noShuffleOutputs - Optional. If set, TX outputs won't be shuffled. Defaults to false
   // * @returns {Callback} cb - Return error or the transaction proposal
+  // * @param {String} baseUrl - Optional. ONLY FOR TESTING
   // */
-  createTxProposal(opts, cb) {
+  createTxProposal(opts, cb, baseUrl) {
     $.checkState(this.credentials && this.credentials.isComplete());
     $.checkState(this.credentials.sharedEncryptingKey);
     $.checkArgument(opts);
 
     var args = this._getCreateTxProposalArgs(opts);
 
-    this.request.post('/v3/txproposals/', args, (err, txp) => {
+    baseUrl = baseUrl || '/v4/txproposals/';
+    this.request.post(baseUrl, args, (err, txp) => {
       if (err) return cb(err);
 
       this._processTxps(txp);
@@ -1482,10 +1484,11 @@ export class API extends EventEmitter {
   // *
   // * @param {Object} txp
   // * @param {Array} signatures
+  // * @param {base} base url (ONLY FOR TESTING)
   // * @param {Callback} cb
   // * @return {Callback} cb - Return error or object
   // */
-  pushSignatures(txp, signatures, cb) {
+  pushSignatures(txp, signatures, cb, base) {
     $.checkState(this.credentials && this.credentials.isComplete());
     $.checkArgument(txp.creatorId);
 
@@ -1501,7 +1504,8 @@ export class API extends EventEmitter {
 
         if (!isLegit) return cb(new Errors.SERVER_COMPROMISED());
 
-        var url = '/v1/txproposals/' + txp.id + '/signatures/';
+        base = base || '/v2/txproposals/';
+        var url = base + txp.id + '/signatures/';
         var args = {
           signatures
         };

--- a/packages/bitcore-wallet-client/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/utils.ts
@@ -267,7 +267,7 @@ export class Utils {
 
       var t = new bitcore.Transaction();
 
-      if (txp.version>=4) {
+      if (txp.version >= 4) {
         t.setVersion(2);
       } else {
         t.setVersion(1);

--- a/packages/bitcore-wallet-client/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/utils.ts
@@ -267,6 +267,12 @@ export class Utils {
 
       var t = new bitcore.Transaction();
 
+      if (txp.version>=4) {
+        t.setVersion(2);
+      } else {
+        t.setVersion(1);
+      }
+
       $.checkState(_.includes(_.values(Constants.SCRIPT_TYPES), txp.addressType));
 
       switch (txp.addressType) {

--- a/packages/bitcore-wallet-client/test/api.test.js
+++ b/packages/bitcore-wallet-client/test/api.test.js
@@ -4026,7 +4026,6 @@ describe('client API', function() { // DONT USE LAMBAS HERE!!! https://stackover
       it('Should send the signed tx in paypro', (done) => {
         clients[0].getTxProposals({}, (err, txps) => {
           should.not.exist(err);
-          console.log(txps);
           let signatures = keys[0].sign(clients[0].getRootPath(), txps[0]);
           clients[0].pushSignatures(txps[0], signatures, (err, xx, paypro) => {
             should.not.exist(err);
@@ -5215,7 +5214,6 @@ describe('client API', function() { // DONT USE LAMBAS HERE!!! https://stackover
                 return helpers.newClient(app)
               }
             }, (err, k, c) => {
-console.log('[api.test.js.5080:err:]',err); // TODO
               should.not.exist(err);
               c.length.should.equal(1);
               let recoveryClient = c[0];

--- a/packages/bitcore-wallet-client/test/api.test.js
+++ b/packages/bitcore-wallet-client/test/api.test.js
@@ -3546,6 +3546,40 @@ describe('client API', function() { // DONT USE LAMBAS HERE!!! https://stackover
           });
         });
       });
+
+      it('Should fail with wrong_signatires error if trying to push v3 signatures to  a v4 txp v', (done) => {
+        var toAddress = 'n2TBMPzPECGUfcT2EByiTJ12TPZkhN2mN5';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(4);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            txp.version = 3; // get v3 signatures
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.exist(err);
+              err.toString().should.contain('BAD_SIGNATURES');
+              done();
+            }, '/v2/txproposals/');
+          });
+        });
+      });
+ 
     });
 
     describe('BCH', (done) => {
@@ -3582,6 +3616,107 @@ describe('client API', function() { // DONT USE LAMBAS HERE!!! https://stackover
               txp.status.should.equal('accepted');
               done();
             });
+          });
+        });
+      });
+
+      it('Should sign proposal (legacy txp version 3)', (done) => {
+        var toAddress = 'qran0w2c8x2n4wdr60s4nrle65s745wt4sakf9xa8e';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+          coin: 'bch',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(3);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            publishedTxp.status.should.equal('pending');
+
+
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.not.exist(err);
+              txp.status.should.equal('accepted');
+              done();
+            });
+          });
+        }, '/v3/txproposals');
+      });
+
+      it('Should fail with need_update error if trying to sign a txp v4 on old client', (done) => {
+        var toAddress = 'qran0w2c8x2n4wdr60s4nrle65s745wt4sakf9xa8e';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(4);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.exist(err);
+              err.toString().should.contain('upgrade');
+              done();
+            }, '/v1/txproposals/');
+          });
+        });
+      });
+
+      it('Should fail with wrong_signatires error if trying to push v3 signatures to  a v4 txp v', (done) => {
+        var toAddress = 'qran0w2c8x2n4wdr60s4nrle65s745wt4sakf9xa8e';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(4);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            txp.version = 3; // get v3 signatures
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.exist(err);
+              err.toString().should.contain('BAD_SIGNATURES');
+              done();
+            }, '/v2/txproposals/');
           });
         });
       });

--- a/packages/bitcore-wallet-client/test/api.test.js
+++ b/packages/bitcore-wallet-client/test/api.test.js
@@ -385,8 +385,10 @@ helpers.newDb = (extra, cb) => {
 }
 
 var db;
-describe('client API', () => {
+describe('client API', function() { // DONT USE LAMBAS HERE!!! https://stackoverflow.com/questions/23492043/change-default-timeout-for-mocha, or this.timeout() will BREAK!
+  //
   var clients, app, sandbox, storage, keys, i;
+  this.timeout(8000);
 
   before((done) => {
     i = 0;
@@ -1082,6 +1084,43 @@ describe('client API', () => {
         });
         should.not.exist(bitcoreError);
       });
+
+      it('should build a v4 tx proposal', () => {
+        var toAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+        var changeAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+
+        var publicKeyRing = [{
+          xPubKey: new Bitcore.HDPublicKey(derivedPrivateKey['BIP44']),
+        }];
+
+        var utxos = helpers.generateUtxos('P2PKH', publicKeyRing, 'm/1/0', 1, [1000, 2000]);
+        var txp = {
+          version: 4,
+          inputs: utxos,
+          outputs: [{
+            toAddress: toAddress,
+            amount: 800,
+            message: 'first output'
+          }, {
+            toAddress: toAddress,
+            amount: 900,
+            message: 'second output'
+          }],
+          changeAddress: {
+            address: changeAddress
+          },
+          requiredSignatures: 1,
+          outputOrder: [0, 1, 2],
+          fee: 10000,
+          derivationStrategy: 'BIP44',
+          addressType: 'P2PKH',
+        };
+        var t = Utils.buildTx(txp);
+        var bitcoreError = t.getSerializationError({
+          disableIsFullySigned: true,
+        });
+        should.not.exist(bitcoreError);
+      });
     });
 
     describe('#pushSignatures', () => {
@@ -1142,7 +1181,7 @@ describe('client API', () => {
         var key = Key.fromExtendedPrivateKey(masterPrivateKey);
         var signatures = key.sign(path, txp);
 
-        // This is a GOOD tests, since bitcore ONLY accept VALID signatures
+        // This is a GOOD test, since bitcore ONLY accept VALID signatures
         signatures.length.should.be.equal(utxos.length);
       });
       it('should sign multiple-outputs proposal correctly', () => {
@@ -1257,6 +1296,45 @@ describe('client API', () => {
         signatures[1].should.equal('3044022069cf6e5d8700ff117f754e4183e81690d99d6a6443e86c9589efa072ecb7d82c02204c254506ac38774a2176f9ef56cc239ef7867fbd24da2bef795128c75a063301');
       });
 
+      it('should sign btc proposal correctly (tx V2)', () => {
+        var toAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+        var changeAddress = 'msj42CCGruhRsFrGATiUuh25dtxYtnpbTx';
+
+        var publicKeyRing = [{
+          xPubKey: new Bitcore.HDPublicKey(derivedPrivateKey['BIP44']),
+        }];
+
+        var utxos = helpers.generateUtxos('P2PKH', publicKeyRing, 'm/1/0', 1, [1000, 2000]);
+        var txp = {
+          version: 4,
+          coin: 'btc',
+          inputs: utxos,
+          outputs: [{
+            toAddress: toAddress,
+            amount: 800,
+            message: 'first output'
+          }, {
+            toAddress: toAddress,
+            amount: 900,
+            message: 'second output'
+          }],
+          changeAddress: {
+            address: changeAddress
+          },
+          requiredSignatures: 1,
+          outputOrder: [0, 1, 2],
+          fee: 10000,
+          derivationStrategy: 'BIP44',
+          addressType: 'P2PKH',
+        };
+        var path = 'm/44\'/1\'/0\'';
+        var key = Key.fromExtendedPrivateKey(masterPrivateKey);
+        var signatures = key.sign(path, txp);
+
+        signatures.length.should.be.equal(utxos.length);
+        signatures[0].should.equal('3045022100da83ffb02ce0c5c7f2b30d0eb2fd62d1177d282fff5ce7deb9d3a8fd6e002c9d022030f0f0b29dd1fb9b602c50e8916568aa0dd68054523989291decfdbf36d70299');
+        signatures[1].should.equal('3045022100951f980ad2fcd764a7824575e18aa4f28309b7160c353a0e3d239bff83050184022039c4ab5be5c40d19cd2c8bfcbf42a6262df851454a494ad78668be7d35519f05');
+      });
 
       it('should sign eth proposal correctly', () => {
         const toAddress = '0xa062a07a0a56beb2872b12f388f511d694626730';
@@ -2748,17 +2826,14 @@ describe('client API', () => {
   describe('Transaction Proposals Creation and Locked funds', () => {
     var myAddress;
     beforeEach((done) => {
-      db.dropDatabase((err) => {
-        helpers.createAndJoinWallet(clients, keys, 2, 3, {}, (w) => {
-
-          clients[0].createAddress((err, address) => {
-            should.not.exist(err);
-            myAddress = address;
-            blockchainExplorerMock.setUtxo(address, 2, 2);
-            blockchainExplorerMock.setUtxo(address, 2, 2);
-            blockchainExplorerMock.setUtxo(address, 1, 2, 0);
-            done(err);
-          });
+      helpers.createAndJoinWallet(clients, keys, 2, 3, {}, (w) => {
+        clients[0].createAddress((err, address) => {
+          should.not.exist(err);
+          myAddress = address;
+          blockchainExplorerMock.setUtxo(address, 2, 2);
+          blockchainExplorerMock.setUtxo(address, 2, 2);
+          blockchainExplorerMock.setUtxo(address, 1, 2, 0);
+          done(err);
         });
       });
     });
@@ -3051,6 +3126,7 @@ describe('client API', () => {
         feePerKb: 800e2,
       };
       helpers.createAndPublishTxProposal(clients[0], opts, (err, x) => {
+
         should.exist(err);
         err.should.be.an.instanceOf(Errors.INSUFFICIENT_FUNDS_FOR_FEE);
         opts.feePerKb = 100e2;
@@ -3400,6 +3476,76 @@ describe('client API', () => {
         });
       });
 
+      it('Should sign proposal (legacy txp version 3)', (done) => {
+        var toAddress = 'n2TBMPzPECGUfcT2EByiTJ12TPZkhN2mN5';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(3);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            publishedTxp.status.should.equal('pending');
+
+
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.not.exist(err);
+              let signatures2 = keys[1].sign(clients[1].getRootPath(), txp);
+              clients[1].pushSignatures(publishedTxp, signatures2, (err, txp) => {
+                should.not.exist(err);
+                txp.status.should.equal('accepted');
+                done();
+              });
+            });
+          });
+        }, '/v3/txproposals');
+      });
+
+      it('Should fail with need_update error if trying to sign a txp v4 on old client', (done) => {
+        var toAddress = 'n2TBMPzPECGUfcT2EByiTJ12TPZkhN2mN5';
+        var opts = {
+          outputs: [{
+            amount: 1e8,
+            toAddress: toAddress,
+          }, {
+            amount: 2e8,
+            toAddress: toAddress,
+          }],
+          feePerKb: 100e2,
+          message: 'just some message',
+        };
+        clients[0].createTxProposal(opts, (err, txp) => {
+          should.not.exist(err);
+          should.exist(txp);
+          txp.version.should.equal(4);
+          clients[0].publishTxProposal({
+            txp: txp,
+          }, (err, publishedTxp) => {
+            should.not.exist(err);
+            should.exist(publishedTxp);
+            let signatures = keys[0].sign(clients[0].getRootPath(), txp);
+            clients[0].pushSignatures(publishedTxp, signatures, (err, txp) => {
+              should.exist(err);
+              err.toString().should.contain('upgrade');
+              done();
+            }, '/v1/txproposals/');
+          });
+        });
+      });
     });
 
     describe('BCH', (done) => {
@@ -5060,6 +5206,7 @@ describe('client API', () => {
           var words = keys[0].get(null, true).mnemonic;
           var walletName = clients[0].credentials.walletName;
           var copayerName = clients[0].credentials.copayerName;
+
           clients[0].createAddress((err, addr) => {
             should.not.exist(err);
             should.exist(addr);
@@ -5068,6 +5215,7 @@ describe('client API', () => {
                 return helpers.newClient(app)
               }
             }, (err, k, c) => {
+console.log('[api.test.js.5080:err:]',err); // TODO
               should.not.exist(err);
               c.length.should.equal(1);
               let recoveryClient = c[0];
@@ -5368,7 +5516,6 @@ describe('client API', () => {
 
 
       it('should be able to gain access to a OLD 44\' 2-2 wallet from mnemonic', function (done) {
-        this.timeout(5000);
         helpers.createAndJoinWallet(clients, keys, 2, 2, {
           useLegacyPurpose: true,
         }, () => {

--- a/packages/bitcore-wallet-service/package-lock.json
+++ b/packages/bitcore-wallet-service/package-lock.json
@@ -336,7 +336,7 @@
 		},
 		"array-flatten": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-from": {
@@ -371,7 +371,7 @@
 		},
 		"async": {
 			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+			"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
 			"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
 		},
 		"async-limiter": {
@@ -523,7 +523,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -586,7 +586,7 @@
 		},
 		"chai": {
 			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
+			"resolved": "http://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
 			"integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk=",
 			"dev": true,
 			"requires": {
@@ -762,7 +762,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -774,7 +774,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -803,7 +803,7 @@
 		},
 		"deep-eql": {
 			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+			"resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
 			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
 			"dev": true,
 			"requires": {
@@ -996,7 +996,7 @@
 		},
 		"es6-promise": {
 			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+			"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
 			"integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
 		},
 		"escape-html": {
@@ -1484,7 +1484,7 @@
 			"dependencies": {
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"has-flag": {
@@ -1724,7 +1724,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"memdown": {
@@ -1802,7 +1802,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -2006,7 +2006,7 @@
 		},
 		"npmlog": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
 			"integrity": "sha1-i5ueRAXX7EjDHCNGllqtx6uuyqU=",
 			"requires": {
 				"ansi": "~0.3.0"
@@ -2095,7 +2095,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-parse": {
@@ -2283,7 +2283,7 @@
 		},
 		"resolve": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
 			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
 		},
 		"resolve-from": {
@@ -2375,7 +2375,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -2533,7 +2533,7 @@
 		},
 		"source-map": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 			"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
 			"optional": true,
 			"requires": {
@@ -2558,7 +2558,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
@@ -2675,7 +2675,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -198,8 +198,6 @@ export class BtcChain implements IChain {
     } else {
       t.setVersion(2);
     }
-    console.log('[txproposal.ts.141] BTC *TX* VERSION: ' + t.version); // TODO
-
     switch (txp.addressType) {
       case Constants.SCRIPT_TYPES.P2WSH:
       case Constants.SCRIPT_TYPES.P2SH:

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -198,6 +198,7 @@ export class BtcChain implements IChain {
     } else {
       t.setVersion(2);
     }
+console.log('[txproposal.ts.141] BTC *TX* VERSION: ' + t.version); // TODO
 
     switch (txp.addressType) {
       case Constants.SCRIPT_TYPES.P2WSH:

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -192,6 +192,13 @@ export class BtcChain implements IChain {
   buildTx(txp) {
     const t = new this.bitcoreLib.Transaction();
 
+    // BTC tx version
+    if (txp.version <= 3) {
+      t.setVersion(1);
+    } else {
+      t.setVersion(2);
+    }
+
     switch (txp.addressType) {
       case Constants.SCRIPT_TYPES.P2WSH:
       case Constants.SCRIPT_TYPES.P2SH:

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -198,7 +198,7 @@ export class BtcChain implements IChain {
     } else {
       t.setVersion(2);
     }
-console.log('[txproposal.ts.141] BTC *TX* VERSION: ' + t.version); // TODO
+    console.log('[txproposal.ts.141] BTC *TX* VERSION: ' + t.version); // TODO
 
     switch (txp.addressType) {
       case Constants.SCRIPT_TYPES.P2WSH:

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -445,6 +445,7 @@ export class ExpressApp {
       });
     });
 
+    // DEPRECATED
     router.post('/v1/txproposals/', (req, res) => {
       const Errors = require('./errors/errordefinitions');
       const err = Errors.UPGRADE_NEEDED;
@@ -462,7 +463,18 @@ export class ExpressApp {
       });
     });
 
+    // DEPRECATED, BTC tx ver=1, txp ver = 3 
     router.post('/v3/txproposals/', (req, res) => {
+      getServerWithAuth(req, res, server => {
+        req.body.txpVersion = 3;
+        server.createTx(req.body, (err, txp) => {
+          if (err) return returnError(err, res, req);
+          res.json(txp);
+        });
+      });
+    });
+
+    router.post('/v4/txproposals/', (req, res) => {
       getServerWithAuth(req, res, server => {
         server.createTx(req.body, (err, txp) => {
           if (err) return returnError(err, res, req);
@@ -470,6 +482,8 @@ export class ExpressApp {
         });
       });
     });
+
+
 
     // DEPRECATED
     router.post('/v1/addresses/', (req, res) => {
@@ -660,6 +674,7 @@ export class ExpressApp {
 
     router.post('/v1/txproposals/:id/signatures/', (req, res) => {
       getServerWithAuth(req, res, server => {
+        req.body.maxTxpVersion = 3;
         req.body.txProposalId = req.params['id'];
         server.signTx(req.body, (err, txp) => {
           if (err) return returnError(err, res, req);
@@ -668,6 +683,19 @@ export class ExpressApp {
         });
       });
     });
+
+    router.post('/v2/txproposals/:id/signatures/', (req, res) => {
+      getServerWithAuth(req, res, server => {
+        req.body.txProposalId = req.params['id'];
+        req.body.maxTxpVersion = 4;
+        server.signTx(req.body, (err, txp) => {
+          if (err) return returnError(err, res, req);
+          res.json(txp);
+          res.end();
+        });
+      });
+    });
+
 
     //
     router.post('/v1/txproposals/:id/publish/', (req, res) => {
@@ -1011,7 +1039,7 @@ export class ExpressApp {
     this.app.use(opts.basePath || '/bws/api', router);
 
     if (config.staticRoot) {
-      log.info(`Serving static files from ${config.staticRoot}`);
+      log.debug(`Serving static files from ${config.staticRoot}`);
       this.app.use('/static', express.static(config.staticRoot));
     }
 

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -463,7 +463,7 @@ export class ExpressApp {
       });
     });
 
-    // DEPRECATED, BTC tx ver=1, txp ver = 3 
+    // DEPRECATED, BTC tx ver=1, txp ver = 3
     router.post('/v3/txproposals/', (req, res) => {
       getServerWithAuth(req, res, server => {
         req.body.txpVersion = 3;
@@ -482,8 +482,6 @@ export class ExpressApp {
         });
       });
     });
-
-
 
     // DEPRECATED
     router.post('/v1/addresses/', (req, res) => {
@@ -695,7 +693,6 @@ export class ExpressApp {
         });
       });
     });
-
 
     //
     router.post('/v1/txproposals/:id/publish/', (req, res) => {

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -136,7 +136,6 @@ export class TxProposal {
       $.checkArgument(opts.version === 3);
     }
 
-
     x.version = opts.version || 4;
     const now = Date.now();
     x.createdOn = Math.floor(now / 1000);

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -131,8 +131,13 @@ export class TxProposal {
 
     const x = new TxProposal();
 
-    x.version = 4;
+    // allow creating legacy tx version == 3 only
+    if (opts.version) {
+      $.checkArgument(opts.version === 3);
+    }
 
+
+    x.version = opts.version || 4;
     const now = Date.now();
     x.createdOn = Math.floor(now / 1000);
     x.id = opts.id || Uuid.v4();

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -131,7 +131,7 @@ export class TxProposal {
 
     const x = new TxProposal();
 
-    x.version = 3;
+    x.version = 4;
 
     const now = Date.now();
     x.createdOn = Math.floor(now / 1000);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -2721,7 +2721,7 @@ export class WalletService {
    * Sign a transaction proposal.
    * @param {Object} opts
    * @param {string} opts.txProposalId - The identifier of the transaction.
-   * @param {string} opts.maxTxpVersion - Client's maximum supported txp version 
+   * @param {string} opts.maxTxpVersion - Client's maximum supported txp version
    * @param {string} opts.signatures - The signatures of the inputs of this tx for this copayer (in apperance order)
    */
   signTx(opts, cb) {
@@ -2742,11 +2742,10 @@ export class WalletService {
             return cb(
               new ClientError(
                 Errors.codes.UPGRADE_NEEDED,
-                'Your client does not support signing this transaction. Please upgrade',
+                'Your client does not support signing this transaction. Please upgrade'
               )
             );
-        }
- 
+          }
 
           const action = _.find(txp.actions, {
             copayerId: this.copayerId

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -6903,6 +6903,26 @@ describe('Wallet service', function() {
         });
       });
     });
+
+    it('should broadcast a tx and set locktime & version', function(done) {
+      var clock = sinon.useFakeTimers({ now: 1234000, toFake: ['Date'] });
+      helpers.stubBroadcast(txid);
+      server.broadcastTx({
+        txProposalId: txpid
+      }, function(err) {
+        should.not.exist(err);
+        server.getTx({
+          txProposalId: txpid
+        }, function(err, txp) {
+          should.not.exist(err);
+
+          should.exist(txp.raw);
+          const tx = new Bitcore.Transaction(txp.raw);
+          clock.restore();
+          done();
+        });
+      });
+    });
     it('should broadcast a raw tx', function(done) {
       helpers.stubBroadcast(txid);
       server.broadcastRawTx({

--- a/packages/bitcore-wallet-service/test/model/txproposal.js
+++ b/packages/bitcore-wallet-service/test/model/txproposal.js
@@ -88,19 +88,19 @@ describe('TxProposal', function() {
   });
 
   describe('#sign', function() {
-    it('should sign 2-2', function() {
+    it('should sign 2-2 (txp version 3, btc tx version 1)', function() {
       var txp = TxProposal.fromObj(aTXP());
       txp.sign('1', theSignatures, theXPub);
       txp.isAccepted().should.equal(false);
       txp.isRejected().should.equal(false);
       txp.sign('2', theSignatures, theXPub);
-      txp.isAccepted().should.equal(true);
+      txp.isAccepted().should.equal(true); //<===
       txp.isRejected().should.equal(false);
     });
   });
 
   describe('#getRawTx', function() {
-    it('should generate correct raw transaction for signed 2-2', function() {
+    it('should generate correct raw transaction for signed 2-2, tx version 1', function() {
       var txp = TxProposal.fromObj(aTXP());
       txp.sign('1', theSignatures, theXPub);
       txp.getRawTx().should.equal(theRawTx);

--- a/packages/crypto-wallet-core/package-lock.json
+++ b/packages/crypto-wallet-core/package-lock.json
@@ -17,18 +17,11 @@
 				"defer-to-connect": "^1.0.1"
 			}
 		},
-		"@types/bignumber.js": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
-			"integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
-			"requires": {
-				"bignumber.js": "*"
-			}
-		},
 		"@types/bn.js": {
 			"version": "4.11.6",
 			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
 			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			},
@@ -36,7 +29,8 @@
 				"@types/node": {
 					"version": "13.9.1",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+					"dev": true
 				}
 			}
 		},
@@ -60,8 +54,7 @@
 		"@types/node": {
 			"version": "10.12.15",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
-			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
-			"dev": true
+			"integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA=="
 		},
 		"@types/underscore": {
 			"version": "1.9.4",
@@ -91,42 +84,6 @@
 					"version": "13.9.1",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
 					"integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
-				}
-			}
-		},
-		"@web3-js/scrypt-shim": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@web3-js/scrypt-shim/-/scrypt-shim-0.1.0.tgz",
-			"integrity": "sha512-ZtZeWCc/s0nMcdx/+rZwY1EcuRdemOK9ag21ty9UsHkFxsNb/AaoucUz0iPuyGe0Ku+PFuRmWZG7Z7462p9xPw==",
-			"requires": {
-				"scryptsy": "^2.1.0",
-				"semver": "^6.3.0"
-			}
-		},
-		"@web3-js/websocket": {
-			"version": "1.0.30",
-			"resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
-			"integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
-			"requires": {
-				"debug": "^2.2.0",
-				"es5-ext": "^0.10.50",
-				"nan": "^2.14.0",
-				"typedarray-to-buffer": "^3.1.5",
-				"yaeti": "^0.0.6"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -351,22 +308,6 @@
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
 			"integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-		},
-		"bindings": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"requires": {
-				"file-uri-to-path": "1.0.0"
-			}
-		},
-		"bip66": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
 		},
 		"bl": {
 			"version": "1.2.2",
@@ -884,9 +825,9 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"decompress": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
-			"integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+			"integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
 			"requires": {
 				"decompress-tar": "^4.0.0",
 				"decompress-tarbz2": "^4.0.0",
@@ -1036,19 +977,9 @@
 			}
 		},
 		"dom-walk": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-			"integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-		},
-		"drbg.js": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-			"requires": {
-				"browserify-aes": "^1.0.6",
-				"create-hash": "^1.1.2",
-				"create-hmac": "^1.1.4"
-			}
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+			"integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -1252,49 +1183,6 @@
 				}
 			}
 		},
-		"ethereum-bloom-filters": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
-			"integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
-			"requires": {
-				"js-sha3": "^0.8.0"
-			},
-			"dependencies": {
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-				}
-			}
-		},
-		"ethereumjs-common": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.0.tgz",
-			"integrity": "sha512-SZOjgK1356hIY7MRj3/ma5qtfr/4B5BL+G4rP/XSMYr2z1H5el4RX5GReYCKmQmYI/nSBmRnwrZ17IfHuG0viQ=="
-		},
-		"ethereumjs-tx": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.2.tgz",
-			"integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
-			"requires": {
-				"ethereumjs-common": "^1.5.0",
-				"ethereumjs-util": "^6.0.0"
-			}
-		},
-		"ethereumjs-util": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-			"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-			"requires": {
-				"@types/bn.js": "^4.11.3",
-				"bn.js": "^4.11.0",
-				"create-hash": "^1.1.2",
-				"ethjs-util": "0.1.6",
-				"keccak": "^2.0.0",
-				"rlp": "^2.2.3",
-				"secp256k1": "^3.0.1"
-			}
-		},
 		"ethers": {
 			"version": "4.0.37",
 			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.37.tgz",
@@ -1333,15 +1221,6 @@
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
 				}
-			}
-		},
-		"ethjs-util": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-			"requires": {
-				"is-hex-prefixed": "1.0.0",
-				"strip-hex-prefix": "1.0.0"
 			}
 		},
 		"eventemitter3": {
@@ -1477,11 +1356,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
-		},
-		"file-uri-to-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"finalhandler": {
 			"version": "1.1.2",
@@ -2053,17 +1927,6 @@
 				"verror": "1.10.0"
 			}
 		},
-		"keccak": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-			"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-			"requires": {
-				"bindings": "^1.5.0",
-				"inherits": "^2.0.4",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.2.0"
-			}
-		},
 		"keyv": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -2249,7 +2112,8 @@
 		"minimist": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"dev": true
 		},
 		"minipass": {
 			"version": "2.9.0",
@@ -2269,9 +2133,9 @@
 			}
 		},
 		"mkdirp": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-			"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
 		},
 		"mkdirp-promise": {
 			"version": "5.0.1",
@@ -2675,9 +2539,9 @@
 			}
 		},
 		"psl": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -2737,6 +2601,11 @@
 				"randombytes": "^2.0.5",
 				"safe-buffer": "^5.1.0"
 			}
+		},
+		"randomhex": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
+			"integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
 		},
 		"range-parser": {
 			"version": "1.2.1",
@@ -3050,14 +2919,6 @@
 				}
 			}
 		},
-		"rlp": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-			"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
-			"requires": {
-				"bn.js": "^4.11.1"
-			}
-		},
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -3078,37 +2939,6 @@
 			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
 			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
 		},
-		"secp256k1": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-			"integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-			"requires": {
-				"bindings": "^1.5.0",
-				"bip66": "^1.1.5",
-				"bn.js": "^4.11.8",
-				"create-hash": "^1.2.0",
-				"drbg.js": "^1.0.1",
-				"elliptic": "^6.5.2",
-				"nan": "^2.14.0",
-				"safe-buffer": "^5.1.2"
-			},
-			"dependencies": {
-				"elliptic": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-					"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
-					"requires": {
-						"bn.js": "^4.4.0",
-						"brorand": "^1.0.1",
-						"hash.js": "^1.0.0",
-						"hmac-drbg": "^1.0.0",
-						"inherits": "^2.0.1",
-						"minimalistic-assert": "^1.0.0",
-						"minimalistic-crypto-utils": "^1.0.0"
-					}
-				}
-			}
-		},
 		"seek-bzip": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
@@ -3118,9 +2948,9 @@
 			}
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+			"integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -3471,12 +3301,17 @@
 				"yallist": "^3.0.3"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
 				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 					"requires": {
-						"minimist": "0.0.8"
+						"minimist": "^1.2.5"
 					}
 				}
 			}
@@ -3654,9 +3489,9 @@
 			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
 		},
 		"unbzip2-stream": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-			"integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
+			"integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
 			"requires": {
 				"buffer": "^5.2.1",
 				"through": "^2.3.8"
@@ -3739,154 +3574,123 @@
 			}
 		},
 		"web3": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.4.tgz",
-			"integrity": "sha512-xPXGe+w0x0t88Wj+s/dmAdASr3O9wmA9mpZRtixGZxmBexAF0MjfqYM+MS4tVl5s11hMTN3AZb8cDD4VLfC57A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+			"integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
 			"requires": {
-				"@types/node": "^12.6.1",
-				"web3-bzz": "1.2.4",
-				"web3-core": "1.2.4",
-				"web3-eth": "1.2.4",
-				"web3-eth-personal": "1.2.4",
-				"web3-net": "1.2.4",
-				"web3-shh": "1.2.4",
-				"web3-utils": "1.2.4"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.30",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-					"integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
-				}
+				"web3-bzz": "1.2.1",
+				"web3-core": "1.2.1",
+				"web3-eth": "1.2.1",
+				"web3-eth-personal": "1.2.1",
+				"web3-net": "1.2.1",
+				"web3-shh": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-bzz": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.4.tgz",
-			"integrity": "sha512-MqhAo/+0iQSMBtt3/QI1rU83uvF08sYq8r25+OUZ+4VtihnYsmkkca+rdU0QbRyrXY2/yGIpI46PFdh0khD53A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
+			"integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
 			"requires": {
-				"@types/node": "^10.12.18",
 				"got": "9.6.0",
 				"swarm-js": "0.1.39",
 				"underscore": "1.9.1"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "10.17.17",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
-				}
 			}
 		},
 		"web3-core": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
-			"integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+			"integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
 			"requires": {
-				"@types/bignumber.js": "^5.0.0",
-				"@types/bn.js": "^4.11.4",
-				"@types/node": "^12.6.1",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-core-requestmanager": "1.2.4",
-				"web3-utils": "1.2.4"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.30",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-					"integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
-				}
+				"web3-core-helpers": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-core-requestmanager": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-core-helpers": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
-			"integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
+			"integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-eth-iban": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-eth-iban": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-core-method": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
-			"integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
+			"integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-promievent": "1.2.4",
-				"web3-core-subscriptions": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core-helpers": "1.2.1",
+				"web3-core-promievent": "1.2.1",
+				"web3-core-subscriptions": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-core-promievent": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
-			"integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
+			"integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
 			"requires": {
 				"any-promise": "1.3.0",
 				"eventemitter3": "3.1.2"
 			}
 		},
 		"web3-core-requestmanager": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
-			"integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
+			"integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.4",
-				"web3-providers-http": "1.2.4",
-				"web3-providers-ipc": "1.2.4",
-				"web3-providers-ws": "1.2.4"
+				"web3-core-helpers": "1.2.1",
+				"web3-providers-http": "1.2.1",
+				"web3-providers-ipc": "1.2.1",
+				"web3-providers-ws": "1.2.1"
 			}
 		},
 		"web3-core-subscriptions": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
-			"integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
+			"integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
 			"requires": {
 				"eventemitter3": "3.1.2",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.4"
+				"web3-core-helpers": "1.2.1"
 			}
 		},
 		"web3-eth": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.4.tgz",
-			"integrity": "sha512-+j+kbfmZsbc3+KJpvHM16j1xRFHe2jBAniMo1BHKc3lho6A8Sn9Buyut6odubguX2AxoRArCdIDCkT9hjUERpA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
+			"integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
 			"requires": {
 				"underscore": "1.9.1",
-				"web3-core": "1.2.4",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-core-subscriptions": "1.2.4",
-				"web3-eth-abi": "1.2.4",
-				"web3-eth-accounts": "1.2.4",
-				"web3-eth-contract": "1.2.4",
-				"web3-eth-ens": "1.2.4",
-				"web3-eth-iban": "1.2.4",
-				"web3-eth-personal": "1.2.4",
-				"web3-net": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-helpers": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-core-subscriptions": "1.2.1",
+				"web3-eth-abi": "1.2.1",
+				"web3-eth-accounts": "1.2.1",
+				"web3-eth-contract": "1.2.1",
+				"web3-eth-ens": "1.2.1",
+				"web3-eth-iban": "1.2.1",
+				"web3-eth-personal": "1.2.1",
+				"web3-net": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-eth-abi": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
-			"integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+			"integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
 			"requires": {
 				"ethers": "4.0.0-beta.3",
 				"underscore": "1.9.1",
-				"web3-utils": "1.2.4"
+				"web3-utils": "1.2.1"
 			},
 			"dependencies": {
-				"@types/node": {
-					"version": "10.17.17",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-					"integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
-				},
 				"ethers": {
 					"version": "4.0.0-beta.3",
 					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
@@ -3912,22 +3716,21 @@
 			}
 		},
 		"web3-eth-accounts": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.4.tgz",
-			"integrity": "sha512-04LzT/UtWmRFmi4hHRewP5Zz43fWhuHiK5XimP86sUQodk/ByOkXQ3RoXyGXFMNoRxdcAeRNxSfA2DpIBc9xUw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
+			"integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
 			"requires": {
-				"@web3-js/scrypt-shim": "^0.1.0",
 				"any-promise": "1.3.0",
 				"crypto-browserify": "3.12.0",
 				"eth-lib": "0.2.7",
-				"ethereumjs-common": "^1.3.2",
-				"ethereumjs-tx": "^2.1.1",
+				"scryptsy": "2.1.0",
+				"semver": "6.2.0",
 				"underscore": "1.9.1",
 				"uuid": "3.3.2",
-				"web3-core": "1.2.4",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-helpers": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-utils": "1.2.1"
 			},
 			"dependencies": {
 				"elliptic": {
@@ -3962,126 +3765,116 @@
 			}
 		},
 		"web3-eth-contract": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
-			"integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
+			"integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
 			"requires": {
-				"@types/bn.js": "^4.11.4",
 				"underscore": "1.9.1",
-				"web3-core": "1.2.4",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-core-promievent": "1.2.4",
-				"web3-core-subscriptions": "1.2.4",
-				"web3-eth-abi": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-helpers": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-core-promievent": "1.2.1",
+				"web3-core-subscriptions": "1.2.1",
+				"web3-eth-abi": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-eth-ens": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.4.tgz",
-			"integrity": "sha512-g8+JxnZlhdsCzCS38Zm6R/ngXhXzvc3h7bXlxgKU4coTzLLoMpgOAEz71GxyIJinWTFbLXk/WjNY0dazi9NwVw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
+			"integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
 			"requires": {
 				"eth-ens-namehash": "2.0.8",
 				"underscore": "1.9.1",
-				"web3-core": "1.2.4",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-promievent": "1.2.4",
-				"web3-eth-abi": "1.2.4",
-				"web3-eth-contract": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-helpers": "1.2.1",
+				"web3-core-promievent": "1.2.1",
+				"web3-eth-abi": "1.2.1",
+				"web3-eth-contract": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-eth-iban": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
-			"integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
+			"integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
 			"requires": {
 				"bn.js": "4.11.8",
-				"web3-utils": "1.2.4"
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-eth-personal": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
-			"integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
+			"integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
 			"requires": {
-				"@types/node": "^12.6.1",
-				"web3-core": "1.2.4",
-				"web3-core-helpers": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-net": "1.2.4",
-				"web3-utils": "1.2.4"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.30",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-					"integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
-				}
+				"web3-core": "1.2.1",
+				"web3-core-helpers": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-net": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-net": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
-			"integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
+			"integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
 			"requires": {
-				"web3-core": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-utils": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-utils": "1.2.1"
 			}
 		},
 		"web3-providers-http": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
-			"integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
+			"integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
 			"requires": {
-				"web3-core-helpers": "1.2.4",
+				"web3-core-helpers": "1.2.1",
 				"xhr2-cookies": "1.1.0"
 			}
 		},
 		"web3-providers-ipc": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
-			"integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
+			"integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
 			"requires": {
 				"oboe": "2.1.4",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.4"
+				"web3-core-helpers": "1.2.1"
 			}
 		},
 		"web3-providers-ws": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
-			"integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
+			"integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
 			"requires": {
-				"@web3-js/websocket": "^1.0.29",
 				"underscore": "1.9.1",
-				"web3-core-helpers": "1.2.4"
+				"web3-core-helpers": "1.2.1",
+				"websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
 			}
 		},
 		"web3-shh": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.4.tgz",
-			"integrity": "sha512-z+9SCw0dE+69Z/Hv8809XDbLj7lTfEv9Sgu8eKEIdGntZf4v7ewj5rzN5bZZSz8aCvfK7Y6ovz1PBAu4QzS4IQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
+			"integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
 			"requires": {
-				"web3-core": "1.2.4",
-				"web3-core-method": "1.2.4",
-				"web3-core-subscriptions": "1.2.4",
-				"web3-net": "1.2.4"
+				"web3-core": "1.2.1",
+				"web3-core-method": "1.2.1",
+				"web3-core-subscriptions": "1.2.1",
+				"web3-net": "1.2.1"
 			}
 		},
 		"web3-utils": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
-			"integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+			"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
 			"requires": {
 				"bn.js": "4.11.8",
 				"eth-lib": "0.2.7",
-				"ethereum-bloom-filters": "^1.0.6",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
-				"randombytes": "^2.1.0",
+				"randomhex": "0.1.5",
 				"underscore": "1.9.1",
 				"utf8": "3.0.0"
 			},
@@ -4109,6 +3902,32 @@
 						"elliptic": "^6.4.0",
 						"xhr-request-promise": "^0.1.2"
 					}
+				}
+			}
+		},
+		"websocket": {
+			"version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+			"from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+			"requires": {
+				"debug": "^2.2.0",
+				"es5-ext": "^0.10.50",
+				"nan": "^2.14.0",
+				"typedarray-to-buffer": "^3.1.5",
+				"yaeti": "^0.0.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},


### PR DESCRIPTION
 * Add BIP68 support to BTC and BCH bitcore-lib.
 * add /v4/txproposals POST endpoint to create new TX v2 for BTC/BCH.
 * add /v2/txproposals/<id>/signatures to post signatures to TX v2 for BTC/BCH.
 * throws error (need_upgrade) if /v1/txproposals/<id>/signatures tries to sign a TX v2 
 