### PR TITLE
Support ETH node pools

### DIFF
--- a/bitcore-test.config.json
+++ b/bitcore-test.config.json
@@ -33,7 +33,7 @@
             {
               "host": "parity",
               "protocol": "ws",
-              "port": 30303
+              "port": 8546
             }
           ],
           "provider": {

--- a/bitcore-test.config.json
+++ b/bitcore-test.config.json
@@ -32,6 +32,7 @@
           "trustedPeers": [
             {
               "host": "parity",
+              "protocol": "ws",
               "port": 30303
             }
           ],

--- a/packages/bitcore-node/src/models/baseBlock.ts
+++ b/packages/bitcore-node/src/models/baseBlock.ts
@@ -1,5 +1,4 @@
 import { StorageService } from '../services/storage';
-import { IBlock } from '../types/Block';
 import { ChainNetwork } from '../types/ChainNetwork';
 import { TransformOptions } from '../types/TransformOptions';
 import { BaseModel, MongoBound } from './base';

--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -62,7 +62,7 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
     this.config = Config.chains[this.chain];
   }
 
-  async getWeb3(network: string): Promise<{ rpc: CryptoRpc; web3: Web3 }> {
+  async getWeb3(network: string): Promise<{ rpc: CryptoRpc; web3: Web3; pool: EthPool }> {
     if (ETHStateProvider.rpcs[network]) {
       try {
         await ETHStateProvider.rpcs[network].getWeb3().eth.getBlockNumber();
@@ -73,10 +73,11 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
       console.log('making a new connection');
       ETHStateProvider.rpcs[network] = new EthPool(this.chain, network, this.config);
     }
-    const rpc: CryptoRpc = ETHStateProvider.rpcs[network].getRpc();
+    const pool: EthPool = ETHStateProvider.rpcs[network];
     return {
-      rpc,
-      web3: rpc.web3
+      rpc: pool.getRpc(),
+      web3: pool.getWeb3(),
+      pool
     };
   }
 

--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -63,14 +63,13 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
   }
 
   async getWeb3(network: string): Promise<{ rpc: CryptoRpc; web3: Web3 }> {
-    try {
-      if (ETHStateProvider.rpcs[network]) {
+    if (ETHStateProvider.rpcs[network]) {
+      try {
         await ETHStateProvider.rpcs[network].getWeb3().eth.getBlockNumber();
+      } catch (e) {
+        ETHStateProvider.rpcs[network].checkConnections();
       }
-    } catch (e) {
-      ETHStateProvider.rpcs[network].checkConnections();
-    }
-    if (!ETHStateProvider.rpcs[network]) {
+    } else {
       console.log('making a new connection');
       ETHStateProvider.rpcs[network] = new EthPool(this.chain, network, this.config);
     }

--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -74,7 +74,11 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
       console.log('making a new connection');
       ETHStateProvider.rpcs[network] = new EthPool(this.chain, network, this.config);
     }
-    return ETHStateProvider.rpcs[network].getRpc();
+    const rpc: CryptoRpc = ETHStateProvider.rpcs[network].getRpc();
+    return {
+      rpc,
+      web3: rpc.web3
+    };
   }
 
   async erc20For(network: string, address: string) {

--- a/packages/bitcore-node/src/modules/ethereum/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/csp.ts
@@ -63,13 +63,7 @@ export class ETHStateProvider extends InternalStateProvider implements IChainSta
   }
 
   async getWeb3(network: string): Promise<{ rpc: CryptoRpc; web3: Web3; pool: EthPool }> {
-    if (ETHStateProvider.rpcs[network]) {
-      try {
-        await ETHStateProvider.rpcs[network].getWeb3().eth.getBlockNumber();
-      } catch (e) {
-        ETHStateProvider.rpcs[network].checkConnections();
-      }
-    } else {
+    if (!ETHStateProvider.rpcs[network]) {
       console.log('making a new connection');
       ETHStateProvider.rpcs[network] = new EthPool(this.chain, network, this.config);
     }

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
@@ -33,14 +33,14 @@ export class EthPool {
    * Creates array of CryptoRpc providers from config values
    */
   protected _setupRpcs = (): void => {
-    const { trustedPeers } = this.config[this.network];
-    const baseRpcConfig = { chain: this.chain, currencyConfig: {} };
-    const rpc = new CryptoRpc(_.merge(baseRpcConfig, this.config[this.network].provider), {}).get(this.chain);
-
     this.disconnectListeners(); // Disconnect any active listeners
     this.providers = []; // Clear existing providers
-    this.providers.push(rpc);
 
+    const { trustedPeers, provider } = this.config[this.network];
+    const baseRpcConfig = { chain: this.chain, currencyConfig: {} };
+    const rpc = new CryptoRpc(_.merge(baseRpcConfig, provider), {}).get(this.chain);
+
+    this.providers.push(rpc);
     if (trustedPeers && trustedPeers.length > 0)
       this.providers = this.providers.concat(
         trustedPeers.map(peer => new CryptoRpc(_.merge(baseRpcConfig, peer)).get(this.chain))

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
@@ -68,6 +68,13 @@ export class EthPool {
   };
 
   /**
+   * Gets the array of CryptoRPC providers in the Eth Pool
+   *
+   * @returns {Array<CryptoRpc>} Array of CryptoRPC providers
+   */
+  getRpcs = (): Array<CryptoRpc> => this.providers;
+
+  /**
    * Gets an instance of web3 from a random CryptoRpc provider
    *
    * @returns {Web3} An instance of web3

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
@@ -1,0 +1,76 @@
+import { CryptoRpc } from 'crypto-rpc';
+import _ from 'lodash';
+import Web3 from 'web3';
+import logger from '../../../logger';
+
+/**
+ * Pool of ETH CryptoRpcs used to distribute load among utilized RPC endpoints
+ */
+export class EthPool {
+  protected config: any;
+  protected chain: string;
+  protected network: string;
+  protected providers: Array<CryptoRpc> = [];
+
+  /**
+   * @constructor
+   *
+   * @param chain Chain of the Crypto Rpcs
+   * @param network Network of the Crypto Rpcs
+   * @param config Config with main provider and trusted peers
+   */
+  constructor(chain = 'ETH', network: string, config: any) {
+    this.chain = chain;
+    this.network = network;
+    this.config = config || {};
+    this._setupRpcs();
+  }
+
+  /**
+   * Creates array of CryptoRpc providers from config values
+   */
+  protected _setupRpcs = (): void => {
+    const { trustedPeers } = this.config[this.network];
+    const baseRpcConfig = { chain: this.chain, currencyConfig: {} };
+    const rpc = new CryptoRpc(_.merge(baseRpcConfig, this.config[this.network].provider), {}).get(this.chain);
+
+    this.providers = []; // Clear existing providers, if any
+    this.providers.push(rpc);
+
+    if (trustedPeers && trustedPeers.length > 0)
+      this.providers = this.providers.concat(
+        _.map(trustedPeers, peer => new CryptoRpc(_.merge(baseRpcConfig, peer)).get(this.chain))
+      );
+
+    logger.info(`Set up ${this.providers.length} peers in ETH pool`);
+  };
+
+  /**
+   * Checks for disconnected web3 instances in the providers array
+   */
+  checkConnections = (): void => {
+    const disconnected = _.filter(this.providers, provider => !(provider && provider.web3.eth.net.isListening()));
+
+    if (disconnected.length > 0) {
+      logger.info(`Found ${disconnected.length} disconnected ${this.chain} ${this.network} RPCs, reconnecting...`);
+      this._setupRpcs();
+    }
+  };
+
+  /**
+   * Checks existing connection statuses and gets a random RPC from the providers array
+   *
+   * @returns {CryptoRpc} A CryptoRPC object from the providers array
+   */
+  getRpc = (): CryptoRpc => {
+    this.checkConnections();
+    return _.shuffle(this.providers)[0];
+  };
+
+  /**
+   * Gets an instance of web3 from a random CryptoRpc provider
+   *
+   * @returns {Web3} An instance of web3
+   */
+  getWeb3 = (): Web3 => this.getRpc().web3;
+}

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
@@ -55,7 +55,11 @@ export class EthPool {
   checkConnections = async (reconnect: boolean = true): Promise<boolean> => {
     const disconnected: CryptoRpc[] = [];
     for (const provider of this.providers)
-      if (!(provider && (await provider.web3.eth.net.isListening()))) disconnected.push(provider);
+      try {
+        if (!(provider && (await provider.web3.eth.net.isListening()))) disconnected.push(provider);
+      } catch (e) {
+        disconnected.push(e);
+      }
 
     if (disconnected.length > 0) {
       logger.warn(
@@ -78,7 +82,7 @@ export class EthPool {
     for (const provider of this.providers) {
       this.subscriptions.push(await provider.web3.eth.subscribe(event));
       this.subscriptions[this.subscriptions.length - 1].subscribe((err, res) => {
-        if (err) cb(err);
+        if (err) return cb(err);
 
         const eventStore = getEventStore();
         const isSimilar = (event, _res) =>

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthPool.ts
@@ -48,8 +48,11 @@ export class EthPool {
   /**
    * Checks for disconnected web3 instances in the providers array
    */
-  checkConnections = (): void => {
-    const disconnected = _.filter(this.providers, provider => !(provider && provider.web3.eth.net.isListening()));
+  checkConnections = async (): Promise<void> => {
+    const disconnected: CryptoRpc[] = [];
+    for (const provider of this.providers)
+      if (!(provider && await provider.web3.eth.net.isListening()))
+        disconnected.push(provider);
 
     if (disconnected.length > 0) {
       logger.info(`Found ${disconnected.length} disconnected ${this.chain} ${this.network} RPCs, reconnecting...`);
@@ -70,9 +73,9 @@ export class EthPool {
   /**
    * Gets the array of CryptoRPC providers in the Eth Pool
    *
-   * @returns {Array<CryptoRpc>} Array of CryptoRPC providers
+   * @returns {Array<CryptoRpc>} Shuffled array of CryptoRPC providers
    */
-  getRpcs = (): Array<CryptoRpc> => this.providers;
+  getRpcs = (): Array<CryptoRpc> => _.shuffle(this.providers);
 
   /**
    * Gets an instance of web3 from a random CryptoRpc provider

--- a/packages/bitcore-node/src/modules/ethereum/p2p/EthVerificationPeer.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/EthVerificationPeer.ts
@@ -19,12 +19,10 @@ export class EthVerificationPeer extends EthP2pWorker implements IVerificationPe
   }
 
   async setupListeners() {
-    this.txSubscription = await this.web3!.eth.subscribe('pendingTransactions');
-    this.txSubscription.subscribe((_err, tx) => {
+    await this.pool!.setupListeners('pendingTransactions', (_err, tx) => {
       this.events.emit('transaction', tx);
     });
-    this.blockSubscription = await this.web3!.eth.subscribe('newBlockHeaders');
-    this.blockSubscription.subscribe((_err, block) => {
+    await this.pool!.setupListeners('newBlockHeaders', (_err, block) => {
       this.events.emit('block', block);
     });
   }

--- a/packages/bitcore-node/src/modules/ethereum/p2p/p2p.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/p2p.ts
@@ -151,7 +151,7 @@ export class EthP2pWorker extends BaseP2PWorker<IEthBlock> {
   }
 
   async connect() {
-    this.handleReconnects();
+    await this.handleReconnects();
   }
 
   public async getBlock(height: number) {

--- a/packages/bitcore-node/src/modules/ethereum/p2p/parityRpc.ts
+++ b/packages/bitcore-node/src/modules/ethereum/p2p/parityRpc.ts
@@ -1,10 +1,10 @@
 import AbiDecoder from 'abi-decoder';
-import Web3 from 'web3';
 import { LoggifyClass } from '../../../decorators/Loggify';
 import { ERC20Abi } from '../abi/erc20';
 import { ERC721Abi } from '../abi/erc721';
 import { EthTransactionStorage } from '../models/transaction';
 import { IEthTransaction } from '../types';
+import { EthPool } from './EthPool';
 
 AbiDecoder.addABI(ERC20Abi);
 AbiDecoder.addABI(ERC721Abi);
@@ -65,20 +65,20 @@ interface JsonRPCResponse {
 
 @LoggifyClass
 export class ParityRPC {
-  web3: Web3;
+  pool: EthPool;
 
-  constructor(web3: Web3) {
-    this.web3 = web3;
+  constructor(pool: EthPool) {
+    this.pool = pool;
   }
 
   public getBlock(blockNumber: number) {
-    return this.web3.eth.getBlock(blockNumber, true);
+    return this.pool.getWeb3().eth.getBlock(blockNumber, true);
   }
 
   private async traceBlock(blockNumber: number) {
     const txs = await this.send<Array<ParityTraceResponse>>({
       method: 'trace_block',
-      params: [this.web3.utils.toHex(blockNumber)],
+      params: [this.pool.getWeb3().utils.toHex(blockNumber)],
       jsonrpc: '2.0',
       id: 1
     });
@@ -92,7 +92,7 @@ export class ParityRPC {
 
   public send<T>(data: JsonRPCRequest) {
     return new Promise<T>((resolve, reject) => {
-      const provider = this.web3.eth.currentProvider as any; // Import type HttpProvider web3-core
+      const provider = this.pool.getWeb3().eth.currentProvider as any; // Import type HttpProvider web3-core
       provider.send(data, function(err, data) {
         if (err) return reject(err);
         resolve(data.result as T);

--- a/packages/bitcore-node/test/integration/ethereum/p2p.spec.ts
+++ b/packages/bitcore-node/test/integration/ethereum/p2p.spec.ts
@@ -58,15 +58,16 @@ describe('Ethereum', function() {
     await intAfterHelper(suite);
   });
 
-  it('should be able to create a wallet with an address', async () => {
+  it('should be able to create a wallet with an address', async (done) => {
     const wallet = await getWallet();
     const addresses = await wallet.getAddresses();
     expect(addresses).to.exist;
     expect(addresses.length).to.eq(1);
     expect(addresses[0].toLowerCase()).to.equal('0xd8fd14fb0e0848cb931c1e54a73486c4b968be3d');
+    done();
   });
 
-  it('should be able to get block events from parity', async () => {
+  it('should be able to get block events from parity', async (done) => {
     const wallet = await getWallet();
     const addresses = await wallet.getAddresses();
 
@@ -80,9 +81,10 @@ describe('Ethereum', function() {
     await sawBlock;
     await worker.disconnect();
     await worker.stop();
+    done();
   });
 
-  it('should be able to get the balance for the address', async () => {
+  it('should be able to get the balance for the address', async (done) => {
     const wallet = await getWallet();
     const balance = await wallet.getBalance();
     expect(balance.confirmed).to.be.gt(0);
@@ -92,9 +94,10 @@ describe('Ethereum', function() {
     expect(cached).to.exist;
     expect(cached!.value).to.deep.eq(balance);
     await wallet.lock();
+    done();
   });
 
-  it('should update after a send', async () => {
+  it('should update after a send', async (done) => {
     const wallet = await getWallet();
     const addresses = await wallet.getAddresses();
     const beforeBalance = await wallet.getBalance();
@@ -113,9 +116,10 @@ describe('Ethereum', function() {
     expect(afterBalance).to.not.deep.eq(beforeBalance);
     expect(afterBalance.confirmed).to.be.gt(beforeBalance.confirmed);
     await wallet.lock();
+    done();
   });
 
-  it('should have receipts on tx history', async () => {
+  it('should have receipts on tx history', async (done) => {
     const wallet = await getWallet();
     await new Promise(r =>
       wallet
@@ -135,9 +139,10 @@ describe('Ethereum', function() {
     );
 
     await wallet.lock();
+    done();
   });
 
-  it.skip('should be able to save blocks to the database', async () => {
+  it.skip('should be able to save blocks to the database', async (_done) => {
     const wallet = await getWallet();
     const addresses = await wallet.getAddresses();
 
@@ -156,6 +161,7 @@ describe('Ethereum', function() {
     const dbBlocks = await EthBlockStorage.collection.count({ chain, network });
     expect(dbBlocks).to.be.gt(0);
     await wallet.lock();
+    _done();
   });
 
   it('should be able to handle reorgs');

--- a/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
+++ b/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
@@ -2,6 +2,7 @@ import { ObjectId } from 'bson';
 import { expect } from 'chai';
 import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
+import config from '../../../../src/config';
 import { MongoBound } from '../../../../src/models/base';
 import { ETH, ETHStateProvider } from '../../../../src/modules/ethereum/api/csp';
 import { EthPool } from '../../../../src/modules/ethereum/p2p/EthPool';
@@ -12,10 +13,11 @@ describe('ETH Chain State Provider', () => {
   const sandbox = sinon.createSandbox();
   const chain = 'ETH';
   const network = 'testnet';
+  const defaultPoolConfig = config.chains[chain];
 
   beforeEach(() => {
     sandbox.stub(ETHStateProvider, 'rpcs').value({
-      [network]: new EthPool(chain, network, defaultPoolConfig(network))
+      [network]: new EthPool(chain, network, defaultPoolConfig)
     });
   });
 
@@ -30,21 +32,6 @@ describe('ETH Chain State Provider', () => {
         ...web3Stub.eth,
       });
     });
-
-  const defaultPoolConfig = (network) => {
-    const provider = {
-      protocol: 'http',
-      host: 'localhost',
-      port: 8545
-    };
-
-    return {
-      [network]: {
-        trustedPeers: [provider],
-        provider,
-      }
-    };
-  };
 
   // Tests
   it('should be able to get web3', async () => {
@@ -211,7 +198,7 @@ describe('ETH Chain State Provider', () => {
 
     beforeEach(async () => {
       sandbox.stub(ETHStateProvider, 'rpcs').value({
-        [network]: new EthPool(chain, network, defaultPoolConfig(network))
+        [network]: new EthPool(chain, network, defaultPoolConfig)
       });
 
       // Stub all available web3 providers and assign local provider


### PR DESCRIPTION
Adds a class in `bitcore-node`'s ETH module that enables multiple web3 JSON rpc connections per network & cycles through which one is chosen when `getWeb3` is called for loadbalancing between active connections.