### PR TITLE
BCH schnorr sometimes creates INVALID signatures

### DIFF
--- a/packages/bitcore-lib-cash/lib/crypto/signature.js
+++ b/packages/bitcore-lib-cash/lib/crypto/signature.js
@@ -214,13 +214,12 @@ Signature.prototype.toBuffer = Signature.prototype.toDER = function(signingMetho
 
   signingMethod = signingMethod || "ecdsa";
 
+  if(signingMethod === "schnorr") {
+    return Buffer.concat([this.r.toBuffer({size: 32}), this.s.toBuffer({size: 32})]);
+  }
 
   var rnbuf = this.r.toBuffer();
   var snbuf = this.s.toBuffer();
-
-  if(signingMethod === "schnorr") {
-    return Buffer.concat([rnbuf, snbuf]);
-  }
   
   var rneg = rnbuf[0] & 0x80 ? true : false;
   var sneg = snbuf[0] & 0x80 ? true : false;

--- a/packages/bitcore-lib-cash/test/crypto/schnorr.js
+++ b/packages/bitcore-lib-cash/test/crypto/schnorr.js
@@ -33,6 +33,20 @@ describe("#Schnorr", function() {
         schnorr.verify().verified.should.equal(true);
     });
 
+    it("Sign Schnorr padding",  function() {
+        schnorr.hashbuf =  Hash.sha256((Buffer.from('Very deterministic messageg6', 'utf-8')));
+        schnorr.endianess = 'big';
+        schnorr.privkey = new Privkey(BN.fromBuffer('12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747','hex'), 'livenet');
+        schnorr.privkey2pubkey();
+        schnorr.sign();
+        schnorr.verify().verified.should.equal(true);
+        let x = new Signature();
+        x.isSchnorr = true;
+        x.set(schnorr.sig);
+        let str = x.toBuffer("schnorr").toString('hex');
+        str.should.equal("005e7ab0906a0164306975916350214a69fb80210cf7e37533f197c3d18b23d1b794262dc663d9e99605784b14ee1ecfca27b602e88dbc87af85f9907c214ea3");
+    });
+
     // Following Test Vectors used from
     // https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr/test-vectors.csv
 


### PR DESCRIPTION
Tested with BTCD's fork BCHD. Schnorr must always be of constant length. Padding is crucial.