### PR TITLE
logging for bitcoin p2p peerconnect event

### DIFF
--- a/packages/bitcore-node/src/modules/bitcoin/p2p.ts
+++ b/packages/bitcore-node/src/modules/bitcoin/p2p.ts
@@ -84,6 +84,14 @@ export class BitcoinP2PWorker extends BaseP2PWorker<IBtcBlock> {
       );
     });
 
+    this.pool.on('peerconnect', peer => {
+      logger.info(
+        `${timestamp()} | Connected to peer: ${peer.host}:${peer.port.toString().padEnd(5)} | Chain: ${
+          this.chain
+        } | Network: ${this.network}`
+      );
+    });
+
     this.pool.on('peerdisconnect', peer => {
       logger.warn(
         `${timestamp()} | Not connected to peer: ${peer.host}:${peer.port.toString().padEnd(5)} | Chain: ${


### PR DESCRIPTION
The 'peerconnect' event was not handled by the bitcoin p2p module. The fix adds logging for the 'peerconnect' in bitcoin p2p module.