### PR TITLE
Lower minimum output amount to dust

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -150,7 +150,7 @@ module.exports = {
   UTXO_SELECTION_MAX_FEE_VS_SINGLE_UTXO_FEE_FACTOR: 5,
 
   // Minimum allowed amount for tx outputs (including change) in SAT
-  MIN_OUTPUT_AMOUNT: 5000,
+  MIN_OUTPUT_AMOUNT: 546,
 
   // Number of confirmations from which tx in history will be cached
   // (ie we consider them inmutables)


### PR DESCRIPTION
At today's rate (~$60k USD/BTC), 546 sats is about 30 cents and 5000 sats is ~$3.10

Need to set the MIN_OUTPUT_AMOUNT to equal the absolute bottom of 546 sats.