### PR TITLE
Fix: Schnorr nonceRFC6979

### DIFF
--- a/packages/bitcore-lib-cash/lib/crypto/schnorr.js
+++ b/packages/bitcore-lib-cash/lib/crypto/schnorr.js
@@ -170,14 +170,12 @@ Schnorr.prototype._findSignature = function(d, e) {
     V = Hash.sha256hmac(V,K);
 
     let k = new BN(0);
-    let T;
     while (true) {
       V = Hash.sha256hmac(V,K);
-      T = BN.fromBuffer(V);
-      $.checkState(T.toBuffer().length >= 32, "T failed test");
-      k = T;
       
-      if (k.gt(new BN(0) && k.lt(Point.getN()))) {
+      k = BN.fromBuffer(V);
+      $.checkState(V.length >= 32, "V length should be >= 32");
+      if (k.gt(new BN(0)) && k.lt(Point.getN())) {
         break;
       }
       K = Hash.sha256hmac(Buffer.concat([V, Buffer.from("00", 'hex')]), K);

--- a/packages/bitcore-lib-cash/lib/crypto/schnorr.js
+++ b/packages/bitcore-lib-cash/lib/crypto/schnorr.js
@@ -72,7 +72,7 @@ Schnorr.prototype._findSignature = function(d, e) {
     $.checkState(!d.gte(n), new Error('privkey out of field of curve'));
   
     
-    let k = nonceFunctionRFC6979(d.toBuffer({ size: 32 }), e.toBuffer({ size: 32 }));
+    let k = this.nonceFunctionRFC6979(d.toBuffer({ size: 32 }), e.toBuffer({ size: 32 }));
 
     let P = G.mul(d);
     let R = G.mul(k);
@@ -157,7 +157,7 @@ Schnorr.prototype._findSignature = function(d, e) {
    * @param {Buffer} msgbuf 
    * @return k {BN}
    */
-  function nonceFunctionRFC6979(privkey, msgbuf) {
+  Schnorr.prototype.nonceFunctionRFC6979 = function(privkey, msgbuf) {
     let V = Buffer.from("0101010101010101010101010101010101010101010101010101010101010101","hex");
     let K = Buffer.from("0000000000000000000000000000000000000000000000000000000000000000","hex");
 
@@ -170,10 +170,12 @@ Schnorr.prototype._findSignature = function(d, e) {
     V = Hash.sha256hmac(V,K);
 
     let k = new BN(0);
+    let T;
     while (true) {
       V = Hash.sha256hmac(V,K);
-      
-      k = BN.fromBuffer(V);
+      T = BN.fromBuffer(V);
+
+      k = T;
       $.checkState(V.length >= 32, "V length should be >= 32");
       if (k.gt(new BN(0)) && k.lt(Point.getN())) {
         break;

--- a/packages/bitcore-lib-cash/test/crypto/schnorr.js
+++ b/packages/bitcore-lib-cash/test/crypto/schnorr.js
@@ -161,4 +161,11 @@ describe("#Schnorr", function() {
         schnorr.sig = Signature.fromString("667C2F778E0616E611BD0C14B8A600C5884551701A949EF0EBFD72D452D64E844160BCFC3F466ECB8FACD19ADE57D8699D74E7207D78C6AEDC3799B52A8E0598");
         schnorr.verify().verified.should.equal(false, "Should fail");
     });
+
+    it("Schnorr nonceFunctionRFC6979", function() {
+        var privkey = [247,229,95,194,90,177,180,124,16,212,194,1,4,84,217,63,135,141,214,161,83,44,149,178,196,172,199,160,224,226,3,171]
+        var msgbuf = [203,64,126,5,128,46,163,26,233,17,17,84,85,232,237,114,254,233,21,23,122,3,27,106,32,178,75,75,119,76,13,176]
+        var k = schnorr.nonceFunctionRFC6979(Buffer.from(privkey), Buffer.from(msgbuf));
+        k.toString().should.equal('40736259912772382559816990380041422373693363729339996443093592104584195165');
+    });
 });


### PR DESCRIPTION
Removes T from nonce function and makes sure V is always a buffer of length 32.