### PR TITLE
[BWS] Blockchain explorer should use chain instead of coin

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -39,7 +39,7 @@ export function BlockChainExplorer(opts) {
 
   const provider = opts.provider || 'v8';
   // TODO require that `chain` be passed in instead of `coin`. Coin could refer to an ERC20 which may not be in our list.
-  const chain = ChainService.getChain(opts.chain || opts.coin || Defaults.COIN).toLowerCase();
+  const chain = (opts.chain || ChainService.getChain(opts.coin || Defaults.COIN)).toLowerCase();
   const network = opts.network || 'livenet';
 
   $.checkState(PROVIDERS[provider], 'Provider ' + provider + ' not supported');

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -59,7 +59,7 @@ export function BlockChainExplorer(opts) {
   switch (provider) {
     case 'v8':
       return new V8({
-        coin: chain, // TODO V8 should take chain instead of coin
+        chain,
         network,
         url,
         apiPrefix: opts.apiPrefix,

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -38,27 +38,28 @@ export function BlockChainExplorer(opts) {
   $.checkArgument(opts, 'Failed state: opts undefined at <BlockChainExplorer()>');
 
   const provider = opts.provider || 'v8';
-  const coin = ChainService.getChain(opts.coin || Defaults.COIN).toLowerCase();
+  // TODO require that `chain` be passed in instead of `coin`. Coin could refer to an ERC20 which may not be in our list.
+  const chain = ChainService.getChain(opts.chain || opts.coin || Defaults.COIN).toLowerCase();
   const network = opts.network || 'livenet';
 
   $.checkState(PROVIDERS[provider], 'Provider ' + provider + ' not supported');
-  $.checkState(_.includes(_.keys(PROVIDERS[provider]), coin), 'Coin ' + coin + ' not supported by this provider');
+  $.checkState(_.includes(_.keys(PROVIDERS[provider]), chain), 'Chain ' + chain + ' not supported by this provider');
 
   $.checkState(
-    _.includes(_.keys(PROVIDERS[provider][coin]), network),
-    'Network ' + network + ' not supported by this provider for coin ' + coin
+    _.includes(_.keys(PROVIDERS[provider][chain]), network),
+    'Network ' + network + ' not supported by this provider for chain ' + chain
   );
 
-  const url = opts.url || PROVIDERS[provider][coin][network];
+  const url = opts.url || PROVIDERS[provider][chain][network];
 
-  if (coin != 'bch' && opts.addressFormat) throw new Error('addressFormat only supported for bch');
+  if (chain != 'bch' && opts.addressFormat) throw new Error('addressFormat only supported for bch');
 
-  if (coin == 'bch' && !opts.addressFormat) opts.addressFormat = 'cashaddr';
+  if (chain == 'bch' && !opts.addressFormat) opts.addressFormat = 'cashaddr';
 
   switch (provider) {
     case 'v8':
       return new V8({
-        coin,
+        coin: chain, // TODO V8 should take chain instead of coin
         network,
         url,
         apiPrefix: opts.apiPrefix,

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -47,15 +47,13 @@ export class V8 {
   constructor(opts) {
     $.checkArgument(opts);
     $.checkArgument(Utils.checkValueInCollection(opts.network, Constants.NETWORKS));
-    $.checkArgument(Utils.checkValueInCollection(opts.coin, Constants.COINS));
+    $.checkArgument(Utils.checkValueInCollection(opts.chain, Constants.CHAINS));
     $.checkArgument(opts.url);
 
     this.apiPrefix = _.isUndefined(opts.apiPrefix) ? '/api' : opts.apiPrefix;
-    // TODO need to take `chain` instead of `coin`.
-    // This class treats `coin` as merely a lowerCase `chain`.
-    // In reality, coin may be an ERC20 which may not be in our list. Also, we won't be able
-    //  to infer the chain from an ERC20 when we implement other smart chains.
-    this.chain = ChainService.getChain(opts.coin || Defaults.COIN);
+    this.chain = opts.chain.toUpperCase();
+    // This class treats `coin` as merely a lowerCase `chain` which is confusing
+    // TODO refactor to not be confusing.
     this.coin = this.chain.toLowerCase();
 
     this.network = opts.network || 'livenet';

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -51,6 +51,10 @@ export class V8 {
     $.checkArgument(opts.url);
 
     this.apiPrefix = _.isUndefined(opts.apiPrefix) ? '/api' : opts.apiPrefix;
+    // TODO need to take `chain` instead of `coin`.
+    // This class treats `coin` as merely a lowerCase `chain`.
+    // In reality, coin may be an ERC20 which may not be in our list. Also, we won't be able
+    //  to infer the chain from an ERC20 when we implement other smart chains.
     this.chain = ChainService.getChain(opts.coin || Defaults.COIN);
     this.coin = this.chain.toLowerCase();
 

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -2,6 +2,18 @@
 import * as CWC from 'crypto-wallet-core';
 
 module.exports = {
+  CHAINS: {
+    BTC: 'btc',
+    BCH: 'bch',
+    ETH: 'eth',
+    XRP: 'xrp',
+    DOGE: 'doge',
+    LTC: 'ltc'
+  },
+
+  // TODO rethink COINS. If we want to concatenate CHAINS + ERC20's, we can do that in the implementation.
+  // In the future, ERC20 "coins" may not be specific to ETH, so inferring that a USDC coin is on ETH (for example) may be incorrect.
+  // Perhaps, this should be a nested object, with there being coins nested inside smart chains.
   COINS: {
     BTC: 'btc',
     BCH: 'bch',

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1434,27 +1434,30 @@ export class WalletService {
     });
   }
 
-  _getBlockchainExplorer(coin, network): ReturnType<typeof BlockChainExplorer> {
+  _getBlockchainExplorer(chain, network): ReturnType<typeof BlockChainExplorer> {
     let opts: Partial<{
       provider: string;
-      coin: string;
+      chain: string;
       network: string;
       userAgent: string;
     }> = {};
 
     let provider;
 
+    // blockchainExplorerOpts has lowercased fields
+    chain = chain.toLowerCase();
+
     if (this.blockchainExplorer) return this.blockchainExplorer;
     if (this.blockchainExplorerOpts) {
-      if (this.blockchainExplorerOpts[coin] && this.blockchainExplorerOpts[coin][network]) {
-        opts = this.blockchainExplorerOpts[coin][network];
+      if (this.blockchainExplorerOpts[chain] && this.blockchainExplorerOpts[chain][network]) {
+        opts = this.blockchainExplorerOpts[chain][network];
         provider = opts.provider;
       } else if (this.blockchainExplorerOpts[network]) {
         opts = this.blockchainExplorerOpts[network];
       }
     }
     opts.provider = provider;
-    opts.coin = coin;
+    opts.chain = chain;
     opts.network = network;
     opts.userAgent = WalletService.getServiceVersion();
     let bc;
@@ -2702,7 +2705,7 @@ export class WalletService {
 
   _checkTxInBlockchain(txp, cb) {
     if (!txp.txid) return cb();
-    const bc = this._getBlockchainExplorer(txp.coin, txp.network);
+    const bc = this._getBlockchainExplorer(txp.chain, txp.network);
     if (!bc) return cb(new Error('Could not get blockchain explorer instance'));
     bc.getTransaction(txp.txid, (err, tx) => {
       if (err) return cb(err);

--- a/packages/bitcore-wallet-service/test/v8.js
+++ b/packages/bitcore-wallet-service/test/v8.js
@@ -73,7 +73,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'btc',
+        chain: 'btc',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -110,7 +110,7 @@ describe('V8', () => {
         };
       };
       var be2 = new V8({
-        coin: 'btc',
+        chain: 'btc',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -143,7 +143,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -182,7 +182,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -211,7 +211,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -235,7 +235,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -259,7 +259,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -293,7 +293,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -318,7 +318,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',
@@ -351,7 +351,7 @@ describe('V8', () => {
       };
 
       var be = new V8({
-        coin: 'bch',
+        chain: 'bch',
         network: 'livenet',
         url: 'http://dummy/',
         apiPrefix: 'dummyPath',


### PR DESCRIPTION
"coin" and "chain" are often confused and thus confusing in the codebase. There are places where "coin" is assumed to be just a lower case "chain". Perhaps this was once true, but with the addition of ETH and ERC20's, the idea of coin has shifted to maybe not be the same as chain. We should put forth effort to be more cognizant of the nuance between the two moving forward.

I decided against changing `ChainService.getChain` to assume ETH if a coin isn't found in Constants.COINS because this is potentially a dangerous assumption that we could easily miss if/when other smart chains are implemented. I would rather have to debug and fix a wrong implementation than try to patch it with an assumptive fix that might cause harder to debug issues later.

This PR:

* Updates `_checkTxInBlockchain` to pass in the txp's `chain` since the `coin` may be an ERC20 that's not in our Constants list.
* Changes the parameter name in `_getBlockchainExplorer` from `coin` to `chain`.
* Changes the parameter opts in `BlockChainExplorer` to allow for both `coin` and `chain` (In the future we should remove coin to force a proper implementation)
* Changes the variable name in `BlockChainExplorer` to `chain` to avoid future confusion
* Changed the parameter opts in `V8` constructor to take `chain`
* Added TODO and editorial comments to note future effort and help clarify the distinction