### PR TITLE
add default no-store cache

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -250,6 +250,7 @@ export class ExpressApp {
       res.setHeader('Cache-Control', `public, max-age=${seconds}, stale-if-error=${10 * seconds}`);
     }
 
+
     // retrieve latest version of copay
     router.get('/latest-version', async (req, res) => {
       SetPublicCache(res, 10 * ONE_MINUTE);
@@ -1291,7 +1292,17 @@ export class ExpressApp {
       });
     });
 
+
+    // Set no-cache by default
+    this.app.use((req, res, next) => {
+      res.setHeader('Cache-Control', `no-store`);
+      next();
+    });
+
     this.app.use(opts.basePath || '/bws/api', router);
+
+
+ 
 
     if (config.staticRoot) {
       logger.debug(`Serving static files from ${config.staticRoot}`);


### PR DESCRIPTION

DEFAULT:

➤ curl -v http://localhost:3232/bws/api/latest-version
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE
< Access-Control-Allow-Headers: x-signature,x-identity,x-session,x-client-version,x-wallet-id,X-Requested-With,Content-Type,Authorization
< x-service-version: bws-8.22.0
**< Cache-Control: no-store**
< User-Agent: copay
< Content-Type: application/json; charset=utf-8
< Content-Length: 21
< ETag: W/"15-luvZsGeT1Qhj3f+YVEvFSuW/Xxw"
< Vary: Accept-Encoding
< Date: Wed, 12 Aug 2020 20:00:42 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
{"version":"v10.1.1"}* Closing connection 0

WITH CACHE:

➤ curl -v http://localhost:3232/bws/api/latest-version
➤ curl -v http://localhost:3232/bws/api/latest-version

< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, DELETE
< Access-Control-Allow-Headers: x-signature,x-identity,x-session,x-client-version,x-wallet-id,X-Requested-With,Content-Type,Authorization
< x-service-version: bws-8.22.0
**< Cache-Control: public, max-age=600, stale-if-error=6000**
< User-Agent: copay
< Content-Type: application/json; charset=utf-8
< Content-Length: 21
< ETag: W/"15-luvZsGeT1Qhj3f+YVEvFSuW/Xxw"
< Vary: Accept-Encoding
< Date: Wed, 12 Aug 2020 20:01:35 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
{"version":"v10.1.1"}* Closing connection 0