### PR TITLE
Update blockchainexplorer default urls

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -8,12 +8,12 @@ const Defaults = Common.Defaults;
 const PROVIDERS = {
   v8: {
     btc: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     bch: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     eth: {
       livenet: 'https://api-eth.bitcore.io',
@@ -24,12 +24,12 @@ const PROVIDERS = {
       testnet: 'https://api-xrp.bitcore.io'
     },
     doge: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     ltc: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     }
   }
 };


### PR DESCRIPTION
"api.bitpay.com" doesn't exist

https://www.nslookup.io/dns-records/api.bitpay.com