### PR TITLE
[FIX] actually delete network

### DIFF
--- a/packages/bitcore-lib/lib/networks.js
+++ b/packages/bitcore-lib/lib/networks.js
@@ -130,10 +130,12 @@ function removeNetwork(network) {
   }
   for (var key in networkMaps) {
     const index = networkMaps[key].indexOf(network);
-    if (networkMaps[key].length == 1) {
-      delete networkMaps[key];
-    } else if (index >= 0) {
-      networkMaps[key].splice(index, 1);
+    if (index >= 0) {
+      if (networkMaps[key].length == 1) {
+        delete networkMaps[key];
+      } else {
+        networkMaps[key].splice(index, 1);
+      }
     }
   }
 }

--- a/packages/bitcore-lib/lib/networks.js
+++ b/packages/bitcore-lib/lib/networks.js
@@ -130,8 +130,10 @@ function removeNetwork(network) {
   }
   for (var key in networkMaps) {
     const index = networkMaps[key].indexOf(network);
-    if (index >= 0) {
-      delete networkMaps[key][index];
+    if (networkMaps[key].length == 1) {
+      delete networkMaps[key];
+    } else if (index >= 0) {
+      networkMaps[key].splice(index, 1);
     }
   }
 }


### PR DESCRIPTION
Solution close to what was described in #2400, but with a `delete networkMaps[key]` when length is 1 (to prevent splicing from leaving an empty entry on networkMaps).