### PR TITLE
Improve Insight Search Performance

### DIFF
--- a/packages/insight/src/components/head-nav/head-nav.ts
+++ b/packages/insight/src/components/head-nav/head-nav.ts
@@ -68,7 +68,7 @@ export class HeadNavComponent implements OnInit {
         if (searchInputs.length) {
           this.showSearch = false;
           this.searchProvider
-            .search(searchInputs)
+            .search(searchInputs, this.chainNetwork)
             .subscribe(
               res => {
                 this.processAllResponse(res);
@@ -151,13 +151,41 @@ export class HeadNavComponent implements OnInit {
         });
       }
 
+      // Skip results screen if there is only one result
+      const totalMatches = matches.addresses.length + matches.txs.length + matches.blocks.length;
+      if (totalMatches === 1) {
+        if (matches.addresses.length) {
+          return this.redirProvider.redir('address', {
+            addrStr: matches.addresses[0].address,
+            chain: matches.addresses[0].chain,
+            network: matches.addresses[0].network
+          });
+        } else if (matches.txs.length) {
+          return this.redirProvider.redir('transaction', {
+            txId: matches.txs[0].txid,
+            chain: matches.txs[0].chain,
+            network: matches.txs[0].network
+          });
+        } else {
+          return this.redirProvider.redir('block-detail', {
+            blockHash: matches.blocks[0].hash,
+            chain: matches.blocks[0].chain,
+            network: matches.blocks[0].network
+          });
+        }
+      }
+
       this.redirProvider.redir('search', {
         matches,
         chain: this.chainNetwork.chain,
         network: this.chainNetwork.network
       });
     } else {
-      const message = 'No matching records found!';
+      let message = 'No matching records found!';
+      if (this.chainNetwork.chain !== 'ALL') {
+        // Give the user currency specific error since search is limited to one chain/network
+        message = `No matching records found on the ${this.chainNetwork.chain} ${this.chainNetwork.network}. Select a different chain or try a different search`;
+      }
       this.wrongSearch(message);
       this.logger.info(message);
     }
@@ -174,8 +202,9 @@ export class HeadNavComponent implements OnInit {
   private presentToast(message): void {
     const toast: any = this.toastCtrl.create({
       message,
-      duration: 3000,
-      position: 'top'
+      duration: 5000,
+      position: 'top',
+      showCloseButton: true
     });
     toast.present();
   }

--- a/packages/insight/src/components/head-nav/head-nav.ts
+++ b/packages/insight/src/components/head-nav/head-nav.ts
@@ -63,31 +63,15 @@ export class HeadNavComponent implements OnInit {
   public search(): void {
     this.q = this.q.replace(/\s/g, '');
     this.searchProvider
-      .isInputValid(this.q, this.chainNetwork)
-      .subscribe(inputDetails => {
-        if (this.q !== '' && inputDetails.isValid) {
+      .determineInputType(this.q)
+      .subscribe(searchInputs => {
+        if (searchInputs.length) {
           this.showSearch = false;
           this.searchProvider
-            .search(this.q, inputDetails.type, this.chainNetwork)
+            .search(searchInputs)
             .subscribe(
               res => {
-                if (this.chainNetwork.chain !== 'ALL') {
-                  const nextView = this.processResponse(res);
-                  if (!_.includes(nextView, '')) {
-                    this.params[nextView.type] = nextView.params;
-                    this.redirTo = nextView.redirTo;
-                    this.navCtrl.setRoot('home', this.params, {
-                      animate: false
-                    });
-                    this.redirProvider.redir(this.redirTo, this.params);
-                  } else {
-                    const message = 'No matching records found!';
-                    this.wrongSearch(message);
-                    this.logger.info(message);
-                  }
-                } else {
-                  this.processAllResponse(res);
-                }
+                this.processAllResponse(res);
               },
               err => {
                 this.wrongSearch('Server error. Please try again');
@@ -95,7 +79,7 @@ export class HeadNavComponent implements OnInit {
               }
             );
         } else {
-          this.wrongSearch('No matching records found!');
+          this.wrongSearch('Invalid search, please search for an address, transaction, or block');
         }
       });
   }

--- a/packages/insight/src/providers/search/search.ts
+++ b/packages/insight/src/providers/search/search.ts
@@ -92,7 +92,8 @@ export class SearchProvider {
     },
     // Doge Address
     {
-      regexes: [/^(dogecoin:)?D[5-9A-HJ-NP-U][1-9A-HJ-NP-Za-km-z]{32}/],
+      regexes: [/^(dogecoin:)?(D[5-9A-HJ-NP-U][1-9A-HJ-NP-Za-km-z]{32})/],
+      dataIndex: 2,
       type: 'address',
       chainNetworks: [
         { chain: 'DOGE', network: 'mainnet' }
@@ -128,9 +129,11 @@ export class SearchProvider {
         { chain: 'BTC', network: 'mainnet' },
         { chain: 'BCH', network: 'mainnet' },
         { chain: 'DOGE', network: 'mainnet' },
+        { chain: 'ETH', network: 'mainnet' },
         { chain: 'BTC', network: 'testnet' },
         { chain: 'BCH', network: 'testnet' },
-        { chain: 'DOGE', network: 'testnet' }
+        { chain: 'DOGE', network: 'testnet' },
+        { chain: 'ETH', network: 'testnet' }
       ],
     },
   ]

--- a/packages/insight/src/providers/search/search.ts
+++ b/packages/insight/src/providers/search/search.ts
@@ -140,8 +140,14 @@ export class SearchProvider {
     private httpClient: HttpClient
   ) {}
 
-  public search( searchInputs: CryptoSearchInput[]): Observable<any> {
+  public search( searchInputs: CryptoSearchInput[], chainNetwork): Observable<any> {
     const searchArray: Array<Observable<any>> = [];
+    if (chainNetwork.chain !== 'ALL') {
+      // If user has selected a specific network, we only search that network for results
+      searchInputs = searchInputs
+        .filter(input => input.chainNetwork.chain === chainNetwork.chain)
+        .filter(input => input.chainNetwork.network === chainNetwork.network)
+    }
     searchInputs.forEach(search => {
       this.apiURL = `${this.apiProvider.getUrl(search.chainNetwork)}`;
       if (search.type === 'block') {

--- a/packages/insight/src/providers/search/search.ts
+++ b/packages/insight/src/providers/search/search.ts
@@ -5,61 +5,185 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ApiProvider, ChainNetwork } from '../api/api';
 
+interface CryptoSearchInput {
+  input: string,
+  chainNetwork: ChainNetwork,
+  type: string
+}
+
+interface InputType {
+  regexes: RegExp[],
+  dataIndex?: number,
+  type: string
+  chainNetworks: ChainNetwork[],
+}
+
 @Injectable()
 export class SearchProvider {
   private apiURL: string;
+
+  // Some of these could be combined into more complex regexes, but have been intentionally kept relatively separate to
+  // make it clear which address types are checked for so that we know in the future which address types are present/missing
+  private inputTypes: InputType[] = [
+    // Standard BTC / Legacy BCH address
+    {
+      regexes: [/^(bitcoin:)?([13][a-km-zA-HJ-NP-Z1-9]{25,34})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BTC', network: 'mainnet' }
+      ],
+    },
+    // Standard BTC / Legacy BCH address
+    {
+      regexes: [/^(bitcoincash:)?([13][a-km-zA-HJ-NP-Z1-9]{25,34})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BCH', network: 'mainnet' }
+      ],
+    },
+    // bech32 BTC Address
+    {
+      regexes: [/^(bitcoin:)?(bc1[ac-hj-np-zAC-HJ-NP-Z02-9]{11,71})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BTC', network: 'mainnet' }
+      ],
+    },
+    // Standard BCH Address
+    {
+      regexes: [/^(bitcoincash:)?([qp][a-z0-9]{41})$/, /^(BITCOINCASH:)?([QP][A-Z0-9]{41})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BCH', network: 'mainnet' }
+      ],
+    },
+    // Testnet BTC / BCH / Doge Address
+    {
+      regexes: [/^(bitcoin:|bchtest:|dogecoin:)?([2mn][1-9A-HJ-NP-Za-km-z]{26,35})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BTC', network: 'testnet' },
+        { chain: 'BCH', network: 'testnet' },
+        { chain: 'DOGE', network: 'testnet' }
+      ],
+    },
+    // Testnet BCH Address
+    {
+      regexes: [/^(bchtest:)?([qp][a-z0-9]{41})$/, /^(BCHTEST:)?([QP][A-Z0-9]{41})/],
+      dataIndex: 2,
+      type: 'address',
+      chainNetworks: [
+        { chain: 'BCH', network: 'testnet' }
+      ],
+    },
+    // ETH Address
+    {
+      regexes: [/^0x[a-fA-F0-9]{40}$/],
+      type: 'address',
+      chainNetworks: [
+        { chain: 'ETH', network: 'mainnet' },
+        { chain: 'ETH', network: 'testnet' }
+      ],
+    },
+    // Doge Address
+    {
+      regexes: [/^(dogecoin:)?D[5-9A-HJ-NP-U][1-9A-HJ-NP-Za-km-z]{32}/],
+      type: 'address',
+      chainNetworks: [
+        { chain: 'DOGE', network: 'mainnet' }
+      ],
+    },
+    // BTC / BCH / DOGE block or tx
+    {
+      regexes: [/^[A-Fa-f0-9]{64}$/],
+      type: 'blockOrTx',
+      chainNetworks: [
+        { chain: 'BTC', network: 'mainnet' },
+        { chain: 'BCH', network: 'mainnet' },
+        { chain: 'DOGE', network: 'mainnet' },
+        { chain: 'BTC', network: 'testnet' },
+        { chain: 'BCH', network: 'testnet' },
+        { chain: 'DOGE', network: 'testnet' }
+      ],
+    },
+    // ETH block or tx
+    {
+      regexes: [/^0x[A-Fa-f0-9]{64}$/],
+      type: 'blockOrTx',
+      chainNetworks: [
+        { chain: 'ETH', network: 'mainnet' },
+        { chain: 'ETH', network: 'testnet' }
+      ],
+    },
+    // BTC / BCH / DOGE / ETH block height
+    {
+      regexes: [/^[0-9]{1,9}$/],
+      type: 'block',
+      chainNetworks: [
+        { chain: 'BTC', network: 'mainnet' },
+        { chain: 'BCH', network: 'mainnet' },
+        { chain: 'DOGE', network: 'mainnet' },
+        { chain: 'BTC', network: 'testnet' },
+        { chain: 'BCH', network: 'testnet' },
+        { chain: 'DOGE', network: 'testnet' }
+      ],
+    },
+  ]
 
   constructor(
     private apiProvider: ApiProvider,
     private httpClient: HttpClient
   ) {}
 
-  public search(
-    input: string,
-    type: string,
-    chainNetwork: ChainNetwork
-  ): Observable<any> {
-    if (chainNetwork.chain !== 'ALL') {
-      this.apiURL = `${this.apiProvider.getUrl(chainNetwork)}`;
-      switch (type) {
-        case 'blockOrTx':
-          return Observable.forkJoin(
-            this.searchBlock(input).catch(err => Observable.of(err)),
-            this.searchTx(input).catch(err => Observable.of(err))
-          );
-        case 'addr':
-          return this.searchAddr(input);
+  public search( searchInputs: CryptoSearchInput[]): Observable<any> {
+    const searchArray: Array<Observable<any>> = [];
+    searchInputs.forEach(search => {
+      this.apiURL = `${this.apiProvider.getUrl(search.chainNetwork)}`;
+      if (search.type === 'block') {
+        searchArray.push(
+          this.searchBlock(search.input).catch(err => Observable.of(err))
+        );
+      } else if (search.type === 'blockOrTx') {
+        searchArray.push(
+          this.searchBlock(search.input).catch(err => Observable.of(err))
+        );
+        searchArray.push(
+          this.searchTx(search.input).catch(err => Observable.of(err))
+        );
+      } else if (search.type === 'address') {
+        searchArray.push(
+          this.searchAddr(search.input).catch(err => Observable.of(err))
+        );
       }
-    } else {
-      const searchArray: Array<Observable<any>> = [];
-      this.apiProvider.networkSettings.availableNetworks.forEach(network => {
-        if (network.chain !== 'ALL') {
-          this.apiURL = `${this.apiProvider.getUrl(network)}`;
-          searchArray.push(
-            this.searchBlock(input).catch(err => Observable.of(err))
-          );
-          searchArray.push(
-            this.searchTx(input).catch(err => Observable.of(err))
-          );
-          searchArray.push(
-            this.searchAddr(input).catch(err => Observable.of(err))
-          );
-        }
-      });
-      return Observable.forkJoin(searchArray);
-    }
+    });
+    return Observable.forkJoin(searchArray);
   }
 
-  public isInputValid(inputValue, chainNetwork): Observable<any> {
-    if (chainNetwork.chain !== 'ALL') {
-      return this.httpClient
-        .get<{ isValid: boolean; type: string }>(
-          `${this.apiProvider.getUrl(chainNetwork)}/valid/${inputValue}`
-        )
-        .pipe(map(res => ({ isValid: res.isValid, type: res.type })));
-    } else {
-      return Observable.of({ isValid: true, type: 'all' });
+  public determineInputType(input:string): Observable<CryptoSearchInput[]> {
+    const searchInputs:CryptoSearchInput[] = [];
+    for (const { regexes, chainNetworks, type, dataIndex } of this.inputTypes) {
+      const index = regexes.findIndex(regex => regex.test(input));
+      if (index > -1) {
+        let localInput = input;
+        // If defined then the data we care about is a subset of the actual user input (ie has prefix to discard)
+        if (dataIndex !== undefined) {
+          localInput = input.match(regexes[index])[dataIndex];
+        }
+        for (const chainNetwork of chainNetworks) {
+          searchInputs.push({
+            input: localInput,
+            chainNetwork,
+            type
+          });
+        }
+      }
     }
+    return Observable.of(searchInputs);
   }
 
   private searchBlock(block: string): Observable<{ block: any }> {
@@ -72,8 +196,7 @@ export class SearchProvider {
       .get<{ tx: any }>(`${this.apiURL}/tx/${txid}`)
       .pipe(map(res => ({ tx: res })));
   }
-  private searchAddr(addr: string): Observable<{ addr: any }> {
-    const address = this.extractAddress(addr);
+  private searchAddr(address: string): Observable<{ addr: any }> {
     const apiURL = _.includes(this.apiURL, 'ETH')
       ? `${this.apiURL}/address/${address}/txs?limit=1`
       : `${this.apiURL}/address/${address}`;


### PR DESCRIPTION
### Overview
Implements regex based smart searching to limit api calls to only valid paths based on what input is detected.
As txids and block ids are by far the most shared format, the current implementation of this code avoids querying eth if the 0x prefix is not present. If querying for eth without the 0x prefix is a common occurrence it can be included.

### Performance improvements with this merge for searches:

Input Type | Requests Sent in Master | Requests Sent with this change
------------|----------------------------|-----------------------------------
Garbage data | 24 | 0
Legacy bitcoin address (no bitcoin: prefix) | 24 | 2
Any address with a prefix | 24 | 1
Block or txid | 24 | 12
ETH tx/block ids | 24 | 4

On top of this, there's currently an issue where we **always retry requests**, so even 404's which are legitimate, or worse 429s, are immediately retried. So something like searching for 'test' on live insight results in 40+ requests, all of which fail.

### Additional improvements
* Search results screen is automatically skipped if only one result is returned
* No results search error message when a chain is selected is now more specific to let the user know they are only searching the current chain/network 
![Screenshot from 2021-03-04 13-16-28](https://user-images.githubusercontent.com/739442/110011206-2bde1480-7ced-11eb-9536-701833a88b49.png)


###  Other notes
As we add more currencies and there is even more overlap of txids and block ids, it may make sense to ask the user which currency they're querying for when their query would hit more than 2 chains/networks.

### Review notes
Please double check I haven't missed any strange edge cases in regards to address/block/txid formats.

