### PR TITLE
Exclude invalid transactions from Wallet.listTransactions

### DIFF
--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -311,7 +311,8 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
       chain,
       network,
       wallets: wallet._id,
-      'wallets.0': { $exists: true }
+      'wallets.0': { $exists: true },
+      blockHeight: { $gt: -3 } // Exclude invalid transactions
     } as any;
     if (args) {
       if (args.startBlock || args.endBlock) {
@@ -342,6 +343,7 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
           }
         }
       }
+      if (args.includeInvalidTxs) delete query.blockHeight;
     }
     return query;
   }


### PR DESCRIPTION
Excludes transactions that have been invalidated from the Wallet.listTransactions query by default.

https://github.com/bitpay/bitcore/blob/master/packages/bitcore-node/src/types/Coin.ts#L43
https://github.com/bitpay/bitcore/blob/master/packages/bitcore-node/src/services/pruning.ts#L152-L166