### PR TITLE
[Libs] Upgrade LTC bech32 dep; Remove from DOGE

### DIFF
--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -79,7 +79,6 @@ function get(arg, keys) {
  * @param {Number} data.pubkeyhash - The publickey hash prefix
  * @param {Number} data.privatekey - The privatekey prefix
  * @param {Number} data.scripthash - The scripthash prefix
-//  * @param {string} data.bech32prefix - The native segwit prefix
  * @param {Number} data.xpubkey - The extended public key magic
  * @param {Number} data.xprivkey - The extended private key magic
  * @param {Number} data.networkMagic - The network magic number
@@ -95,7 +94,6 @@ function addNetwork(data) {
     pubkeyhash: data.pubkeyhash,
     privatekey: data.privatekey,
     scripthash: data.scripthash,
-    // bech32prefix: data.bech32prefix,
     xpubkey: data.xpubkey,
     xprivkey: data.xprivkey
   });
@@ -132,7 +130,6 @@ addNetwork({
   pubkeyhash: 0x1e,
   privatekey: 0x9e,
   scripthash: 0x16,
-  // bech32prefix: 'bc',
   xpubkey: 0x0488b21e,
   xprivkey: 0x0488ade4,
   networkMagic: 0xc0c0c0c0,
@@ -162,7 +159,6 @@ addNetwork({
   pubkeyhash: 0x71,
   privatekey: 0xf1,
   scripthash: 0xc4,
-  // bech32prefix: 'tb',
   xpubkey: 0x043587cf,
   xprivkey: 0x04358394
 });
@@ -180,7 +176,6 @@ addNetwork({
   pubkeyhash: 0x6f,
   privatekey: 0xef,
   scripthash: 0xc4,
-  // bech32prefix: 'bcrt',
   xpubkey: 0x043587cf,
   xprivkey: 0x04358394,
 });

--- a/packages/bitcore-lib-doge/package.json
+++ b/packages/bitcore-lib-doge/package.json
@@ -36,7 +36,6 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "bech32": "=1.1.3",
     "bn.js": "=4.11.8",
     "bs58": "^4.0.1",
     "buffer-compare": "=1.1.1",

--- a/packages/bitcore-lib-ltc/lib/encoding/bech32.js
+++ b/packages/bitcore-lib-ltc/lib/encoding/bech32.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var bech32 = require('bech32');
+var bech32 = require('bech32').bech32;
 
 var decode = function(str) {
   if (typeof str !== 'string') {

--- a/packages/bitcore-lib-ltc/package.json
+++ b/packages/bitcore-lib-ltc/package.json
@@ -86,7 +86,7 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "bech32": "=1.1.3",
+    "bech32": "=2.0.0",
     "bn.js": "=4.11.8",
     "bs58": "^4.0.1",
     "buffer-compare": "=1.1.1",


### PR DESCRIPTION
The DOGE dep was added a while ago during development before it was realized that DOGE doesn't use bech32.