### PR TITLE
added recover public key from message method

### DIFF
--- a/packages/bitcore-lib/test/message.js
+++ b/packages/bitcore-lib/test/message.js
@@ -12,7 +12,6 @@ var Signature = bitcore.crypto.Signature;
 var Message = require('../lib/message');
 
 describe('Message', function() {
-
   var address = 'n1ZCYg9YXtB5XCZazLxSmPDa8iwJRZHhGx';
   var badAddress = 'mmRcrB5fTwgxaFJmVLNtaG8SV454y1E3kC';
   var privateKey = bitcore.PrivateKey.fromWIF('cPBn5A4ikZvBTQ8D7NnvHZYCAxzDZ5Z2TSGW2LkyPiLxqYaJPBW4');
@@ -102,6 +101,13 @@ describe('Message', function() {
     verified.should.equal(false);
   });
 
+  it('can recover the public key with address and generated signature string', function() {
+    var message11 = new Message(text);
+    var recoveredPublicKey = message11.recoverPublicKey(address, signature3);
+    should.not.exist(message11.error);
+    recoveredPublicKey.should.equal(publicKey.toString());
+  });
+
   it('will verify with an uncompressed pubkey', function() {
     var privateKey = new bitcore.PrivateKey('5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss');
     var message = new Message('This is an example of a signed message.');
@@ -116,7 +122,6 @@ describe('Message', function() {
   });
 
   describe('#json', function() {
-
     it('roundtrip to-from-to', function() {
       var json = new Message(text).toJSON();
       var message = Message.fromJSON(json);
@@ -128,11 +133,9 @@ describe('Message', function() {
         return Message.fromJSON('¹');
       }).to.throw();
     });
-
   });
 
   describe('#toString', function() {
-
     it('message string', function() {
       var message = new Message(text);
       message.toString().should.equal(text);
@@ -143,24 +146,18 @@ describe('Message', function() {
       var message = Message.fromString(str);
       message.toString().should.equal(text);
     });
-
   });
 
   describe('#inspect', function() {
-
     it('should output formatted output correctly', function() {
       var message = new Message(text);
-      var output = '<Message: '+text+'>';
+      var output = '<Message: ' + text + '>';
       message.inspect().should.equal(output);
     });
-
   });
-
 
   it('accepts Address for verification', function() {
-    var verified = Message(text)
-      .verify(new Address(address), signatureString);
+    var verified = Message(text).verify(new Address(address), signatureString);
     verified.should.equal(true);
   });
-
 });


### PR DESCRIPTION
I added a method for `bitcore-message` to allow public key recovery from a message text, signature, and bitcoin address.
It's derived from a modification of the `Message.prototype.verify` method, the only difference being instead of returning a boolean, it will return the public key recovered from the ecdsa function.
```
  var ecdsa = new ECDSA();
  ecdsa.hashbuf = this.magicHash();
  ecdsa.sig = signature;
  var publicKey = ecdsa.toPublicKey();
```
I've added the test for it as well https://github.com/bitpay/bitcore/compare/master...hoonsubin:master#diff-4f7bd7a34c1c0e62deff0ad891a55559R104
Once this PR has been merged, I'll add the type definitions as well (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45253)
If there's anything you want me to fix, or something is wrong, please tell me.

P.S. I need the pubkey recovery function with enough abstractions for my project, so I've decided to add it myself
