### PR TITLE
use p2sh new M-address instead of deprecated 3-address

### DIFF
--- a/packages/bitcore-lib-ltc/lib/networks.js
+++ b/packages/bitcore-lib-ltc/lib/networks.js
@@ -141,8 +141,8 @@ addNetwork({
   alias: 'mainnet',
   pubkeyhash: 0x30, // 48
   privatekey: 0xb0, // 176
-  scripthash: 0x05, // 5
-  scripthash2: 0x32, // 50
+  scripthash: 0x32, // 50
+  scripthash2: 0x05, // 5
   bech32prefix: 'ltc',
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,


### PR DESCRIPTION
Since 3-address had already deprecated, we should use M-address instead

Ref: https://bitcoin.stackexchange.com/questions/62781/litecoin-constants-and-prefixes