### PR TITLE
Batched calls to getStatusAll now works with token addresses

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/bulkclient.ts
+++ b/packages/bitcore-wallet-client/src/lib/bulkclient.ts
@@ -72,12 +72,14 @@ export class BulkClient extends Request {
     let wallets = opts.wallets;
     if (wallets) {
       Object.keys(wallets).forEach(copayerId => {
-        if (wallets[copayerId].tokenAddress) {
-          qs.push(
-            `${copayerId}[tokenAddress]=` + wallets[copayerId].tokenAddress
-          );
+        if (wallets[copayerId].tokenAddresses) {
+          wallets[copayerId].tokenAddresses.forEach(address => {
+            qs.push(
+              `${copayerId}[tokenAddress]=` + address
+            );
+          })
         }
-
+      
         if (wallets[copayerId].multisigContractAddress) {
           qs.push(
             `${copayerId}[multisigContractAddress]=` +

--- a/packages/bitcore-wallet-client/src/lib/bulkclient.ts
+++ b/packages/bitcore-wallet-client/src/lib/bulkclient.ts
@@ -74,12 +74,10 @@ export class BulkClient extends Request {
       Object.keys(wallets).forEach(copayerId => {
         if (wallets[copayerId].tokenAddresses) {
           wallets[copayerId].tokenAddresses.forEach(address => {
-            qs.push(
-              `${copayerId}[tokenAddress]=` + address
-            );
-          })
+            qs.push(`${copayerId}[tokenAddress]=` + address);
+          });
         }
-      
+
         if (wallets[copayerId].multisigContractAddress) {
           qs.push(
             `${copayerId}[multisigContractAddress]=` +

--- a/packages/bitcore-wallet-client/test/bulkclient.test.js
+++ b/packages/bitcore-wallet-client/test/bulkclient.test.js
@@ -116,7 +116,6 @@ describe('Bulk Client', function () {
 
             helpers.createAndJoinWallet(clients, keys, 1, 1, {}, () => {
                 const credentials = Array(3).fill(clients[0].credentials);
-                
                 clients[0].bulkClient.getStatusAll(credentials,(err, wallets) => {
                     should.not.exist(err);
                     wallets.every(wallet => {
@@ -127,7 +126,50 @@ describe('Bulk Client', function () {
                     done();
                 });
             });
+        });
 
+        it('returns eth wallet and token wallet when getStatusAll is called', done => {
+            helpers.createAndJoinWallet(clients, keys, 1, 1, { coin: 'eth', network: 'livenet' }, () => {
+                let walletOptions = {
+                    [clients[0].credentials.copayerId]: {
+                        tokenAddresses: [
+                            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+                        ]
+                    }
+                };
+
+                clients[0].bulkClient.getStatusAll([clients[0].credentials], { includeExtendedInfo: true, twoStep: true, wallets: walletOptions }, (err, wallets) => {
+                    should.not.exist(err);
+                    wallets.length.should.equal(2);
+                    wallets.findIndex(wallet => wallet.tokenAddress === null).should.be.above(-1);
+                    wallets.findIndex(wallet => wallet.tokenAddress === '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48').should.be.above(-1);
+
+                    done();
+                });
+            });
+        });
+
+        it('returns eth wallet and multiple token wallets when getStatusAll is called', done => {
+            helpers.createAndJoinWallet(clients, keys, 1, 1, { coin: 'eth', network: 'livenet' }, () => {
+                let walletOptions = {
+                    [clients[0].credentials.copayerId]: {
+                        tokenAddresses: [
+                            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd'
+                        ]
+                    }
+                };
+
+                clients[0].bulkClient.getStatusAll([clients[0].credentials], { includeExtendedInfo: true, twoStep: true, wallets: walletOptions }, (err, wallets) => {
+                    should.not.exist(err);
+                    wallets.length.should.equal(3);
+                    wallets.findIndex(wallet => wallet.tokenAddress === null).should.be.above(-1);
+                    wallets.findIndex(wallet => wallet.tokenAddress === '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48').should.be.above(-1);
+                    wallets.findIndex(wallet => wallet.tokenAddress === '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd').should.be.above(-1);
+
+                    done();
+                });
+            });
         });
 
         it('fails gracefully when given bad signature', done => {

--- a/packages/bitcore-wallet-client/test/bulkclient.test.js
+++ b/packages/bitcore-wallet-client/test/bulkclient.test.js
@@ -172,6 +172,32 @@ describe('Bulk Client', function () {
             });
         });
 
+        it('returns two eth wallets and token wallets associated with one of them', done => {
+            let key = new Key({ seedType: 'new' });
+            helpers.createAndJoinWallet(clients, keys, 1, 1, { coin: 'eth', key: key, network: 'livenet' }, () => {
+                helpers.createAndJoinWallet(clients.slice(1), keys, 1, 1, { coin: 'eth', key: key, account: 1, network: 'livenet' }, () => {
+                    let walletOptions = {
+                        [clients[0].credentials.copayerId]: {
+                            tokenAddresses: [
+                                '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                                '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd'
+                            ]
+                        }
+                    };
+
+                    clients[0].bulkClient.getStatusAll([clients[0].credentials, clients[1].credentials], { includeExtendedInfo: true, twoStep: true, wallets: walletOptions }, (err, wallets) => {
+                        should.not.exist(err);
+                        wallets.length.should.equal(4);
+                        wallets.filter(wallet => wallet.tokenAddress === null).length.should.equal(2);
+                        wallets.findIndex(wallet => wallet.tokenAddress === '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48').should.be.above(-1);
+                        wallets.findIndex(wallet => wallet.tokenAddress === '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd').should.be.above(-1);
+
+                        done();
+                    });
+                });
+            });
+        });
+
         it('fails gracefully when given bad signature', done => {
             clients[0].fromString(
                 k.createCredentials(null, {

--- a/packages/bitcore-wallet-client/test/helpers.js
+++ b/packages/bitcore-wallet-client/test/helpers.js
@@ -112,7 +112,7 @@ const helpers = {
         let cred = keys[0].createCredentials(null, {
             coin: coin,
             network: network,
-            account: 0,
+            account: opts.account ? opts.account : 0,
             n: n,
             addressType: opts.addressType
         });

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -520,7 +520,7 @@ export class ExpressApp {
         return returnError(err, res, req);
       }
 
-      return res.json(responses.flat(1));
+      return res.json(_.flatten(responses));
     });
 
     router.get('/v1/wallets/:identifier/', (req, res) => {

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -450,8 +450,7 @@ export class ExpressApp {
     router.get('/v1/wallets/all/', async (req, res) => {
       let responses;
 
-      const buildOpts = req => {
-        const copayerId = req.copayerId;
+      const buildOpts = (req, copayerId) => {
         const opts = {
           includeExtendedInfo: req.query.includeExtendedInfo == '1',
           twoStep: req.query.twoStep == '1',
@@ -473,7 +472,7 @@ export class ExpressApp {
             promise.then(
               (server: any) =>
                 new Promise(resolve => {
-                  let options: any = buildOpts(req);
+                  let options: any = buildOpts(req, server.copayerId);
                   if (options.tokenAddresses) {
                     // add a null entry to array so we can get the chain balance
                     options.tokenAddresses.unshift(null);

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -451,7 +451,7 @@ export class ExpressApp {
       let responses;
 
       const buildOpts = req => {
-        const copayerId = req.headers['x-identity'];
+        const copayerId = req.copayerId;
         const opts = {
           includeExtendedInfo: req.query.includeExtendedInfo == '1',
           twoStep: req.query.twoStep == '1',


### PR DESCRIPTION
There was an issue where the token address was not being passed to the server. That has been fixed.
This also makes it where you can send a single credential with multiple token addresses and it will return an array of responses from getStatusAll for the main wallet and every token you sent.