### PR TITLE
hexToBuffer accept empty string

### DIFF
--- a/packages/bitcore-lib-ltc/lib/util/buffer.js
+++ b/packages/bitcore-lib-ltc/lib/util/buffer.js
@@ -163,7 +163,7 @@ module.exports = {
    * @return {Buffer}
    */
   hexToBuffer: function hexToBuffer(string) {
-    assert(js.isHexa(string));
+    assert(js.isHexa(string) || ('' === string));
     return Buffer.from(string, 'hex');
   }
 };


### PR DESCRIPTION
So it's possible to:
```
bitcore.util.buffer.hexToBuffer('').toString('hex');
```

that produce an empty string as expected,
instead od an assertion error.

This commit makes https://github.com/bitpay/bitcore/pull/3181 unnecessary.