### PR TITLE
isHexa -> isHexaOrEmpty

### DIFF
--- a/packages/bitcore-lib-cash/lib/address.js
+++ b/packages/bitcore-lib-cash/lib/address.js
@@ -515,7 +515,7 @@ Address.fromString = function(str, network, type) {
  */
 Address.fromObject = function fromObject(obj) {
   $.checkState(
-    JSUtil.isHexa(obj.hash),
+    JSUtil.isHexaOrEmpty(obj.hash),
     'Unexpected hash property, "' + obj.hash + '", expected to be hex.'
   );
   var hashBuffer = Buffer.from(obj.hash, 'hex');

--- a/packages/bitcore-lib-cash/lib/hdprivatekey.js
+++ b/packages/bitcore-lib-cash/lib/hdprivatekey.js
@@ -370,7 +370,7 @@ HDPrivateKey.prototype._buildFromObject = function(arg) {
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
     chainCode: _.isString(arg.chainCode) ? Buffer.from(arg.chainCode,'hex') : arg.chainCode,
-    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
+    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexaOrEmpty(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
     checksum: arg.checksum ? (arg.checksum.length ? arg.checksum : BufferUtil.integerAsBuffer(arg.checksum)) : undefined
   };
   return this._buildFromBuffers(buffers);
@@ -405,7 +405,7 @@ HDPrivateKey.prototype._generateRandomly = function(network) {
  */
 HDPrivateKey.fromSeed = function(hexa, network) {
   /* jshint maxcomplexity: 8 */
-  if (JSUtil.isHexaString(hexa)) {
+  if (JSUtil.isHexaOrEmptyString(hexa)) {
     hexa = Buffer.from(hexa,'hex');
   }
   if (!Buffer.isBuffer(hexa)) {

--- a/packages/bitcore-lib-cash/lib/privatekey.js
+++ b/packages/bitcore-lib-cash/lib/privatekey.js
@@ -102,7 +102,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.bn = PrivateKey._getRandomBN();
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
-    if (JSUtil.isHexa(data)) {
+    if (JSUtil.isHexaOrEmpty(data)) {
       info.bn = new BN(Buffer.from(data, 'hex'));
     } else {
       info = PrivateKey._transformWIF(data, network);

--- a/packages/bitcore-lib-cash/lib/script/script.js
+++ b/packages/bitcore-lib-cash/lib/script/script.js
@@ -176,7 +176,7 @@ Script.fromHex = function(str) {
 };
 
 Script.fromString = function(str) {
-  if (JSUtil.isHexa(str) || str.length === 0) {
+  if (JSUtil.isHexaOrEmpty(str) || str.length === 0) {
     return new Script(Buffer.from(str, 'hex'));
   }
   var script = new Script();

--- a/packages/bitcore-lib-cash/lib/transaction/input/input.js
+++ b/packages/bitcore-lib-cash/lib/transaction/input/input.js
@@ -62,7 +62,7 @@ Input.fromObject = function(obj) {
 
 Input.prototype._fromObject = function(params) {
   var prevTxId;
-  if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
+  if (_.isString(params.prevTxId) && JSUtil.isHexaOrEmpty(params.prevTxId)) {
     prevTxId = Buffer.from(params.prevTxId, 'hex');
   } else {
     prevTxId = params.prevTxId;
@@ -131,7 +131,7 @@ Input.prototype.setScript = function(script) {
     this._script = Script.empty();
     this._script._isInput = true;
     this._scriptBuffer = this._script.toBuffer();
-  } else if (JSUtil.isHexa(script)) {
+  } else if (JSUtil.isHexaOrEmpty(script)) {
     // hex string script
     this._scriptBuffer = Buffer.from(script, 'hex');
   } else if (_.isString(script)) {

--- a/packages/bitcore-lib-cash/lib/transaction/output.js
+++ b/packages/bitcore-lib-cash/lib/transaction/output.js
@@ -22,7 +22,7 @@ function Output(args) {
       this._scriptBuffer = args.script;
     } else {
       var script;
-      if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
+      if (_.isString(args.script) && JSUtil.isHexaOrEmpty(args.script)) {
         script = Buffer.from(args.script, 'hex');
       } else {
         script = args.script;

--- a/packages/bitcore-lib-cash/lib/transaction/signature.js
+++ b/packages/bitcore-lib-cash/lib/transaction/signature.js
@@ -54,9 +54,9 @@ TransactionSignature.prototype._checkObjectArgs = function(arg) {
   $.checkArgument(arg.prevTxId, 'prevTxId');
   $.checkState(arg.signature instanceof Signature ||
                BufferUtil.isBuffer(arg.signature) ||
-               JSUtil.isHexa(arg.signature), 'signature must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.signature), 'signature must be a buffer or hexa value');
   $.checkState(BufferUtil.isBuffer(arg.prevTxId) ||
-               JSUtil.isHexa(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
   $.checkArgument(arg.sigtype, 'sigtype');
   $.checkState(_.isNumber(arg.sigtype), 'sigtype must be a number');
 };

--- a/packages/bitcore-lib-cash/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/lib/transaction/transaction.js
@@ -44,7 +44,7 @@ function Transaction(serialized) {
   if (serialized) {
     if (serialized instanceof Transaction) {
       return Transaction.shallowCopy(serialized);
-    } else if (JSUtil.isHexa(serialized)) {
+    } else if (JSUtil.isHexaOrEmpty(serialized)) {
       this.fromString(serialized);
     } else if (BufferUtil.isBuffer(serialized)) {
       this.fromBuffer(serialized);

--- a/packages/bitcore-lib-cash/lib/transaction/unspentoutput.js
+++ b/packages/bitcore-lib-cash/lib/transaction/unspentoutput.js
@@ -33,7 +33,7 @@ function UnspentOutput(data) {
   $.checkArgument(_.isObject(data), 'Must provide an object from where to extract data');
   var address = data.address ? new Address(data.address) : undefined;
   var txId = data.txid ? data.txid : data.txId;
-  if (!txId || !JSUtil.isHexaString(txId) || txId.length > 64) {
+  if (!txId || !JSUtil.isHexaOrEmptyString(txId) || txId.length > 64) {
     // TODO: Use the errors library
     throw new Error('Invalid TXID in object', data);
   }

--- a/packages/bitcore-lib-cash/lib/util/js.js
+++ b/packages/bitcore-lib-cash/lib/util/js.js
@@ -5,15 +5,15 @@ var _ = require('lodash');
 /**
  * Determines whether a string contains only hexadecimal values
  *
- * @name JSUtil.isHexa
+ * @name JSUtil.isHexaOrEmpty
  * @param {string} value
- * @return {boolean} true if the string is the hexa representation of a number
+ * @return {boolean} true if the string is the hexa representation of a number or is empty
  */
-var isHexa = function isHexa(value) {
+var isHexaOrEmpty = function isHexaOrEmpty(value) {
   if (!_.isString(value)) {
     return false;
   }
-  return /^[0-9a-fA-F]+$/.test(value);
+  return /^[0-9a-fA-F]+$/.test(value) || ('' === value);
 };
 
 /**
@@ -42,8 +42,8 @@ module.exports = {
     }
     return false;
   },
-  isHexa: isHexa,
-  isHexaString: isHexa,
+  isHexaOrEmpty: isHexaOrEmpty,
+  isHexaOrEmptyString: isHexaOrEmpty,
 
   /**
    * Clone an array

--- a/packages/bitcore-lib-cash/test/crypto/signature.js
+++ b/packages/bitcore-lib-cash/test/crypto/signature.js
@@ -255,7 +255,7 @@ describe('Signature', function() {
       var test_sigs = function(set, expected) {
         var i = 0;
         set.forEach(function(vector) {
-          if (!JSUtil.isHexa(vector)) {
+          if (!JSUtil.isHexaOrEmpty(vector)) {
             // non-hex strings are ignored
             return;
           }

--- a/packages/bitcore-lib-doge/lib/address.js
+++ b/packages/bitcore-lib-doge/lib/address.js
@@ -388,7 +388,7 @@ Address.fromString = function(str, network, type) {
  */
 Address.fromObject = function fromObject(obj) {
   $.checkState(
-    JSUtil.isHexa(obj.hash),
+    JSUtil.isHexaOrEmpty(obj.hash),
     'Unexpected hash property, "' + obj.hash + '", expected to be hex.'
   );
   var hashBuffer = Buffer.from(obj.hash, 'hex');

--- a/packages/bitcore-lib-doge/lib/hdprivatekey.js
+++ b/packages/bitcore-lib-doge/lib/hdprivatekey.js
@@ -314,7 +314,7 @@ HDPrivateKey.prototype._buildFromObject = function(arg) {
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
     chainCode: _.isString(arg.chainCode) ? BufferUtil.hexToBuffer(arg.chainCode) : arg.chainCode,
-    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? BufferUtil.hexToBuffer(arg.privateKey) : arg.privateKey,
+    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexaOrEmpty(arg.privateKey)) ? BufferUtil.hexToBuffer(arg.privateKey) : arg.privateKey,
     checksum: arg.checksum ? (arg.checksum.length ? arg.checksum : BufferUtil.integerAsBuffer(arg.checksum)) : undefined
   };
   return this._buildFromBuffers(buffers);
@@ -349,7 +349,7 @@ HDPrivateKey.prototype._generateRandomly = function(network) {
  */
 HDPrivateKey.fromSeed = function(hexa, network) {
   /* jshint maxcomplexity: 8 */
-  if (JSUtil.isHexaString(hexa)) {
+  if (JSUtil.isHexaOrEmptyString(hexa)) {
     hexa = BufferUtil.hexToBuffer(hexa);
   }
   if (!Buffer.isBuffer(hexa)) {

--- a/packages/bitcore-lib-doge/lib/privatekey.js
+++ b/packages/bitcore-lib-doge/lib/privatekey.js
@@ -102,7 +102,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.bn = PrivateKey._getRandomBN();
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
-    if (JSUtil.isHexa(data)) {
+    if (JSUtil.isHexaOrEmpty(data)) {
       info.bn = new BN(Buffer.from(data, 'hex'));
     } else {
       info = PrivateKey._transformWIF(data, network);

--- a/packages/bitcore-lib-doge/lib/script/script.js
+++ b/packages/bitcore-lib-doge/lib/script/script.js
@@ -176,7 +176,7 @@ Script.fromHex = function(str) {
 };
 
 Script.fromString = function(str) {
-  if (JSUtil.isHexa(str) || str.length === 0) {
+  if (JSUtil.isHexaOrEmpty(str) || str.length === 0) {
     return new Script(Buffer.from(str, 'hex'));
   }
   var script = new Script();

--- a/packages/bitcore-lib-doge/lib/transaction/input/input.js
+++ b/packages/bitcore-lib-doge/lib/transaction/input/input.js
@@ -60,7 +60,7 @@ Input.fromObject = function(obj) {
 
 Input.prototype._fromObject = function(params) {
   var prevTxId;
-  if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
+  if (_.isString(params.prevTxId) && JSUtil.isHexaOrEmpty(params.prevTxId)) {
     prevTxId = Buffer.from(params.prevTxId, 'hex');
   } else {
     prevTxId = params.prevTxId;
@@ -126,7 +126,7 @@ Input.prototype.setScript = function(script) {
     this._script = script;
     this._script._isInput = true;
     this._scriptBuffer = script.toBuffer();
-  } else if (JSUtil.isHexa(script)) {
+  } else if (JSUtil.isHexaOrEmpty(script)) {
     // hex string script
     this._scriptBuffer = Buffer.from(script, 'hex');
   } else if (_.isString(script)) {

--- a/packages/bitcore-lib-doge/lib/transaction/output.js
+++ b/packages/bitcore-lib-doge/lib/transaction/output.js
@@ -22,7 +22,7 @@ function Output(args) {
       this._scriptBuffer = args.script;
     } else {
       var script;
-      if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
+      if (_.isString(args.script) && JSUtil.isHexaOrEmpty(args.script)) {
         script = new buffer.Buffer(args.script, 'hex');
       } else {
         script = args.script;

--- a/packages/bitcore-lib-doge/lib/transaction/signature.js
+++ b/packages/bitcore-lib-doge/lib/transaction/signature.js
@@ -54,9 +54,9 @@ TransactionSignature.prototype._checkObjectArgs = function(arg) {
   $.checkArgument(arg.prevTxId, 'prevTxId');
   $.checkState(arg.signature instanceof Signature ||
                BufferUtil.isBuffer(arg.signature) ||
-               JSUtil.isHexa(arg.signature), 'signature must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.signature), 'signature must be a buffer or hexa value');
   $.checkState(BufferUtil.isBuffer(arg.prevTxId) ||
-               JSUtil.isHexa(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
   $.checkArgument(arg.sigtype, 'sigtype');
   $.checkState(_.isNumber(arg.sigtype), 'sigtype must be a number');
 };

--- a/packages/bitcore-lib-doge/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-doge/lib/transaction/transaction.js
@@ -46,7 +46,7 @@ function Transaction(serialized, opts) {
   if (serialized) {
     if (serialized instanceof Transaction) {
       return Transaction.shallowCopy(serialized);
-    } else if (JSUtil.isHexa(serialized)) {
+    } else if (JSUtil.isHexaOrEmpty(serialized)) {
       this.fromString(serialized);
     } else if (BufferUtil.isBuffer(serialized)) {
       this.fromBuffer(serialized);

--- a/packages/bitcore-lib-doge/lib/transaction/unspentoutput.js
+++ b/packages/bitcore-lib-doge/lib/transaction/unspentoutput.js
@@ -33,7 +33,7 @@ function UnspentOutput(data) {
   $.checkArgument(_.isObject(data), 'Must provide an object from where to extract data');
   var address = data.address ? new Address(data.address) : undefined;
   var txId = data.txid ? data.txid : data.txId;
-  if (!txId || !JSUtil.isHexaString(txId) || txId.length > 64) {
+  if (!txId || !JSUtil.isHexaOrEmptyString(txId) || txId.length > 64) {
     // TODO: Use the errors library
     throw new Error('Invalid TXID in object', data);
   }

--- a/packages/bitcore-lib-doge/lib/util/buffer.js
+++ b/packages/bitcore-lib-doge/lib/util/buffer.js
@@ -164,7 +164,7 @@ module.exports = {
    * @return {Buffer}
    */
   hexToBuffer: function hexToBuffer(string) {
-    assert(js.isHexa(string));
+    assert(js.isHexaOrEmpty(string));
     return new buffer.Buffer(string, 'hex');
   }
 };

--- a/packages/bitcore-lib-doge/lib/util/js.js
+++ b/packages/bitcore-lib-doge/lib/util/js.js
@@ -5,15 +5,15 @@ var _ = require('lodash');
 /**
  * Determines whether a string contains only hexadecimal values
  *
- * @name JSUtil.isHexa
+ * @name JSUtil.isHexaOrEmpty
  * @param {string} value
- * @return {boolean} true if the string is the hexa representation of a number
+ * @return {boolean} true if the string is the hexa representation of a number or is empty
  */
-var isHexa = function isHexa(value) {
+var isHexaOrEmpty = function isHexaOrEmpty(value) {
   if (!_.isString(value)) {
     return false;
   }
-  return /^[0-9a-fA-F]+$/.test(value);
+  return /^[0-9a-fA-F]+$/.test(value) || ('' === value);
 };
 
 /**
@@ -42,8 +42,8 @@ module.exports = {
     }
     return false;
   },
-  isHexa: isHexa,
-  isHexaString: isHexa,
+  isHexaOrEmpty: isHexaOrEmpty,
+  isHexaOrEmptyString: isHexaOrEmpty,
 
   /**
    * Clone an array

--- a/packages/bitcore-lib-doge/test/crypto/signature.js
+++ b/packages/bitcore-lib-doge/test/crypto/signature.js
@@ -255,7 +255,7 @@ describe('Signature', function() {
       var test_sigs = function(set, expected) {
         var i = 0;
         set.forEach(function(vector) {
-          if (!JSUtil.isHexa(vector)) {
+          if (!JSUtil.isHexaOrEmpty(vector)) {
             // non-hex strings are ignored
             return;
           }

--- a/packages/bitcore-lib-ltc/lib/address.js
+++ b/packages/bitcore-lib-ltc/lib/address.js
@@ -491,7 +491,7 @@ Address.fromString = function(str, network, type) {
  */
 Address.fromObject = function fromObject(obj) {
   $.checkState(
-    JSUtil.isHexa(obj.hash),
+    JSUtil.isHexaOrEmpty(obj.hash),
     'Unexpected hash property, "' + obj.hash + '", expected to be hex.'
   );
   var hashBuffer = Buffer.from(obj.hash, 'hex');

--- a/packages/bitcore-lib-ltc/lib/hdprivatekey.js
+++ b/packages/bitcore-lib-ltc/lib/hdprivatekey.js
@@ -339,7 +339,7 @@ HDPrivateKey.prototype._buildFromObject = function(arg) {
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
     chainCode: _.isString(arg.chainCode) ? Buffer.from(arg.chainCode,'hex') : arg.chainCode,
-    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
+    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexaOrEmpty(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
     checksum: arg.checksum ? (arg.checksum.length ? arg.checksum : BufferUtil.integerAsBuffer(arg.checksum)) : undefined
   };
   return this._buildFromBuffers(buffers);
@@ -374,7 +374,7 @@ HDPrivateKey.prototype._generateRandomly = function(network) {
  */
 HDPrivateKey.fromSeed = function(hexa, network) {
   /* jshint maxcomplexity: 8 */
-  if (JSUtil.isHexaString(hexa)) {
+  if (JSUtil.isHexaOrEmptyString(hexa)) {
     hexa = Buffer.from(hexa, 'hex');
   }
   if (!Buffer.isBuffer(hexa)) {

--- a/packages/bitcore-lib-ltc/lib/privatekey.js
+++ b/packages/bitcore-lib-ltc/lib/privatekey.js
@@ -102,7 +102,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.bn = PrivateKey._getRandomBN();
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
-    if (JSUtil.isHexa(data)) {
+    if (JSUtil.isHexaOrEmpty(data)) {
       info.bn = new BN(Buffer.from(data, 'hex'));
     } else {
       info = PrivateKey._transformWIF(data, network);

--- a/packages/bitcore-lib-ltc/lib/script/script.js
+++ b/packages/bitcore-lib-ltc/lib/script/script.js
@@ -175,7 +175,7 @@ Script.fromHex = function(str) {
 };
 
 Script.fromString = function(str) {
-  if (JSUtil.isHexa(str) || str.length === 0) {
+  if (JSUtil.isHexaOrEmpty(str) || str.length === 0) {
     return new Script(Buffer.from(str, 'hex'));
   }
   var script = new Script();

--- a/packages/bitcore-lib-ltc/lib/transaction/input/input.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/input/input.js
@@ -59,7 +59,7 @@ Input.fromObject = function(obj) {
 
 Input.prototype._fromObject = function(params) {
   var prevTxId;
-  if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
+  if (_.isString(params.prevTxId) && JSUtil.isHexaOrEmpty(params.prevTxId)) {
     prevTxId = Buffer.from(params.prevTxId, 'hex');
   } else {
     prevTxId = params.prevTxId;
@@ -130,7 +130,7 @@ Input.prototype.setScript = function(script) {
     this._script = script;
     this._script._isInput = true;
     this._scriptBuffer = script.toBuffer();
-  } else if (JSUtil.isHexa(script)) {
+  } else if (JSUtil.isHexaOrEmpty(script)) {
     // hex string script
     this._scriptBuffer = Buffer.from(script, 'hex');
   } else if (_.isString(script)) {

--- a/packages/bitcore-lib-ltc/lib/transaction/output.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/output.js
@@ -21,7 +21,7 @@ function Output(args) {
       this._scriptBuffer = args.script;
     } else {
       var script;
-      if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
+      if (_.isString(args.script) && JSUtil.isHexaOrEmpty(args.script)) {
         script = Buffer.from(args.script, 'hex');
       } else {
         script = args.script;

--- a/packages/bitcore-lib-ltc/lib/transaction/signature.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/signature.js
@@ -54,9 +54,9 @@ TransactionSignature.prototype._checkObjectArgs = function(arg) {
   $.checkArgument(arg.prevTxId, 'prevTxId');
   $.checkState(arg.signature instanceof Signature ||
                BufferUtil.isBuffer(arg.signature) ||
-               JSUtil.isHexa(arg.signature), 'signature must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.signature), 'signature must be a buffer or hexa value');
   $.checkState(BufferUtil.isBuffer(arg.prevTxId) ||
-               JSUtil.isHexa(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
   $.checkArgument(arg.sigtype, 'sigtype');
   $.checkState(_.isNumber(arg.sigtype), 'sigtype must be a number');
 };

--- a/packages/bitcore-lib-ltc/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/transaction.js
@@ -45,7 +45,7 @@ function Transaction(serialized, opts) {
   if (serialized) {
     if (serialized instanceof Transaction) {
       return Transaction.shallowCopy(serialized);
-    } else if (JSUtil.isHexa(serialized)) {
+    } else if (JSUtil.isHexaOrEmpty(serialized)) {
       this.fromString(serialized);
     } else if (BufferUtil.isBuffer(serialized)) {
       this.fromBuffer(serialized);

--- a/packages/bitcore-lib-ltc/lib/transaction/unspentoutput.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/unspentoutput.js
@@ -33,7 +33,7 @@ function UnspentOutput(data) {
   $.checkArgument(_.isObject(data), 'Must provide an object from where to extract data');
   var address = data.address ? new Address(data.address) : undefined;
   var txId = data.txid ? data.txid : data.txId;
-  if (!txId || !JSUtil.isHexaString(txId) || txId.length > 64) {
+  if (!txId || !JSUtil.isHexaOrEmptyString(txId) || txId.length > 64) {
     // TODO: Use the errors library
     throw new Error('Invalid TXID in object', data);
   }

--- a/packages/bitcore-lib-ltc/lib/util/buffer.js
+++ b/packages/bitcore-lib-ltc/lib/util/buffer.js
@@ -163,7 +163,7 @@ module.exports = {
    * @return {Buffer}
    */
   hexToBuffer: function hexToBuffer(string) {
-    assert(js.isHexa(string));
+    assert(js.isHexaOrEmpty(string));
     return Buffer.from(string, 'hex');
   }
 };

--- a/packages/bitcore-lib-ltc/lib/util/js.js
+++ b/packages/bitcore-lib-ltc/lib/util/js.js
@@ -5,15 +5,15 @@ var _ = require('lodash');
 /**
  * Determines whether a string contains only hexadecimal values
  *
- * @name JSUtil.isHexa
+ * @name JSUtil.isHexaOrEmpty
  * @param {string} value
- * @return {boolean} true if the string is the hexa representation of a number
+ * @return {boolean} true if the string is the hexa representation of a number or is empty
  */
-var isHexa = function isHexa(value) {
+var isHexaOrEmpty = function isHexaOrEmpty(value) {
   if (!_.isString(value)) {
     return false;
   }
-  return /^[0-9a-fA-F]+$/.test(value);
+  return /^[0-9a-fA-F]+$/.test(value) || ('' === value);
 };
 
 /**
@@ -42,8 +42,8 @@ module.exports = {
     }
     return false;
   },
-  isHexa: isHexa,
-  isHexaString: isHexa,
+  isHexaOrEmpty: isHexaOrEmpty,
+  isHexaOrEmptyString: isHexaOrEmpty,
 
   /**
    * Clone an array

--- a/packages/bitcore-lib-ltc/test/crypto/signature.js
+++ b/packages/bitcore-lib-ltc/test/crypto/signature.js
@@ -255,7 +255,7 @@ describe('Signature', function() {
       var test_sigs = function(set, expected) {
         var i = 0;
         set.forEach(function(vector) {
-          if (!JSUtil.isHexa(vector)) {
+          if (!JSUtil.isHexaOrEmpty(vector)) {
             // non-hex strings are ignored
             return;
           }

--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -491,7 +491,7 @@ Address.fromString = function(str, network, type) {
  */
 Address.fromObject = function fromObject(obj) {
   $.checkState(
-    JSUtil.isHexa(obj.hash),
+    JSUtil.isHexaOrEmpty(obj.hash),
     'Unexpected hash property, "' + obj.hash + '", expected to be hex.'
   );
   var hashBuffer = Buffer.from(obj.hash, 'hex');

--- a/packages/bitcore-lib/lib/hdprivatekey.js
+++ b/packages/bitcore-lib/lib/hdprivatekey.js
@@ -370,7 +370,7 @@ HDPrivateKey.prototype._buildFromObject = function(arg) {
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
     chainCode: _.isString(arg.chainCode) ? Buffer.from(arg.chainCode,'hex') : arg.chainCode,
-    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
+    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexaOrEmpty(arg.privateKey)) ? Buffer.from(arg.privateKey,'hex') : arg.privateKey,
     checksum: arg.checksum ? (arg.checksum.length ? arg.checksum : BufferUtil.integerAsBuffer(arg.checksum)) : undefined
   };
   return this._buildFromBuffers(buffers);
@@ -405,7 +405,7 @@ HDPrivateKey.prototype._generateRandomly = function(network) {
  */
 HDPrivateKey.fromSeed = function(hexa, network) {
   /* jshint maxcomplexity: 8 */
-  if (JSUtil.isHexaString(hexa)) {
+  if (JSUtil.isHexaOrEmptyString(hexa)) {
     hexa = Buffer.from(hexa, 'hex');
   }
   if (!Buffer.isBuffer(hexa)) {

--- a/packages/bitcore-lib/lib/privatekey.js
+++ b/packages/bitcore-lib/lib/privatekey.js
@@ -102,7 +102,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.bn = PrivateKey._getRandomBN();
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
-    if (JSUtil.isHexa(data)) {
+    if (JSUtil.isHexaOrEmpty(data)) {
       info.bn = new BN(Buffer.from(data, 'hex'));
     } else {
       info = PrivateKey._transformWIF(data, network);

--- a/packages/bitcore-lib/lib/script/script.js
+++ b/packages/bitcore-lib/lib/script/script.js
@@ -176,7 +176,7 @@ Script.fromHex = function(str) {
 };
 
 Script.fromString = function(str) {
-  if (JSUtil.isHexa(str) || str.length === 0) {
+  if (JSUtil.isHexaOrEmpty(str) || str.length === 0) {
     return new Script(Buffer.from(str, 'hex'));
   }
   var script = new Script();

--- a/packages/bitcore-lib/lib/transaction/input/input.js
+++ b/packages/bitcore-lib/lib/transaction/input/input.js
@@ -60,7 +60,7 @@ Input.fromObject = function(obj) {
 
 Input.prototype._fromObject = function(params) {
   var prevTxId;
-  if (_.isString(params.prevTxId) && JSUtil.isHexa(params.prevTxId)) {
+  if (_.isString(params.prevTxId) && JSUtil.isHexaOrEmpty(params.prevTxId)) {
     prevTxId = Buffer.from(params.prevTxId, 'hex');
   } else {
     prevTxId = params.prevTxId;
@@ -126,7 +126,7 @@ Input.prototype.setScript = function(script) {
     this._script = script;
     this._script._isInput = true;
     this._scriptBuffer = script.toBuffer();
-  } else if (JSUtil.isHexa(script)) {
+  } else if (JSUtil.isHexaOrEmpty(script)) {
     // hex string script
     this._scriptBuffer = Buffer.from(script, 'hex');
   } else if (_.isString(script)) {

--- a/packages/bitcore-lib/lib/transaction/output.js
+++ b/packages/bitcore-lib/lib/transaction/output.js
@@ -22,7 +22,7 @@ function Output(args) {
       this._scriptBuffer = args.script;
     } else {
       var script;
-      if (_.isString(args.script) && JSUtil.isHexa(args.script)) {
+      if (_.isString(args.script) && JSUtil.isHexaOrEmpty(args.script)) {
         script = Buffer.from(args.script, 'hex');
       } else {
         script = args.script;

--- a/packages/bitcore-lib/lib/transaction/signature.js
+++ b/packages/bitcore-lib/lib/transaction/signature.js
@@ -54,9 +54,9 @@ TransactionSignature.prototype._checkObjectArgs = function(arg) {
   $.checkArgument(arg.prevTxId, 'prevTxId');
   $.checkState(arg.signature instanceof Signature ||
                BufferUtil.isBuffer(arg.signature) ||
-               JSUtil.isHexa(arg.signature), 'signature must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.signature), 'signature must be a buffer or hexa value');
   $.checkState(BufferUtil.isBuffer(arg.prevTxId) ||
-               JSUtil.isHexa(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
+               JSUtil.isHexaOrEmpty(arg.prevTxId), 'prevTxId must be a buffer or hexa value');
   $.checkArgument(arg.sigtype, 'sigtype');
   $.checkState(_.isNumber(arg.sigtype), 'sigtype must be a number');
 };

--- a/packages/bitcore-lib/lib/transaction/transaction.js
+++ b/packages/bitcore-lib/lib/transaction/transaction.js
@@ -45,7 +45,7 @@ function Transaction(serialized, opts) {
   if (serialized) {
     if (serialized instanceof Transaction) {
       return Transaction.shallowCopy(serialized);
-    } else if (JSUtil.isHexa(serialized)) {
+    } else if (JSUtil.isHexaOrEmpty(serialized)) {
       this.fromString(serialized);
     } else if (BufferUtil.isBuffer(serialized)) {
       this.fromBuffer(serialized);

--- a/packages/bitcore-lib/lib/transaction/unspentoutput.js
+++ b/packages/bitcore-lib/lib/transaction/unspentoutput.js
@@ -33,7 +33,7 @@ function UnspentOutput(data) {
   $.checkArgument(_.isObject(data), 'Must provide an object from where to extract data');
   var address = data.address ? new Address(data.address) : undefined;
   var txId = data.txid ? data.txid : data.txId;
-  if (!txId || !JSUtil.isHexaString(txId) || txId.length > 64) {
+  if (!txId || !JSUtil.isHexaOrEmptyString(txId) || txId.length > 64) {
     // TODO: Use the errors library
     throw new Error('Invalid TXID in object', data);
   }

--- a/packages/bitcore-lib/lib/util/js.js
+++ b/packages/bitcore-lib/lib/util/js.js
@@ -5,15 +5,15 @@ var _ = require('lodash');
 /**
  * Determines whether a string contains only hexadecimal values
  *
- * @name JSUtil.isHexa
+ * @name JSUtil.isHexaOrEmpty
  * @param {string} value
- * @return {boolean} true if the string is the hexa representation of a number
+ * @return {boolean} true if the string is the hexa representation of a number or is empty
  */
-var isHexa = function isHexa(value) {
+var isHexaOrEmpty = function isHexaOrEmpty(value) {
   if (!_.isString(value)) {
     return false;
   }
-  return /^[0-9a-fA-F]+$/.test(value);
+  return /^[0-9a-fA-F]+$/.test(value) || ('' === value);
 };
 
 /**
@@ -42,8 +42,8 @@ module.exports = {
     }
     return false;
   },
-  isHexa: isHexa,
-  isHexaString: isHexa,
+  isHexaOrEmpty: isHexaOrEmpty,
+  isHexaOrEmptyString: isHexaOrEmpty,
 
   /**
    * Clone an array

--- a/packages/bitcore-lib/test/crypto/signature.js
+++ b/packages/bitcore-lib/test/crypto/signature.js
@@ -255,7 +255,7 @@ describe('Signature', function() {
       var test_sigs = function(set, expected) {
         var i = 0;
         set.forEach(function(vector) {
-          if (!JSUtil.isHexa(vector)) {
+          if (!JSUtil.isHexaOrEmpty(vector)) {
             // non-hex strings are ignored
             return;
           }


### PR DESCRIPTION
So it's possible to

```
bitcore.crypto.Hash.sha256 (bitcore.util.buffer.hexToBuffer('')).toString ('hex');
```

that correctly produce
"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

instead of an assertion error.

This small change is quite invasive anyway, so I think that before being merged, it must be well tested.