### PR TITLE
[REF] simplify adding new chains - bwc

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -445,12 +445,12 @@ export class API extends EventEmitter {
     return cb(null, privateKeyWif);
   }
 
-  getBalanceFromPrivateKey(privateKey, coin, cb) {
-    if (_.isFunction(coin)) {
-      cb = coin;
-      coin = 'btc';
+  getBalanceFromPrivateKey(privateKey, chain, cb) {
+    if (_.isFunction(chain)) {
+      cb = chain;
+      chain = 'btc';
     }
-    var B = Bitcore_[coin];
+    var B = Bitcore_[chain];
 
     var privateKey = new B.PrivateKey(privateKey);
     var address = privateKey.publicKey.toAddress().toString(true);
@@ -469,16 +469,16 @@ export class API extends EventEmitter {
   buildTxFromPrivateKey(privateKey, destinationAddress, opts, cb) {
     opts = opts || {};
 
-    var coin = opts.coin || 'btc';
+    var chain = opts.chain?.toLowerCase() || Utils.getChain(opts.coin); // getChain -> backwards compatibility
     var signingMethod = opts.signingMethod || 'ecdsa';
 
-    if (!_.includes(Constants.COINS, coin))
-      return cb(new Error('Invalid coin'));
+    if (!_.includes(Constants.CHAINS, chain))
+      return cb(new Error('Invalid chain'));
 
-    if (coin == 'eth')
-      return cb(new Error('ETH not supported for this action'));
+    if (Constants.EVM_CHAINS.includes(chain))
+      return cb(new Error('EVM based chains not supported for this action'));
 
-    var B = Bitcore_[coin];
+    var B = Bitcore_[chain];
     var privateKey = B.PrivateKey(privateKey);
     var address = privateKey.publicKey.toAddress().toString(true);
 
@@ -676,7 +676,9 @@ export class API extends EventEmitter {
       txp.signingMethod,
       'Failed state: txp.signingMethod undefined at _addSignaturesToBitcoreTxBitcoin'
     );
-    const bitcore = Bitcore_[txp.coin];
+
+    var chain = txp.chain?.toLowerCase() || Utils.getChain(txp.coin); // getChain -> backwards compatibility
+    const bitcore = Bitcore_[chain];
     if (signatures.length != txp.inputs.length)
       throw new Error('Number of signatures does not match number of inputs');
 
@@ -705,8 +707,7 @@ export class API extends EventEmitter {
   }
 
   _addSignaturesToBitcoreTx(txp, t, signatures, xpub) {
-    const { coin, network } = txp;
-    const chain = Utils.getChain(coin);
+    const { chain, network } = txp;
     switch (chain) {
       case 'XRP':
       case 'ETH':
@@ -828,16 +829,14 @@ export class API extends EventEmitter {
   // /**
   // * Get current fee levels for the specified network
   // *
-  // * @param {string} coin - 'btc' (default) or 'bch'
+  // * @param {string} chain - 'btc' (default) or 'bch'
   // * @param {string} network - 'livenet' (default) or 'testnet'
   // * @param {Callback} cb
   // * @returns {Callback} cb - Returns error or an object with status information
   // */
-  getFeeLevels(coin, network, cb) {
-    $.checkArgument(coin || _.includes(Constants.COINS, coin));
+  getFeeLevels(chain, network, cb) {
+    $.checkArgument(chain || _.includes(Constants.CHAINS, chain));
     $.checkArgument(network || _.includes(['livenet', 'testnet'], network));
-
-    const chain = Utils.getChain(coin).toLowerCase();
 
     this.request.get(
       '/v2/feelevels/?coin=' +
@@ -899,7 +898,9 @@ export class API extends EventEmitter {
     opts = opts || {};
 
     var coin = opts.coin || 'btc';
-    if (!_.includes(Constants.COINS, coin))
+
+    // checking in chains for simplicity
+    if (!_.includes(Constants.CHAINS, coin))
       return cb(new Error('Invalid coin'));
 
     var network = opts.network || 'livenet';
@@ -992,7 +993,8 @@ export class API extends EventEmitter {
     opts = opts || {};
 
     var coin = opts.coin || 'btc';
-    if (!_.includes(Constants.COINS, coin))
+    // checking in chains for simplicity
+    if (!_.includes(Constants.CHAINS, coin))
       return cb(new Error('Invalid coin'));
 
     try {
@@ -1723,8 +1725,8 @@ export class API extends EventEmitter {
   getPayProV2(txp) {
     if (!txp.payProUrl || this.doNotVerifyPayPro) return Promise.resolve();
 
-    const chain = Utils.getChain(txp.coin);
-    const currency = txp.coin.toUpperCase();
+    const chain = txp.chain || Utils.getChain(txp.coin); // getChain -> backwards compatibility
+    const currency = txp.coin;
     const payload = {
       address: txp.from
     };
@@ -1961,7 +1963,8 @@ export class API extends EventEmitter {
     opts = opts || {};
 
     var coin = opts.coin || 'btc';
-    if (!_.includes(Constants.COINS, coin))
+    // checking in chains for simplicity
+    if (!_.includes(Constants.CHAINS, coin))
       return cb(new Error('Invalid coin'));
 
     var publicKeyRing = JSON.parse(unencryptedPkr);
@@ -2087,8 +2090,8 @@ export class API extends EventEmitter {
 
           this._applyAllSignatures(txp, t);
 
-          const chain = Utils.getChain(txp.coin);
-          const currency = txp.coin.toUpperCase();
+          const chain = txp.chain || Utils.getChain(txp.coin); // getChain -> backwards compatibility
+          const currency = txp.coin;
           const rawTxUnsigned = t_unsigned.uncheckedSerialize();
           const serializedTx = t.serialize({
             disableSmallFees: true,
@@ -2521,14 +2524,18 @@ export class API extends EventEmitter {
 
   // /**
   // * Returns nonce.
-  // * @param {Object} opts - coin, network
+  // * @param {Object} opts - chain, coin, network
   // * @return {Callback} cb - Return error (if exists) and nonce
   // */
   getNonce(opts, cb) {
-    $.checkArgument(opts.coin == 'eth', 'Invalid coin: must be "eth"');
+    $.checkArgument(
+      Constants.EVM_CHAINS.includes(opts.chain),
+      'Invalid chain: must be EVM based'
+    );
 
     var qs = [];
     qs.push(`coin=${opts.coin}`);
+    qs.push(`chain=${opts.chain}`);
     qs.push(`network=${opts.network}`);
 
     const url = `/v1/nonce/${opts.address}?${qs.join('&')}`;
@@ -2570,6 +2577,7 @@ export class API extends EventEmitter {
   // /**
   // * Returns contract info. (name symbol precision)
   // * @param {string} opts.tokenAddress - token contract address
+  // * @param {string} opts.chain - chain name, defaults to 'eth'
   // * @return {Callback} cb - Return error (if exists) instantiation info
   // */
   getTokenContractInfo(opts, cb) {
@@ -2809,6 +2817,7 @@ export class API extends EventEmitter {
     var checkCredentials = (key, opts, icb) => {
       let c = key.createCredentials(null, {
         coin: opts.coin,
+        chain: opts.coin, // chain === coin for stored clients
         network: opts.network,
         account: opts.account,
         n: opts.n
@@ -2875,8 +2884,10 @@ export class API extends EventEmitter {
                 return;
               }
               log.info(`Importing token: ${token.name}`);
-              const tokenCredentials =
-                client.credentials.getTokenCredentials(token);
+              const tokenCredentials = client.credentials.getTokenCredentials(
+                token,
+                'eth'
+              );
               let tokenClient = _.cloneDeep(client);
               tokenClient.credentials = tokenCredentials;
               clients.push(tokenClient);
@@ -2909,7 +2920,10 @@ export class API extends EventEmitter {
                   }
                   log.info(`Importing multisig token: ${token.name}`);
                   const tokenCredentials =
-                    multisigEthClient.credentials.getTokenCredentials(token);
+                    multisigEthClient.credentials.getTokenCredentials(
+                      token,
+                      'eth'
+                    );
                   let tokenClient = _.cloneDeep(multisigEthClient);
                   tokenClient.credentials = tokenCredentials;
                   clients.push(tokenClient);

--- a/packages/bitcore-wallet-client/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/constants.ts
@@ -21,7 +21,7 @@ export const Constants = {
     REQUEST_KEY_AUTH: 'm/2' // relative to BASE
   },
   BIP45_SHARED_INDEX: 0x80000000 - 1,
-  COINS: [
+  BITPAY_SUPPORTED_COINS: [
     'btc',
     'bch',
     'eth',
@@ -38,8 +38,21 @@ export const Constants = {
     'ape',
     'euroc'
   ],
-  ERC20: ['usdc', 'pax', 'gusd', 'busd', 'dai', 'wbtc', 'shib', 'ape', 'euroc'],
+  BITPAY_SUPPORTED_ERC20: [
+    'usdc',
+    'pax',
+    'gusd',
+    'busd',
+    'dai',
+    'wbtc',
+    'shib',
+    'ape',
+    'euroc'
+  ],
   UTXO_COINS: ['btc', 'bch', 'doge', 'ltc'],
+  CHAINS: ['btc', 'bch', 'eth', 'xrp', 'doge', 'ltc'],
+  UTXO_CHAINS: ['btc', 'bch', 'doge', 'ltc'],
+  EVM_CHAINS: ['eth'],
   TOKEN_OPTS: CWC.Constants.TOKEN_OPTS,
   UNITS: CWC.Constants.UNITS
 };

--- a/packages/bitcore-wallet-client/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/defaults.ts
@@ -3,8 +3,8 @@ export const Defaults = {
   DEFAULT_FEE_PER_KB: 10000,
   MIN_FEE_PER_KB: 0,
   MAX_FEE_PER_KB: 1000000,
-  MAX_TX_FEE(coin) {
-    switch (coin) {
+  MAX_TX_FEE(chain) {
+    switch (chain) {
       case 'btc':
         return 0.5e8;
       case 'doge':

--- a/packages/bitcore-wallet-client/src/lib/credentials.ts
+++ b/packages/bitcore-wallet-client/src/lib/credentials.ts
@@ -12,6 +12,7 @@ const sjcl = require('sjcl');
 export class Credentials {
   static FIELDS = [
     'coin',
+    'chain',
     'network',
     'xPrivKey', // obsolete
     'xPrivKeyEncrypted', // obsolte
@@ -62,6 +63,7 @@ export class Credentials {
   derivationStrategy: any;
   network: string;
   coin: string;
+  chain: string;
   use145forBCH: any;
 
   addressType: string;
@@ -81,6 +83,7 @@ export class Credentials {
 
   static fromDerivedKey(opts) {
     $.shouldBeString(opts.coin);
+    $.shouldBeString(opts.chain);
     $.shouldBeString(opts.network);
     $.shouldBeNumber(opts.account, 'Invalid account');
     $.shouldBeString(opts.xPubKey, 'Invalid xPubKey');
@@ -92,6 +95,7 @@ export class Credentials {
 
     var x: any = new Credentials();
     x.coin = opts.coin;
+    x.chain = opts.chain;
     x.network = opts.network;
     x.account = opts.account;
     x.n = opts.n;
@@ -126,7 +130,7 @@ export class Credentials {
     const b = Buffer.from(entropySource, 'hex');
     const b2 = Bitcore.crypto.Hash.sha256hmac(b, Buffer.from(prefix));
     x.personalEncryptingKey = b2.slice(0, 16).toString('base64');
-    x.copayerId = Utils.xPubToCopayerId(x.coin, x.xPubKey);
+    x.copayerId = Utils.xPubToCopayerId(x.chain, x.xPubKey);
     x.publicKeyRing = [
       {
         xPubKey: x.xPubKey,
@@ -140,14 +144,18 @@ export class Credentials {
   /*
    * creates an ERC20 wallet from a ETH wallet
    */
-  getTokenCredentials(token: {
-    name: string;
-    symbol: string;
-    address: string;
-  }) {
+  getTokenCredentials(
+    token: {
+      name: string;
+      symbol: string;
+      address: string;
+    },
+    chain: string
+  ) {
     const ret = _.cloneDeep(this);
     ret.walletId = `${ret.walletId}-${token.address}`;
     ret.coin = token.symbol.toLowerCase();
+    ret.chain = chain;
     ret.walletName = token.name;
     ret.token = token;
 
@@ -189,9 +197,10 @@ export class Credentials {
       }
 
       var coin = '0';
+      // checking in chains for simplicity
       if (
         this.network != 'livenet' &&
-        Constants.UTXO_COINS.includes(this.coin)
+        Constants.UTXO_CHAINS.includes(this.coin)
       ) {
         coin = '1';
       } else if (this.coin == 'bch') {
@@ -242,6 +251,7 @@ export class Credentials {
     }
 
     x.coin = x.coin || 'btc';
+    x.chain = x.chain || Utils.getChain(x.coin); // getChain -> backwards compatibility
     x.addressType = x.addressType || Constants.SCRIPT_TYPES.P2SH;
     x.account = x.account || 0;
 
@@ -311,10 +321,10 @@ export class Credentials {
   isComplete() {
     if (!this.m || !this.n) return false;
     if (
-      (this.coin === 'btc' ||
-        this.coin === 'bch' ||
-        this.coin === 'doge' ||
-        this.coin === 'ltc') &&
+      (this.chain === 'btc' ||
+        this.chain === 'bch' ||
+        this.chain === 'doge' ||
+        this.chain === 'ltc') &&
       (!this.publicKeyRing || this.publicKeyRing.length != this.n)
     )
       return false;

--- a/packages/bitcore-wallet-client/src/lib/key.ts
+++ b/packages/bitcore-wallet-client/src/lib/key.ts
@@ -359,8 +359,8 @@ export class Key {
     return deriveFn(path);
   };
 
-  _checkCoin = function (coin) {
-    if (!_.includes(Constants.COINS, coin)) throw new Error('Invalid coin');
+  _checkChain = function (chain) {
+    if (!_.includes(Constants.CHAINS, chain)) throw new Error('Invalid chain');
   };
 
   _checkNetwork = function (network) {
@@ -381,7 +381,11 @@ export class Key {
     let purpose = opts.n == 1 || this.use44forMultisig ? '44' : '48';
     var coinCode = '0';
 
-    if (opts.network == 'testnet' && Constants.UTXO_COINS.includes(opts.coin)) {
+    // checking in chains for simplicity
+    if (
+      opts.network == 'testnet' &&
+      Constants.UTXO_CHAINS.includes(opts.coin)
+    ) {
       coinCode = '1';
     } else if (opts.coin == 'bch') {
       if (this.use0forBCH) {
@@ -446,6 +450,7 @@ export class Key {
     return Credentials.fromDerivedKey({
       xPubKey: xPrivKey.hdPublicKey.toString(),
       coin: opts.coin,
+      chain: opts.chain?.toLowerCase() || Utils.getChain(opts.coin), // getChain -> backwards compatibility
       network: opts.network,
       account: opts.account,
       n: opts.n,
@@ -493,7 +498,9 @@ export class Key {
 
     var t = Utils.buildTx(txp);
 
-    if (Constants.UTXO_COINS.includes(txp.coin)) {
+    var chain = txp.chain?.toLowerCase() || Utils.getChain(txp.coin); // getChain -> backwards compatibility
+
+    if (Constants.UTXO_CHAINS.includes(chain)) {
       _.each(txp.inputs, function (i) {
         $.checkState(
           i.path,
@@ -520,14 +527,11 @@ export class Key {
     } else {
       let tx = t.uncheckedSerialize();
       tx = typeof tx === 'string' ? [tx] : tx;
-      const chain = txp.chain
-        ? txp.chain.toUpperCase()
-        : Utils.getChain(txp.coin);
       const txArray = _.isArray(tx) ? tx : [tx];
       const isChange = false;
       const addressIndex = 0;
       const { privKey, pubKey } = Deriver.derivePrivateKey(
-        chain,
+        chain.toUpperCase(),
         txp.network,
         derived,
         addressIndex,
@@ -536,7 +540,7 @@ export class Key {
       let signatures = [];
       for (const rawTx of txArray) {
         const signed = Transactions.getSignature({
-          chain,
+          chain: chain.toUpperCase(),
           tx: rawTx,
           key: { privKey, pubKey }
         });

--- a/packages/bitcore-wallet-client/src/lib/payproV2.ts
+++ b/packages/bitcore-wallet-client/src/lib/payproV2.ts
@@ -217,8 +217,8 @@ export class PayProV2 {
         'Keep-Alive': 'timeout=30, max=10'
       },
       args: JSON.stringify({
-        chain,
-        currency,
+        chain: chain?.toUpperCase(),
+        currency: currency?.toUpperCase(),
         payload
       })
     });
@@ -258,8 +258,8 @@ export class PayProV2 {
         'Keep-Alive': 'timeout=30, max=10'
       },
       args: JSON.stringify({
-        chain,
-        currency,
+        chain: chain?.toUpperCase(),
+        currency: currency?.toUpperCase(),
         transactions: unsignedTransactions
       })
     });
@@ -302,8 +302,8 @@ export class PayProV2 {
         'Keep-Alive': 'timeout=30, max=10'
       },
       args: JSON.stringify({
-        chain,
-        currency,
+        chain: chain?.toUpperCase(),
+        currency: currency?.toUpperCase(),
         transactions: signedTransactions
       })
     });
@@ -460,7 +460,8 @@ export class PayProV2 {
     }
 
     if (responseData.chain) {
-      payProDetails.coin = responseData.chain.toLowerCase();
+      payProDetails.coin = responseData.chain?.toLowerCase(); // TODO responseData.coin ???
+      payProDetails.chain = responseData.chain?.toLowerCase();
     }
 
     if (responseData.expires) {
@@ -483,7 +484,7 @@ export class PayProV2 {
 
       if (payProDetails.requiredFeeRate) {
         if (
-          payProDetails.requiredFeeRate > MAX_FEE_PER_KB[payProDetails.coin]
+          payProDetails.requiredFeeRate > MAX_FEE_PER_KB[payProDetails.chain]
         ) {
           throw new Error('Fee rate too high:' + payProDetails.requiredFeeRate);
         }

--- a/packages/bitcore-wallet-client/src/lib/verifier.ts
+++ b/packages/bitcore-wallet-client/src/lib/verifier.ts
@@ -34,7 +34,7 @@ export class Verifier {
       address.path,
       credentials.m,
       credentials.network,
-      credentials.coin,
+      credentials.chain,
       escrowInputs
     );
     return (
@@ -161,13 +161,9 @@ export class Verifier {
       'Failed state: credentials at checkTxProposalSignature'
     );
 
+    var chain = txp.chain?.toLowerCase() || Utils.getChain(txp.coin); // getChain -> backwards compatibility
     var creatorKeys = _.find(credentials.publicKeyRing, item => {
-      if (
-        Utils.xPubToCopayerId(
-          txp.chain ? txp.chain : txp.coin ? txp.coin : 'btc',
-          item.xPubKey
-        ) === txp.creatorId
-      )
+      if (Utils.xPubToCopayerId(chain, item.xPubKey) === txp.creatorId)
         return true;
     });
 
@@ -209,7 +205,7 @@ export class Verifier {
     if (!Utils.verifyMessage(hash, txp.proposalSignature, creatorSigningPubKey))
       return false;
 
-    if (Constants.UTXO_COINS.includes(txp.coin)) {
+    if (Constants.UTXO_CHAINS.includes(chain)) {
       if (!this.checkAddress(credentials, txp.changeAddress)) {
         return false;
       }

--- a/packages/bitcore-wallet-client/test/api.test.js
+++ b/packages/bitcore-wallet-client/test/api.test.js
@@ -691,7 +691,7 @@ describe('client API', function() {
 
         (() => {
           var t = x.buildTx(txp);
-        }).should.throw('Failed state: totalInputs - totalOutputs <= Defaults.MAX_TX_FEE(coin) at buildTx');
+        }).should.throw('Failed state: totalInputs - totalOutputs <= Defaults.MAX_TX_FEE(chain) at buildTx');
 
         x.newBitcoreTransaction = x;
       });


### PR DESCRIPTION
- stop using `coin` when it really means `chain`
- `chain` always lowercase
- REF `COINS` and `ERC20` constant s -> replaced by `BITPAY_SUPPORTED_COINS` and `BITPAY_SUPPORTED_ERC20` ( only used for backwards compatibility )
- Always get bitcore libs using `chain` -> `Bitcore_[chain]`
- Keep `Utils` `getChain` function only for backwards compatibility
- Add `chain` to wallet credentials