### PR TITLE
bitcore-lib-cash: respect the dust limit for change

### DIFF
--- a/packages/bitcore-lib-cash/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/lib/transaction/transaction.js
@@ -865,7 +865,7 @@ Transaction.prototype._updateChangeOutput = function() {
   var available = this._getUnspentValue();
   var fee = this.getFee();
   var changeAmount = available - fee;
-  if (changeAmount > 0) {
+  if (changeAmount >= Transaction.DUST_AMOUNT) {
     this._changeIndex = this.outputs.length;
     this._addOutput(new Output({
       script: this._changeScript,


### PR DESCRIPTION
The current transaction.js builder allows change amount less than the `Transaction.DUST_AMOUNT` constant.

No unit tests are affected by this change.