### PR TITLE
fix: remove unuse sign variable

### DIFF
--- a/packages/bitcore-lib-cash/lib/crypto/signature.js
+++ b/packages/bitcore-lib-cash/lib/crypto/signature.js
@@ -5,7 +5,6 @@ var _ = require('lodash');
 var $ = require('../util/preconditions');
 var BufferUtil = require('../util/buffer');
 var JSUtil = require('../util/js');
-const { sign } = require('./ecdsa');
 
 var Signature = function Signature(r, s, isSchnorr) {
   if (!(this instanceof Signature)) {


### PR DESCRIPTION
and fix below

```
(node:7438) Warning: Accessing non-existent property 'sign' of module exports inside circular dependency
    at emitCircularRequireWarning (node:internal/modules/cjs/loader:674:11)
    at Object.get (node:internal/modules/cjs/loader:688:5)
    at Object.<anonymous> (/app/node_modules/bitcore-lib-cash/lib/crypto/signature.js:8:9)
    at Module._compile (node:internal/modules/cjs/loader:1083:30)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1112:10)
    at Module.load (node:internal/modules/cjs/loader:948:32)
    at Function.Module._load (node:internal/modules/cjs/loader:789:14)
    at Module.require (node:internal/modules/cjs/loader:972:19)
    at require (node:internal/modules/cjs/helpers:88:18)
    at Object.<anonymous> (/app/node_modules/bitcore-lib-cash/lib/crypto/ecdsa.js:5:17)
```