### PR TITLE
Add fiat rates to API for stablecoins

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -28,6 +28,14 @@ module.exports = {
     SHIB: 'shib'
   },
 
+  USD_STABLECOINS: {
+    USDC: 'usdc',
+    PAX: 'pax',
+    GUSD: 'gusd',
+    BUSD: 'busd',
+    DAI: 'dai'
+  },
+
   UTXO_COINS: {
     BTC: 'btc',
     BCH: 'bch',

--- a/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
+++ b/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
@@ -656,7 +656,7 @@ describe('Fiat rate service', function() {
             USD: 1
           });
           service.getRatesForStablecoin.calledWith(sinon.match({
-            fiatCode: 'USD',
+            code: 'USD',
             ts: sinon.match.number
           })).should.equal(true);
           done();

--- a/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
+++ b/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var async = require('async');
 
 var chai = require('chai');
@@ -583,6 +582,20 @@ describe('Fiat rate service', function() {
       { code: "JPY", value: 1124900.43 },
       { code: "NZD", value: 16119.66 }
     ]
+    const btcRates = [
+      { code: 'USD', value: 44173.54 },
+      { code: 'INR', value: 3306411.94 },
+      { code: 'GBP', value: 32558.07 },
+      { code: 'EUR', value: 38642.15 },
+      { code: 'CAD', value: 56070.58 },
+      { code: 'COP', value: 173924929.36 },
+      { code: 'NGN', value: 18409323.7 },
+      { code: 'BRL', value: 233457.17 },
+      { code: 'ARS', value: 4678684.28 },
+      { code: 'AUD', value: 61503.4 },
+      { code: 'JPY', value: 5099004.98 },
+      { code: 'NZD', value: 50966068.64 },
+    ];
     it('should get rates for all the supported fiat currencies of the specified coin', function(done) {
       service.storage.storeFiatRate('bch', bchRates, function(err) {
         should.not.exist(err);
@@ -617,6 +630,35 @@ describe('Fiat rate service', function() {
         }, function(err) {
           should.exist(err);
           err.should.equal('AOA is not supported');
+          done();
+        });
+      });
+    });
+    it('should get fiat rates for a USD stablecoin', function(done) {
+      sinon.spy(service, 'getRatesForStablecoin');
+      service.storage.storeFiatRate('btc', btcRates, function(err) {
+        should.not.exist(err);
+        service.getRatesByCoin({ coin: 'gusd' }, function(err, res) {
+          should.not.exist(err);
+          should.exist(res);
+          res.reduce((rates, { code, rate }) => ({ ...rates, [code]: rate }), {}).should.deep.equal({
+            ARS: 105.92,
+            AUD: 1.39,
+            BRL: 5.29,
+            CAD: 1.27,
+            COP: 3937.31,
+            EUR: 0.87,
+            GBP: 0.74,
+            INR: 74.85,
+            JPY: 115.43,
+            NGN: 416.75,
+            NZD: 1153.77,
+            USD: 1
+          });
+          service.getRatesForStablecoin.calledWith(sinon.match({
+            fiatCode: 'USD',
+            ts: sinon.match.number
+          })).should.equal(true);
           done();
         });
       });


### PR DESCRIPTION
- add `getRatesForStablecoin` to fiat rate service
- add USD stablecoin case to `getRatesByCoin`
- add `USD_STABLECOINS` to BWS constants