### PR TITLE
Update circle ci pipeline image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
       docker_layer_caching: true
+      resource_class: large
     working_directory: ~/bitcore
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 # Javascript Node CircleCI 2.0 configuration file
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
-version: 2
+version: 2.1
 jobs:
   build:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202201-02
       docker_layer_caching: true
     working_directory: ~/bitcore
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,4 @@ jobs:
       - run:
           name: Build service
           command: npm run test:ci
+          no_output_timeout: 1200

--- a/packages/bitcore-lib-cash/lib/networks.js
+++ b/packages/bitcore-lib-cash/lib/networks.js
@@ -133,14 +133,6 @@ function indexNetworkBy(network, keys) {
   }
 }
 
-function unindexNetworkBy(network, values) {
-  for(var index = 0; index < values.length; index++){
-    var value = values[index];
-    if(networkMaps[value] === network) {
-      delete networkMaps[value];
-    }
-  }
-}
 
 /**
  * @function
@@ -149,12 +141,27 @@ function unindexNetworkBy(network, values) {
  * @param {Network} network
  */
 function removeNetwork(network) {
+  if (typeof network !== 'object') {
+    network = get(network);
+  }
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
     }
   }
-  unindexNetworkBy(network, Object.keys(networkMaps));
+  for (var key in networkMaps) {
+    if (networkMaps[key].length) {
+      const index = networkMaps[key].indexOf(network);
+      if (index >= 0) {
+        networkMaps[key].splice(index, 1);
+      }
+      if (networkMaps[key].length === 0) {
+        delete networkMaps[key];
+      }
+    } else if (networkMaps[key] === network) {
+      delete networkMaps[key];
+    }
+  }
 }
 
 // from https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/chainparams.cpp#L212

--- a/packages/bitcore-lib-cash/test/networks.js
+++ b/packages/bitcore-lib-cash/test/networks.js
@@ -75,7 +75,14 @@ describe('Networks', function() {
     var somenet = networks.get('somenet');
     should.exist(somenet);
     somenet.name.should.equal('somenet');
-    networks.remove(somenet);
+  });
+
+  it('can remove a custom network by name', function() {
+    var net = networks.get('somenet');
+    should.exist(net);
+    networks.remove('somenet');
+    var net = networks.get('somenet');
+    should.equal(net, undefined);
   });
 
   var constants = ['name', 'alias', 'pubkeyhash', 'scripthash', 'xpubkey', 'xprivkey'];

--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -25,24 +25,24 @@ Network.prototype.toString = function toString() {
  * @param {Network} network
  */
 function removeNetwork(network) {
-  const id = (Math.random() * 1e8).toFixed();
-  console.log('Removing network ' + id, network);
+  if (typeof network !== 'object') {
+    network = get(network);
+  }
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
-      console.log('removed ' + id);
     }
   }
   for (var key in networkMaps) {
-    if (networkMaps[key] === network) {
+    if (networkMaps[key].length) {
+      const index = networkMaps[key].indexOf(network);
+      if (index >= 0) {
+        delete networkMaps[key][index];
+      }
+    } else if (networkMaps[key] === network) {
       delete networkMaps[key];
-      console.log('removed ' + id);
     }
   }
-  console.log('has1 ' + id, get(network));
-  console.log('has2 ' + id, get(network.name));
-  console.log('has3 ' + id, get(network.alias));
-  console.log('has4 ' + id, get('customnet'));
 }
 
 /**

--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -25,14 +25,18 @@ Network.prototype.toString = function toString() {
  * @param {Network} network
  */
 function removeNetwork(network) {
+  const id = (Math.random() * 1e8).toFixed();
+  console.log('Removing network ' + id, data);
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
+      console.log('removed ' + id);
     }
   }
   for (var key in networkMaps) {
     if (networkMaps[key] === network) {
       delete networkMaps[key];
+      console.log('removed ' + id);
     }
   }
 }
