### PR TITLE
Fix multiple currency libraries from overwriting the global elliptic "Point" prototype

### DIFF
--- a/packages/bitcore-lib-cash/lib/crypto/point.js
+++ b/packages/bitcore-lib-cash/lib/crypto/point.js
@@ -30,7 +30,7 @@ var Point = function Point(x, y, isRed) {
   return point;
 };
 
-Point.prototype = Object.getPrototypeOf(ec.curve.point());
+Point.prototype = Object.create(ec.curve.point().prototype);
 
 /**
  *

--- a/packages/bitcore-lib-doge/lib/crypto/point.js
+++ b/packages/bitcore-lib-doge/lib/crypto/point.js
@@ -30,7 +30,7 @@ var Point = function Point(x, y, isRed) {
   return point;
 };
 
-Point.prototype = Object.getPrototypeOf(ec.curve.point());
+Point.prototype = Object.create(ec.curve.point().prototype);
 
 /**
  *

--- a/packages/bitcore-lib-ltc/lib/crypto/point.js
+++ b/packages/bitcore-lib-ltc/lib/crypto/point.js
@@ -30,7 +30,7 @@ var Point = function Point(x, y, isRed) {
   return point;
 };
 
-Point.prototype = Object.getPrototypeOf(ec.curve.point());
+Point.prototype = Object.create(ec.curve.point().prototype);
 
 /**
  *

--- a/packages/bitcore-lib/lib/crypto/point.js
+++ b/packages/bitcore-lib/lib/crypto/point.js
@@ -30,7 +30,7 @@ var Point = function Point(x, y, isRed) {
   return point;
 };
 
-Point.prototype = Object.getPrototypeOf(ec.curve.point());
+Point.prototype = Object.create(ec.curve.point().prototype);
 
 /**
  *


### PR DESCRIPTION
By switching to `Object.create(x)` as opposed to `Object.getPrototypeOf(x)`, the `Point` prototype is cloned as opposed to copied.

This closes #3128, as using `Object.getPrototypeOf` caused the HDPrivateKey generation to fail if you include multiple bitcore currency libraries in a single environment.