@@ -87,6 +91,7 @@ function get(arg, keys) {
  * @return Network
  */
 function addNetwork(data) {
+  console.log('Adding network', data);
   var network = new Network();
   JSUtil.defineImmutable(network, {
     name: data.name,

--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -26,7 +26,7 @@ Network.prototype.toString = function toString() {
  */
 function removeNetwork(network) {
   const id = (Math.random() * 1e8).toFixed();
-  console.log('Removing network ' + id, data);
+  console.log('Removing network ' + id, network);
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
@@ -39,6 +39,10 @@ function removeNetwork(network) {
       console.log('removed ' + id);
     }
   }
+  console.log('has1 ' + id, get(network));
+  console.log('has2 ' + id, get(network.name));
+  console.log('has3 ' + id, get(network.alias));
+  console.log('has4 ' + id, get('customnet'));
 }
 
 /**

--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -37,7 +37,10 @@ function removeNetwork(network) {
     if (networkMaps[key].length) {
       const index = networkMaps[key].indexOf(network);
       if (index >= 0) {
-        delete networkMaps[key][index];
+        networkMaps[key].splice(index, 1);
+      }
+      if (networkMaps[key].length === 0) {
+        delete networkMaps[key];
       }
     } else if (networkMaps[key] === network) {
       delete networkMaps[key];
@@ -95,7 +98,6 @@ function get(arg, keys) {
  * @return Network
  */
 function addNetwork(data) {
-  console.log('Adding network', data);
   var network = new Network();
   JSUtil.defineImmutable(network, {
     name: data.name,

--- a/packages/bitcore-lib-doge/test/address.js
+++ b/packages/bitcore-lib-doge/test/address.js
@@ -58,8 +58,22 @@ describe('Address', function() {
     });
     invalidbase58.map(function(d) {
       it('should describe input ' + d[0].slice(0, 10) + '... as invalid', function() {
+        if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
+          console.log('here');
+        }
         expect(function() {
-          return new Address(d[0]);
+          try {
+            const address = new Address(d[0]);
+            if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
+              console.log('address: ', address);
+            }
+            return address;
+          } catch (e) {
+            if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
+              console.log('error:', e);
+            }
+            throw e;
+          }
         }).to.throw(Error);
       });
     });

--- a/packages/bitcore-lib-doge/test/address.js
+++ b/packages/bitcore-lib-doge/test/address.js
@@ -58,22 +58,8 @@ describe('Address', function() {
     });
     invalidbase58.map(function(d) {
       it('should describe input ' + d[0].slice(0, 10) + '... as invalid', function() {
-        if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
-          console.log('here');
-        }
         expect(function() {
-          try {
-            const address = new Address(d[0]);
-            if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
-              console.log('address: ', address);
-            }
-            return address;
-          } catch (e) {
-            if (d[0] == '4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB') {
-              console.log('error:', e);
-            }
-            throw e;
-          }
+          return new Address(d[0]);
         }).to.throw(Error);
       });
     });
@@ -410,7 +396,6 @@ describe('Address', function() {
       it('returns the same address if the script is a pay to public key hash out', function() {
         var address = 'D77Z1nmgSZxJTmtN65n2MVF9yvLSB4MpiC';
         var script = Script.buildPublicKeyHashOut(new Address(address));
-        console.log(script);
         Address(script, Networks.livenet).toString().should.equal(address);
       });
       it('returns the same address if the script is a pay to script hash out', function() {

--- a/packages/bitcore-lib-doge/test/networks.js
+++ b/packages/bitcore-lib-doge/test/networks.js
@@ -64,9 +64,9 @@ describe('Networks', function() {
   });
 
   it('can remove a custom network', function() {
-    networks.remove('customnet');
-    Object.keys(networks).should.not.contain('customnet');
-    should.not.exist(networks.get('customnet'));
+    networks.remove(customnet);
+    var net = networks.get('customnet');
+    should.equal(net, undefined);
   });
 
   it('should not set a network map for an undefined value', function() {
@@ -86,7 +86,14 @@ describe('Networks', function() {
     networks.add(custom);
     var network = networks.get(undefined);
     should.not.exist(network);
-    networks.remove(custom);
+  });
+
+  it('can remove a custom network by name', function() {
+    var net = networks.get('somenet');
+    should.exist(net);
+    networks.remove('somenet');
+    var net = networks.get('somenet');
+    should.equal(net, undefined);
   });
 
   var constants = ['name', 'alias', 'pubkeyhash', 'scripthash', 'xpubkey', 'xprivkey'];

--- a/packages/bitcore-lib-doge/test/networks.js
+++ b/packages/bitcore-lib-doge/test/networks.js
@@ -66,6 +66,7 @@ describe('Networks', function() {
   it('can remove a custom network', function() {
     networks.remove('customnet');
     Object.keys(networks).should.not.contain('customnet');
+    should.not.exist(networks.get('customnet'));
   });
 
   it('should not set a network map for an undefined value', function() {

--- a/packages/bitcore-lib-ltc/lib/networks.js
+++ b/packages/bitcore-lib-ltc/lib/networks.js
@@ -124,17 +124,27 @@ function addNetwork(data) {
  * @param {Network} network
  */
 function removeNetwork(network) {
+  if (typeof network !== 'object') {
+    network = get(network);
+  }
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
     }
   }
   for (var key in networkMaps) {
-    if (networkMaps[key] === network) {
+    if (networkMaps[key].length) {
+      const index = networkMaps[key].indexOf(network);
+      if (index >= 0) {
+        networkMaps[key].splice(index, 1);
+      }
+      if (networkMaps[key].length === 0) {
+        delete networkMaps[key];
+      }
+    } else if (networkMaps[key] === network) {
       delete networkMaps[key];
     }
-  }
-}
+  }}
 
 addNetwork({
   name: 'livenet',

--- a/packages/bitcore-lib-ltc/test/networks.js
+++ b/packages/bitcore-lib-ltc/test/networks.js
@@ -87,7 +87,14 @@ describe('Networks', function() {
     networks.add(custom);
     var network = networks.get(undefined);
     should.not.exist(network);
-    networks.remove(custom);
+  });
+
+  it('can remove a custom network by name', function() {
+    var net = networks.get('somenet');
+    should.exist(net);
+    networks.remove('somenet');
+    var net = networks.get('somenet');
+    should.equal(net, undefined);
   });
 
   var constants = ['name', 'alias', 'pubkeyhash', 'scripthash', 'xpubkey', 'xprivkey'];

--- a/packages/bitcore-lib/lib/networks.js
+++ b/packages/bitcore-lib/lib/networks.js
@@ -123,15 +123,25 @@ function addNetwork(data) {
  * @param {Network} network
  */
 function removeNetwork(network) {
+  if (typeof network !== 'object') {
+    network = get(network);
+  }
   for (var i = 0; i < networks.length; i++) {
     if (networks[i] === network) {
       networks.splice(i, 1);
     }
   }
   for (var key in networkMaps) {
-    const index = networkMaps[key].indexOf(network);
-    if (index >= 0) {
-      delete networkMaps[key][index];
+    if (networkMaps[key].length) {
+      const index = networkMaps[key].indexOf(network);
+      if (index >= 0) {
+        networkMaps[key].splice(index, 1);
+      }
+      if (networkMaps[key].length === 0) {
+        delete networkMaps[key];
+      }
+    } else if (networkMaps[key] === network) {
+      delete networkMaps[key];
     }
   }
 }

--- a/packages/bitcore-lib/test/networks.js
+++ b/packages/bitcore-lib/test/networks.js
@@ -89,7 +89,14 @@ describe('Networks', function() {
     var somenet = networks.get('somenet');
     should.exist(somenet);
     somenet.name.should.equal('somenet');
-    networks.remove(somenet);
+  });
+
+  it('can remove a custom network by name', function() {
+    var net = networks.get('somenet');
+    should.exist(net);
+    networks.remove('somenet');
+    net = networks.get('somenet');
+    should.equal(net, undefined);
   });
 
   var constants = ['name', 'alias', 'pubkeyhash', 'scripthash', 'xpubkey', 'xprivkey'];

--- a/packages/bitcore-node/src/modules/ripple/api/csp.ts
+++ b/packages/bitcore-node/src/modules/ripple/api/csp.ts
@@ -118,10 +118,10 @@ export class RippleStateProvider extends InternalStateProvider implements IChain
           try {
             if (err) {
               return reject(err);
-            } else if (body.result === 'error') {
-              return reject(body);
             } else if (body == null) {
               return resolve(body);
+            } else if (body.result === 'error') {
+              return reject(body);
             } else {
               return resolve({
                 ...body.ledger,

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -7209,6 +7209,10 @@ describe('Wallet service', function() {
   describe('Check requiredFeeRate  BTC', function() {
     var server, wallet;
 
+    // some of these tests, particularly case 26, can run a bit long
+    //  and cause the ci pipeline to fail
+    this.timeout(4000);
+
     beforeEach(function(done) {
       helpers.stubFeeLevels({
         1: 40002,


### PR DESCRIPTION
- Firstly, it updates the pipeline to use a ubuntu 20 image -- which was the main purpose of the PR, but it exposed some bugs which are fixed below.
- Secondly, it makes the `removeNetwork` function consistent across the libs, and also fixes one or two bugs with the network removal (not that anyone ever adds custom networks anyway, so it makes sense whey this hasn't really been addressed)
- Thirdly, it extends the timeout for some long-running tests that would sometimes cause the pipeline to fail
- Lastly, it fixes a bug where an XRP response would evaluate `body.result` before `body == null`...which inevitably throws if `body == null`