### PR TITLE
[REF] simplify adding new chains - bws

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -38,8 +38,7 @@ export function BlockChainExplorer(opts) {
   $.checkArgument(opts, 'Failed state: opts undefined at <BlockChainExplorer()>');
 
   const provider = opts.provider || 'v8';
-  // TODO require that `chain` be passed in instead of `coin`. Coin could refer to an ERC20 which may not be in our list.
-  const chain = (opts.chain || ChainService.getChain(opts.coin || Defaults.COIN)).toLowerCase();
+  const chain = opts.chain?.toLowerCase() || ChainService.getChain(opts.coin); // getChain -> backwards compatibility
   const network = opts.network || 'livenet';
 
   $.checkState(PROVIDERS[provider], 'Provider ' + provider + ' not supported');

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -32,7 +32,6 @@ function v8network(bwsNetwork) {
 
 export class V8 {
   chain: string;
-  coin: string;
   network: string;
   v8network: string;
   // v8 is always cashaddr
@@ -51,17 +50,14 @@ export class V8 {
     $.checkArgument(opts.url);
 
     this.apiPrefix = _.isUndefined(opts.apiPrefix) ? '/api' : opts.apiPrefix;
-    this.chain = opts.chain.toUpperCase();
-    // This class treats `coin` as merely a lowerCase `chain` which is confusing
-    // TODO refactor to not be confusing.
-    this.coin = this.chain.toLowerCase();
+    this.chain = opts.chain;
 
     this.network = opts.network || 'livenet';
     this.v8network = v8network(this.network);
 
     // v8 is always cashaddr
-    this.addressFormat = this.coin == 'bch' ? 'cashaddr' : null;
-    this.apiPrefix += `/${this.chain}/${this.v8network}`;
+    this.addressFormat = this.chain == 'bch' ? 'cashaddr' : null;
+    this.apiPrefix += `/${this.chain.toUpperCase()}/${this.v8network}`;
 
     this.host = opts.url;
     this.userAgent = opts.userAgent || 'bws';
@@ -84,7 +80,7 @@ export class V8 {
     $.checkState(wallet.beAuthPrivateKey2, 'Failed state: wallet.beAuthPrivateKey2 at <_getAuthClient()>');
     return new this.Client({
       baseUrl: this.baseUrl,
-      authKey: Bitcore_[this.coin].PrivateKey(wallet.beAuthPrivateKey2)
+      authKey: Bitcore_[this.chain].PrivateKey(wallet.beAuthPrivateKey2)
     });
   }
 
@@ -114,8 +110,8 @@ export class V8 {
   }
 
   register(wallet, cb) {
-    if (wallet.coin != this.coin || wallet.network != this.network) {
-      return cb(new Error('Network coin or network mismatch'));
+    if (wallet.chain != this.chain || wallet.network != this.network) {
+      return cb(new Error('Network chain or network mismatch'));
     }
 
     const client = this._getAuthClient(wallet);
@@ -146,7 +142,7 @@ export class V8 {
   }
 
   getConnectionInfo() {
-    return 'V8 (' + this.coin + '/' + this.v8network + ') @ ' + this.host;
+    return 'V8 (' + this.chain + '/' + this.v8network + ') @ ' + this.host;
   }
 
   _transformUtxos(utxos, bcheight) {
@@ -577,7 +573,7 @@ export class V8 {
     walletsSocket.on('coin', data => {
       if (!data || !data.coin) return;
 
-      const notification = ChainService.onCoin(this.coin, data.coin);
+      const notification = ChainService.onCoin(this.chain, data.coin);
       if (!notification) return;
 
       return callbacks.onIncomingPayments(notification);
@@ -586,7 +582,7 @@ export class V8 {
     walletsSocket.on('tx', data => {
       if (!data || !data.tx) return;
 
-      const notification = ChainService.onTx(this.coin, data.tx);
+      const notification = ChainService.onTx(this.chain, data.tx);
       if (!notification) return;
 
       return callbacks.onIncomingPayments(notification);

--- a/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
@@ -17,11 +17,11 @@ const Constants = Common.Constants;
 const Utils = Common.Utils;
 const Defaults = Common.Defaults;
 
-type throttledNewBlocksFnType = (that: any, coin: any, network: any, hash: any) => void;
+type throttledNewBlocksFnType = (that: any, chain: any, network: any, hash: any) => void;
 
-var throttledNewBlocks = _.throttle((that, coin, network, hash) => {
-  that._notifyNewBlock(coin, network, hash);
-  // that._handleTxConfirmations(coin, network, hash); // no need to throttledNewBlocks
+var throttledNewBlocks = _.throttle((that, chain, network, hash) => {
+  that._notifyNewBlock(chain, network, hash);
+  // that._handleTxConfirmations(chain, network, hash); // no need to throttledNewBlocks
 }, Defaults.NEW_BLOCK_THROTTLE_TIME_MIN * 60 * 1000) as throttledNewBlocksFnType;
 
 export class BlockchainMonitor {
@@ -56,38 +56,38 @@ export class BlockchainMonitor {
             ltc: {}
           };
 
-          const coinNetworkPairs = [];
-          _.each(_.values(Constants.COINS), coin => {
+          const chainNetworkPairs = [];
+          _.each(_.values(Constants.CHAINS), chain => {
             _.each(_.values(Constants.NETWORKS), network => {
-              coinNetworkPairs.push({
-                coin,
+              chainNetworkPairs.push({
+                chain,
                 network
               });
             });
           });
-          _.each(coinNetworkPairs, pair => {
+          _.each(chainNetworkPairs, pair => {
             let explorer;
             if (
               opts.blockchainExplorers &&
-              opts.blockchainExplorers[pair.coin] &&
-              opts.blockchainExplorers[pair.coin][pair.network]
+              opts.blockchainExplorers[pair.chain] &&
+              opts.blockchainExplorers[pair.chain][pair.network]
             ) {
-              explorer = opts.blockchainExplorers[pair.coin][pair.network];
+              explorer = opts.blockchainExplorers[pair.chain][pair.network];
             } else {
               let config: { url?: string; provider?: any } = {};
               if (
                 opts.blockchainExplorerOpts &&
-                opts.blockchainExplorerOpts[pair.coin] &&
-                opts.blockchainExplorerOpts[pair.coin][pair.network]
+                opts.blockchainExplorerOpts[pair.chain] &&
+                opts.blockchainExplorerOpts[pair.chain][pair.network]
               ) {
-                config = opts.blockchainExplorerOpts[pair.coin][pair.network];
+                config = opts.blockchainExplorerOpts[pair.chain][pair.network];
               } else {
                 return;
               }
 
               explorer = BlockChainExplorer({
                 provider: config.provider,
-                coin: pair.coin,
+                chain: pair.chain,
                 network: pair.network,
                 url: config.url,
                 userAgent: WalletService.getServiceVersion()
@@ -95,8 +95,8 @@ export class BlockchainMonitor {
             }
             $.checkState(explorer, 'Failed State: explorer undefined at <start()>');
 
-            this._initExplorer(pair.coin, pair.network, explorer);
-            this.explorers[pair.coin][pair.network] = explorer;
+            this._initExplorer(pair.chain, pair.network, explorer);
+            this.explorers[pair.chain][pair.network] = explorer;
           });
           done();
         },
@@ -133,14 +133,14 @@ export class BlockchainMonitor {
     );
   }
 
-  _initExplorer(coin, network, explorer) {
+  _initExplorer(chain, network, explorer) {
     explorer.initSocket({
-      onBlock: _.bind(this._handleNewBlock, this, coin, network),
-      onIncomingPayments: _.bind(this._handleIncomingPayments, this, coin, network)
+      onBlock: _.bind(this._handleNewBlock, this, chain, network),
+      onIncomingPayments: _.bind(this._handleIncomingPayments, this, chain, network)
     });
   }
 
-  _handleThirdPartyBroadcasts(coin, network, data, processIt) {
+  _handleThirdPartyBroadcasts(chain, network, data, processIt) {
     if (!data || !data.txid) return;
 
     if (!processIt) {
@@ -151,7 +151,7 @@ export class BlockchainMonitor {
       this.lastTx[this.Nix++] = data.txid;
       if (this.Nix >= this.N) this.Nix = 0;
 
-      logger.debug(`\tChecking ${coin}/${network} txid: ${data.txid}`);
+      logger.debug(`\tChecking ${chain}/${network} txid: ${data.txid}`);
     }
 
     this.storage.fetchTxByHash(data.txid, (err, txp) => {
@@ -175,7 +175,7 @@ export class BlockchainMonitor {
             txp.amount +
             'sat ]'
         );
-        return setTimeout(this._handleThirdPartyBroadcasts.bind(this, coin, network, data, true), 20 * 1000);
+        return setTimeout(this._handleThirdPartyBroadcasts.bind(this, chain, network, data, true), 20 * 1000);
       }
 
       logger.debug('Processing accepted txp [' + txp.id + '] for wallet ' + walletId + ' [' + txp.amount + 'sat ]');
@@ -201,13 +201,13 @@ export class BlockchainMonitor {
     });
   }
 
-  _handleIncomingPayments(coin, network, data) {
+  _handleIncomingPayments(chain, network, data) {
     if (!data) return;
     let out = data.out;
     if (!out || !out.address || out.address.length < 10) return;
 
-    // For eth, amount = 0 is ok, repeating addr payments are ok (no change).
-    if (coin != 'eth') {
+    // For evm chains, amount = 0 is ok, repeating addr payments are ok (no change).
+    if (!Constants.EVM_CHAINS[chain.toUpperCase()]) {
       if (!(out.amount > 0)) return;
       if (this.last.indexOf(out.address) >= 0) {
         logger.debug('The incoming tx"s out ' + out.address + ' was already processed');
@@ -215,7 +215,7 @@ export class BlockchainMonitor {
       }
       this.last[this.Ni++] = out.address;
       if (this.Ni >= this.N) this.Ni = 0;
-    } else if (coin == 'eth') {
+    } else {
       if (this.lastTx.indexOf(data.txid) >= 0) {
         logger.debug('The incoming tx ' + data.txid + ' was already processed');
         return;
@@ -225,15 +225,15 @@ export class BlockchainMonitor {
       if (this.Nix >= this.N) this.Nix = 0;
     }
 
-    logger.debug(`Checking ${coin}:${network}:${out.address} ${out.amount}`);
-    this.storage.fetchAddressByCoin(coin, out.address, (err, address) => {
+    logger.debug(`Checking ${chain}:${network}:${out.address} ${out.amount}`);
+    this.storage.fetchAddressByChain(chain, out.address, (err, address) => {
       if (err) {
         logger.error('Could not fetch addresses from the db');
         return;
       }
       if (!address || address.isChange) {
         // no incomming payment
-        return this._handleThirdPartyBroadcasts(coin, network, data, null);
+        return this._handleThirdPartyBroadcasts(chain, network, data, null);
       }
 
       const walletId = address.walletId;
@@ -290,14 +290,14 @@ export class BlockchainMonitor {
     });
   }
 
-  _notifyNewBlock(coin, network, hash) {
-    logger.debug(` ** NOTIFY New ${coin}/${network} block ${hash}`);
+  _notifyNewBlock(chain, network, hash) {
+    logger.debug(` ** NOTIFY New ${chain}/${network} block ${hash}`);
     const notification = Notification.create({
       type: 'NewBlock',
-      walletId: `${coin}:${network}`, // use coin:network name as wallet id for global notifications
+      walletId: `${chain}:${network}`, // use chain:network name as wallet id for global notifications
       data: {
         hash,
-        coin,
+        chain,
         network
       }
     });
@@ -305,8 +305,8 @@ export class BlockchainMonitor {
     this._storeAndBroadcastNotification(notification, () => {});
   }
 
-  _handleTxConfirmations(coin, network, hash) {
-    if (!ChainService.notifyConfirmations(coin, network)) return;
+  _handleTxConfirmations(chain, network, hash) {
+    if (!ChainService.notifyConfirmations(chain, network)) return;
 
     const processTriggeredSubs = (subs, cb) => {
       async.mapSeries(
@@ -326,7 +326,7 @@ export class BlockchainMonitor {
                     isCreator: sub.isCreator,
                     data: {
                       txid: sub.txid,
-                      coin,
+                      chain,
                       network,
                       amount: sub.amount
                     }
@@ -344,7 +344,7 @@ export class BlockchainMonitor {
         cb
       );
     };
-    const explorer = this.explorers[coin][network];
+    const explorer = this.explorers[chain][network];
     if (!explorer) return;
 
     explorer.getTxidsInBlock(hash, (err, txids) => {
@@ -375,20 +375,20 @@ export class BlockchainMonitor {
     });
   }
 
-  _handleNewBlock(coin, network, hash) {
+  _handleNewBlock(chain, network, hash) {
     // clear height cache.
-    const cacheKey = Storage.BCHEIGHT_KEY + ':' + coin + ':' + network;
+    const cacheKey = Storage.BCHEIGHT_KEY + ':' + chain + ':' + network;
     this.storage.clearGlobalCache(cacheKey, () => {});
 
-    if (coin == 'xrp') {
+    if (chain == 'xrp') {
       return;
     }
 
     if (network == 'testnet') {
-      throttledNewBlocks(this, coin, network, hash);
+      throttledNewBlocks(this, chain, network, hash);
     } else {
-      this._notifyNewBlock(coin, network, hash);
-      this._handleTxConfirmations(coin, network, hash);
+      this._notifyNewBlock(chain, network, hash);
+      this._handleTxConfirmations(chain, network, hash);
     }
   }
 

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -891,7 +891,7 @@ export class BtcChain implements IChain {
     return true;
   }
 
-  isUTXOCoin() {
+  isUTXOChain() {
     return true;
   }
   isSingleAddress() {

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -69,7 +69,7 @@ export class EthChain implements IChain {
   }
 
   getWalletBalance(server, wallet, opts, cb) {
-    const bc = server._getBlockchainExplorer(wallet.coin, wallet.network);
+    const bc = server._getBlockchainExplorer(wallet.chain || wallet.coin, wallet.network);
 
     if (opts.tokenAddress) {
       wallet.tokenAddress = opts.tokenAddress;
@@ -383,7 +383,7 @@ export class EthChain implements IChain {
     return true;
   }
 
-  isUTXOCoin() {
+  isUTXOChain() {
     return false;
   }
   isSingleAddress() {
@@ -408,7 +408,7 @@ export class EthChain implements IChain {
       throw new Error('Signatures Required');
     }
 
-    const chain = 'ETH';
+    const chain = 'ETH'; // TODO use lowercase always to avoid confusion
     const unsignedTxs = tx.uncheckedSerialize();
     const signedTxs = [];
     for (let index = 0; index < signatures.length; index++) {
@@ -426,7 +426,7 @@ export class EthChain implements IChain {
   }
 
   validateAddress(wallet, inaddr, opts) {
-    const chain = 'ETH';
+    const chain = 'eth';
     const isValidTo = Validation.validateAddress(chain, wallet.network, inaddr);
     if (!isValidTo) {
       throw Errors.INVALID_ADDRESS;

--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -82,10 +82,12 @@ class ChainProxy {
     return chains[normalizedChain];
   }
 
-  // only used for backwards compatibility
+  /**
+   * @deprecated
+   */
   getChain(coin: string): string {
     try {
-      // TODO add a warning that we are not uncluding chain
+      // TODO add a warning that we are not including chain
       let normalizedChain = coin.toLowerCase();
       if (
         Constants.BITPAY_SUPPORTED_ERC20[coin.toUpperCase()] ||

--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -9,6 +9,7 @@ import { XrpChain } from './xrp';
 
 const Common = require('../common');
 const Constants = Common.Constants;
+const Defaults = Common.Defaults;
 
 export interface INotificationData {
   out: {
@@ -47,7 +48,7 @@ export interface IChain {
   selectTxInputs(server: WalletService, txp: ITxProposal, wallet: IWallet, opts: { utxosToExclude: any[] } & any, cb);
   checkUtxos(opts: { fee: number; inputs: any[] });
   checkValidTxAmount(output): boolean;
-  isUTXOCoin(): boolean;
+  isUTXOChain(): boolean;
   isSingleAddress(): boolean;
   supportsMultisig(): boolean;
   notifyConfirmations(network: string): boolean;
@@ -66,7 +67,7 @@ export interface IChain {
   onTx(tx: any): INotificationData | null;
 }
 
-const chain: { [chain: string]: IChain } = {
+const chains: { [chain: string]: IChain } = {
   BTC: new BtcChain(),
   BCH: new BchChain(),
   ETH: new EthChain(),
@@ -76,61 +77,70 @@ const chain: { [chain: string]: IChain } = {
 };
 
 class ChainProxy {
-  get(coin: string) {
-    const normalizedChain = this.getChain(coin);
-    return chain[normalizedChain];
+  get(chain: string) {
+    const normalizedChain = chain.toUpperCase();
+    return chains[normalizedChain];
   }
 
+  // only used for backwards compatibility
   getChain(coin: string): string {
-    let normalizedChain = coin.toUpperCase();
-    if (Constants.ERC20[normalizedChain]) {
-      normalizedChain = 'ETH';
+    try {
+      // TODO add a warning that we are not uncluding chain
+      let normalizedChain = coin.toLowerCase();
+      if (
+        Constants.BITPAY_SUPPORTED_ERC20[coin.toUpperCase()] ||
+        !Constants.BITPAY_SUPPORTED_COINS[coin.toUpperCase()]
+      ) {
+        normalizedChain = 'eth';
+      }
+      return normalizedChain;
+    } catch (err) {
+      return Defaults.CHAIN; // coin should always exist but most unit test don't have it -> return btc as default
     }
-    return normalizedChain;
   }
 
   getWalletBalance(server, wallet, opts, cb) {
-    return this.get(wallet.coin).getWalletBalance(server, wallet, opts, cb);
+    return this.get(wallet.chain).getWalletBalance(server, wallet, opts, cb);
   }
 
   getWalletSendMaxInfo(server, wallet, opts, cb) {
-    return this.get(wallet.coin).getWalletSendMaxInfo(server, wallet, opts, cb);
+    return this.get(wallet.chain).getWalletSendMaxInfo(server, wallet, opts, cb);
   }
 
-  getDustAmountValue(coin) {
-    return this.get(coin).getDustAmountValue();
+  getDustAmountValue(chain) {
+    return this.get(chain).getDustAmountValue();
   }
 
   getTransactionCount(server, wallet, from) {
-    return this.get(wallet.coin).getTransactionCount(server, wallet, from);
+    return this.get(wallet.chain).getTransactionCount(server, wallet, from);
   }
 
   getChangeAddress(server, wallet, opts) {
-    return this.get(wallet.coin).getChangeAddress(server, wallet, opts);
+    return this.get(wallet.chain).getChangeAddress(server, wallet, opts);
   }
 
-  checkDust(coin, output, opts) {
-    return this.get(coin).checkDust(output, opts);
+  checkDust(chain, output, opts) {
+    return this.get(chain).checkDust(output, opts);
   }
 
   getFee(server, wallet, opts) {
-    return this.get(wallet.coin).getFee(server, wallet, opts);
+    return this.get(wallet.chain).getFee(server, wallet, opts);
   }
 
   getBitcoreTx(txp: TxProposal, opts = { signed: true }) {
     return this.get(txp.chain).getBitcoreTx(txp, { signed: opts.signed });
   }
 
-  convertFeePerKb(coin, p, feePerKb) {
-    return this.get(coin).convertFeePerKb(p, feePerKb);
+  convertFeePerKb(chain, p, feePerKb) {
+    return this.get(chain).convertFeePerKb(p, feePerKb);
   }
 
-  addressToStorageTransform(coin, network, address) {
-    return this.get(coin).addressToStorageTransform(network, address);
+  addressToStorageTransform(chain, network, address) {
+    return this.get(chain).addressToStorageTransform(network, address);
   }
 
-  addressFromStorageTransform(coin, network, address) {
-    return this.get(coin).addressFromStorageTransform(network, address);
+  addressFromStorageTransform(chain, network, address) {
+    return this.get(chain).addressFromStorageTransform(network, address);
   }
 
   checkTx(server, txp) {
@@ -145,28 +155,28 @@ class ChainProxy {
     return this.get(txp.chain).selectTxInputs(server, txp, wallet, opts, cb);
   }
 
-  checkUtxos(coin, opts) {
-    return this.get(coin).checkUtxos(opts);
+  checkUtxos(chain, opts) {
+    return this.get(chain).checkUtxos(opts);
   }
 
-  checkValidTxAmount(coin: string, output): boolean {
-    return this.get(coin).checkValidTxAmount(output);
+  checkValidTxAmount(chain: string, output): boolean {
+    return this.get(chain).checkValidTxAmount(output);
   }
 
-  isUTXOCoin(coin: string): boolean {
-    return this.get(coin).isUTXOCoin();
+  isUTXOChain(chain: string): boolean {
+    return this.get(chain).isUTXOChain();
   }
 
-  isSingleAddress(coin: string): boolean {
-    return this.get(coin).isSingleAddress();
+  isSingleAddress(chain: string): boolean {
+    return this.get(chain).isSingleAddress();
   }
 
-  notifyConfirmations(coin: string, network: string): boolean {
-    return this.get(coin).notifyConfirmations(network);
+  notifyConfirmations(chain: string, network: string): boolean {
+    return this.get(chain).notifyConfirmations(network);
   }
 
-  supportsMultisig(coin: string): boolean {
-    return this.get(coin).supportsMultisig();
+  supportsMultisig(chain: string): boolean {
+    return this.get(chain).supportsMultisig();
   }
 
   addSignaturesToBitcoreTx(chain, tx, inputs, inputPaths, signatures, xpub, signingMethod) {
@@ -174,15 +184,15 @@ class ChainProxy {
   }
 
   validateAddress(wallet, inaddr, opts) {
-    return this.get(wallet.coin).validateAddress(wallet, inaddr, opts);
+    return this.get(wallet.chain).validateAddress(wallet, inaddr, opts);
   }
 
-  onCoin(coin: string, coinData: any) {
-    return this.get(coin).onCoin(coinData);
+  onCoin(chain: string, coinData: any) {
+    return this.get(chain).onCoin(coinData);
   }
 
-  onTx(coin: string, tx: any) {
-    return this.get(coin).onTx(tx);
+  onTx(chain: string, tx: any) {
+    return this.get(chain).onTx(tx);
   }
 }
 

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -48,7 +48,7 @@ export class XrpChain implements IChain {
   }
 
   getWalletBalance(server, wallet, opts, cb) {
-    const bc = server._getBlockchainExplorer(wallet.coin, wallet.network);
+    const bc = server._getBlockchainExplorer(wallet.chain || wallet.coin, wallet.network);
     bc.getBalance(wallet, (err, balance) => {
       if (err) {
         return cb(err);
@@ -209,7 +209,7 @@ export class XrpChain implements IChain {
     return true;
   }
 
-  isUTXOCoin() {
+  isUTXOChain() {
     return false;
   }
   isSingleAddress() {
@@ -234,7 +234,7 @@ export class XrpChain implements IChain {
       throw new Error('Signatures Required');
     }
 
-    const chain = 'XRP';
+    const chain = 'XRP'; // TODO use lowercase always to avoid confusion
     const network = tx.network;
     const unsignedTxs = tx.uncheckedSerialize();
     const signedTxs = [];
@@ -257,7 +257,7 @@ export class XrpChain implements IChain {
   }
 
   validateAddress(wallet, inaddr, opts) {
-    const chain = 'XRP';
+    const chain = 'xrp';
     const isValidTo = Validation.validateAddress(chain, wallet.network, inaddr);
     if (!isValidTo) {
       throw Errors.INVALID_ADDRESS;

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -14,7 +14,7 @@ module.exports = {
   // TODO rethink COINS. If we want to concatenate CHAINS + ERC20's, we can do that in the implementation.
   // In the future, ERC20 "coins" may not be specific to ETH, so inferring that a USDC coin is on ETH (for example) may be incorrect.
   // Perhaps, this should be a nested object, with there being coins nested inside smart chains.
-  COINS: {
+  BITPAY_SUPPORTED_COINS: {
     BTC: 'btc',
     BCH: 'bch',
     ETH: 'eth',
@@ -32,7 +32,7 @@ module.exports = {
     EUROC: 'euroc'
   },
 
-  ERC20: {
+  BITPAY_SUPPORTED_ERC20: {
     USDC: 'usdc',
     PAX: 'pax',
     GUSD: 'gusd',
@@ -44,7 +44,7 @@ module.exports = {
     EUROC: 'euroc'
   },
 
-  USD_STABLECOINS: {
+  BITPAY_USD_STABLECOINS: {
     USDC: 'usdc',
     PAX: 'pax',
     GUSD: 'gusd',
@@ -52,15 +52,19 @@ module.exports = {
     DAI: 'dai'
   },
 
-  EUR_STABLECOINS: {
+  BITPAY_EUR_STABLECOINS: {
     EUROC: 'euroc'
   },
 
-  UTXO_COINS: {
+  UTXO_CHAINS: {
     BTC: 'btc',
     BCH: 'bch',
     DOGE: 'doge',
     LTC: 'ltc'
+  },
+
+  EVM_CHAINS: {
+    ETH: 'eth'
   },
 
   NETWORKS: {

--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -203,8 +203,10 @@ module.exports = {
     //   max: 1200 , // 1 post every 3 sec average, max.
     // },
   },
-
   COIN: 'btc',
+  EVM_COIN: 'eth',
+  CHAIN: 'btc',
+  EVM_CHAIN: 'eth',
   INSIGHT_REQUEST_POOL_SIZE: 10,
   INSIGHT_TIMEOUT: 30000,
 

--- a/packages/bitcore-wallet-service/src/lib/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/emailservice.ts
@@ -281,7 +281,7 @@ export class EmailService {
       }
 
       if (_.includes(['NewIncomingTx', 'NewOutgoingTx'], notification.type) && data.txid) {
-        const urlTemplate = this.publicTxUrlTemplate[wallet.coin][wallet.network];
+        const urlTemplate = this.publicTxUrlTemplate[wallet.coin][wallet.network]; // TODO ERC20
         if (urlTemplate) {
           try {
             data.urlForTx = Mustache.render(urlTemplate, data);

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -893,9 +893,10 @@ export class ExpressApp {
     });
 
     router.get('/v2/feelevels/', (req, res) => {
-      const opts: { coin?: string; network?: string } = {};
+      const opts: { coin?: string; network?: string; chain?: string } = {};
       SetPublicCache(res, 1 * ONE_MINUTE);
       if (req.query.coin) opts.coin = req.query.coin;
+      if (req.query.chain || req.query.coin) opts.chain = req.query.chain || req.query.coin;
       if (req.query.network) opts.network = req.query.network;
 
       let server;

--- a/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
@@ -162,7 +162,7 @@ export class FiatRateService {
     const currencies: { code: string; name: string }[] = fiatFiltered.length ? fiatFiltered : Defaults.FIAT_CURRENCIES;
 
     async.map(
-      _.values(Constants.COINS),
+      _.values(Constants.BITPAY_SUPPORTED_COINS),
       (coin, cb) => {
         rates[coin] = [];
         async.map(
@@ -206,11 +206,11 @@ export class FiatRateService {
     let { coin, code } = opts;
     const ts = opts.ts || Date.now();
 
-    if (Constants.USD_STABLECOINS[coin.toUpperCase()]) {
+    if (Constants.BITPAY_USD_STABLECOINS[coin.toUpperCase()]) {
       return this.getRatesForStablecoin({ code: 'USD', ts }, cb);
     }
 
-    if (Constants.EUR_STABLECOINS[coin.toUpperCase()]) {
+    if (Constants.BITPAY_EUR_STABLECOINS[coin.toUpperCase()]) {
       return this.getRatesForStablecoin({ code: 'EUR', ts }, cb);
     }
 

--- a/packages/bitcore-wallet-service/src/lib/model/address.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/address.ts
@@ -1,5 +1,6 @@
 import { Deriver } from 'crypto-wallet-core';
 import _ from 'lodash';
+import { ChainService } from '../chain/index';
 import { AddressManager } from './addressmanager';
 
 const $ = require('preconditions').singleton();
@@ -18,6 +19,7 @@ export interface IAddress {
   path: string;
   publicKeys: string[];
   coin: string;
+  chain: string;
   network: string;
   type: string;
   hasActivity: boolean;
@@ -34,6 +36,7 @@ export class Address {
   path: string;
   publicKeys: string[];
   coin: string;
+  chain: string;
   network: string;
   type: string;
   hasActivity: boolean;
@@ -51,7 +54,8 @@ export class Address {
 
     const x = new Address();
 
-    $.checkArgument(Utils.checkValueInCollection(opts.coin, Constants.COINS));
+    opts.chain = opts.chain || ChainService.getChain(opts.coin); // getChain -> backwards compatibility
+    $.checkArgument(Utils.checkValueInCollection(opts.chain, Constants.CHAINS));
 
     x.version = '1.0.0';
     x.createdOn = Math.floor(Date.now() / 1000);
@@ -62,8 +66,9 @@ export class Address {
     x.path = opts.path;
     x.publicKeys = opts.publicKeys;
     x.coin = opts.coin;
-    x.network = Address.Bitcore[opts.coin]
-      ? Address.Bitcore[opts.coin].Address(x.address).toObject().network
+    x.chain = opts.chain;
+    x.network = Address.Bitcore[opts.chain]
+      ? Address.Bitcore[opts.chain].Address(x.address).toObject().network
       : opts.network;
     x.type = opts.type || Constants.SCRIPT_TYPES.P2SH;
     x.hasActivity = undefined;
@@ -79,6 +84,7 @@ export class Address {
     x.address = obj.address;
     x.walletId = obj.walletId;
     x.coin = obj.coin || Defaults.COIN;
+    x.chain = obj.chain || ChainService.getChain(x.coin);
     x.network = obj.network;
     x.isChange = obj.isChange;
     x.isEscrow = obj.isEscrow;
@@ -90,12 +96,12 @@ export class Address {
     return x;
   }
 
-  static _deriveAddress(scriptType, publicKeyRing, path, m, coin, network, noNativeCashAddr, escrowInputs?) {
+  static _deriveAddress(scriptType, publicKeyRing, path, m, chain, network, noNativeCashAddr, escrowInputs?) {
     $.checkArgument(Utils.checkValueInCollection(scriptType, Constants.SCRIPT_TYPES));
 
     let publicKeys = _.map(publicKeyRing, item => {
-      const xpub = Address.Bitcore[coin]
-        ? new Address.Bitcore[coin].HDPublicKey(item.xPubKey)
+      const xpub = Address.Bitcore[chain]
+        ? new Address.Bitcore[chain].HDPublicKey(item.xPubKey)
         : new Address.Bitcore.btc.HDPublicKey(item.xPubKey);
       return xpub.deriveChild(path).publicKey;
     });
@@ -104,7 +110,7 @@ export class Address {
     switch (scriptType) {
       case Constants.SCRIPT_TYPES.P2WSH:
         const nestedWitness = false;
-        bitcoreAddress = Address.Bitcore[coin].Address.createMultisig(
+        bitcoreAddress = Address.Bitcore[chain].Address.createMultisig(
           publicKeys,
           m,
           network,
@@ -114,16 +120,16 @@ export class Address {
         break;
       case Constants.SCRIPT_TYPES.P2SH:
         if (escrowInputs) {
-          var xpub = new Address.Bitcore[coin].HDPublicKey(publicKeyRing[0].xPubKey);
+          var xpub = new Address.Bitcore[chain].HDPublicKey(publicKeyRing[0].xPubKey);
           const inputPublicKeys = escrowInputs.map(input => xpub.deriveChild(input.path).publicKey);
-          bitcoreAddress = Address.Bitcore[coin].Address.createEscrow(inputPublicKeys, publicKeys[0], network);
+          bitcoreAddress = Address.Bitcore[chain].Address.createEscrow(inputPublicKeys, publicKeys[0], network);
           publicKeys = [publicKeys[0], ...inputPublicKeys];
         } else {
-          bitcoreAddress = Address.Bitcore[coin].Address.createMultisig(publicKeys, m, network);
+          bitcoreAddress = Address.Bitcore[chain].Address.createMultisig(publicKeys, m, network);
         }
         break;
       case Constants.SCRIPT_TYPES.P2WPKH:
-        bitcoreAddress = Address.Bitcore[coin].Address.fromPublicKey(publicKeys[0], network, 'witnesspubkeyhash');
+        bitcoreAddress = Address.Bitcore[chain].Address.fromPublicKey(publicKeys[0], network, 'witnesspubkeyhash');
         break;
       case Constants.SCRIPT_TYPES.P2PKH:
         $.checkState(
@@ -131,18 +137,18 @@ export class Address {
           'Failed state: publicKeys length < 1 or publicKeys not an array at <_deriveAddress()>'
         );
 
-        if (Address.Bitcore[coin]) {
-          bitcoreAddress = Address.Bitcore[coin].Address.fromPublicKey(publicKeys[0], network);
+        if (Address.Bitcore[chain]) {
+          bitcoreAddress = Address.Bitcore[chain].Address.fromPublicKey(publicKeys[0], network);
         } else {
           const { addressIndex, isChange } = new AddressManager().parseDerivationPath(path);
           const [{ xPubKey }] = publicKeyRing;
-          bitcoreAddress = Deriver.deriveAddress(coin.toUpperCase(), network, xPubKey, addressIndex, isChange);
+          bitcoreAddress = Deriver.deriveAddress(chain.toUpperCase(), network, xPubKey, addressIndex, isChange);
         }
         break;
     }
 
     let addrStr = bitcoreAddress.toString(true);
-    if (noNativeCashAddr && coin == 'bch') {
+    if (noNativeCashAddr && chain == 'bch') {
       addrStr = bitcoreAddress.toLegacyAddress();
     }
 
@@ -164,6 +170,7 @@ export class Address {
     coin,
     network,
     isChange,
+    chain,
     noNativeCashAddr = false,
     escrowInputs?
   ) {
@@ -172,7 +179,7 @@ export class Address {
       publicKeyRing,
       path,
       m,
-      coin,
+      chain || ChainService.getChain(coin), // getChain -> backwards compatibility
       network,
       noNativeCashAddr,
       escrowInputs
@@ -180,6 +187,7 @@ export class Address {
     return Address.create(
       _.extend(raw, {
         coin,
+        chain,
         network,
         walletId,
         type: scriptType,

--- a/packages/bitcore-wallet-service/src/lib/model/copayer.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/copayer.ts
@@ -28,6 +28,7 @@ export class Copayer {
   version: number;
   createdOn: number;
   coin: string;
+  chain: string;
   xPubKey: string;
   id: string;
   name: string;
@@ -52,7 +53,7 @@ export class Copayer {
       .checkArgument(opts.requestPubKey, 'Missing copayer request public key')
       .checkArgument(opts.signature, 'Missing copayer request public key signature');
 
-    $.checkArgument(Utils.checkValueInCollection(opts.coin, Constants.COINS));
+    $.checkArgument(Utils.checkValueInCollection(opts.coin, Constants.CHAINS));
 
     opts.copayerIndex = opts.copayerIndex || 0;
 
@@ -92,6 +93,7 @@ export class Copayer {
     x.version = obj.version;
     x.createdOn = obj.createdOn;
     x.coin = obj.coin || Defaults.COIN;
+    x.chain = obj.chain || x.coin;
     x.id = obj.id;
     x.name = obj.name;
     x.xPubKey = obj.xPubKey;
@@ -130,7 +132,8 @@ export class Copayer {
       wallet.m,
       wallet.coin,
       wallet.network,
-      isChange
+      isChange,
+      wallet.chain
     );
     return address;
   }

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -242,7 +242,7 @@ export class TxProposal {
     x.walletId = obj.walletId;
     x.creatorId = obj.creatorId;
     x.coin = obj.coin || Defaults.COIN;
-    x.chain = obj.chain ? obj.chain : ChainService.getChain(x.coin);
+    x.chain = obj.chain?.toLowerCase() || ChainService.getChain(x.coin); // getChain -> backwards compatibility
     x.network = obj.network;
     x.outputs = obj.outputs;
     x.amount = obj.amount;

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -162,7 +162,7 @@ export class TxProposal {
     x.walletId = opts.walletId;
     x.creatorId = opts.creatorId;
     x.coin = opts.coin;
-    x.chain = opts.chain;
+    x.chain = opts.chain?.toLowerCase() || ChainService.getChain(x.coin); // getChain -> backwards compatibility
     x.network = opts.network;
     x.signingMethod = opts.signingMethod;
     x.message = opts.message;

--- a/packages/bitcore-wallet-service/src/lib/pushnotificationsservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/pushnotificationsservice.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import 'source-map-support/register';
 
 import request from 'request';
+import { ChainService } from './chain';
 import logger from './logger';
 import { MessageBroker } from './messagebroker';
 import { INotification, IPreferences } from './model';
@@ -210,8 +211,9 @@ export class PushNotificationsService {
                 const walletId = sjcl.codec.hex.fromBits(sjcl.hash.sha256.hash(notification.walletId || sub.walletId));
                 const copayerId = sjcl.codec.hex.fromBits(sjcl.hash.sha256.hash(sub.copayerId));
                 const notification_type = notification.type;
-                // coin and network are needed for NewBlock notifications
-                const coin = notification?.data?.coin;
+                // chain and network are needed for NewBlock notifications
+                const chain = notification?.data?.chain || notification?.data?.coin;
+                const coin = chain; // backwards compatibility
                 const network = notification?.data?.network;
 
                 if (sub.token) {
@@ -225,7 +227,8 @@ export class PushNotificationsService {
                       multisigContractAddress,
                       copayerId,
                       notification_type,
-                      coin,
+                      coin, // not really coin value it's chain
+                      chain,
                       network
                     }
                   };
@@ -250,14 +253,15 @@ export class PushNotificationsService {
                     walletId,
                     copayerId,
                     notification_type,
-                    coin,
+                    coin, // not really coin value it's chain
+                    chain,
                     network,
                     tokenAddress,
                     multisigContractAddress,
                     title,
                     body
                   };
-                  const custom_uri = `bitpay://wallet?walletId=${walletId}&tokenAddress=${tokenAddress}&multisigContractAddress=${multisigContractAddress}&copayerId=${copayerId}&coin=${coin}&network=${network}&notification_type=${notification_type}&title=${title}&body=${body}`;
+                  const custom_uri = `bitpay://wallet?walletId=${walletId}&tokenAddress=${tokenAddress}&multisigContractAddress=${multisigContractAddress}&copayerId=${copayerId}&coin=${coin}&chain=${chain}&network=${network}&notification_type=${notification_type}&title=${title}&body=${body}`;
                   notificationData = {
                     external_user_ids: [sub.externalUserId],
                     messages: {
@@ -595,7 +599,9 @@ export class PushNotificationsService {
         // avoid multiple notifications
         const allSubs = allSubsWithExternalId.length > 0 ? allSubsWithExternalId : allSubsWithToken;
         logger.info(
-          `Sending ${notification.type} [${notification.data.coin}/${notification.data.network}] notifications to: ${allSubs.length} devices`
+          `Sending ${notification.type} [${notification.data.chain || notification.data.coin}/${
+            notification.data.network
+          }] notifications to: ${allSubs.length} devices`
         );
         return cb(null, allSubs);
       });

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -834,7 +834,7 @@ export class Storage {
       });
   }
 
-  fetchAddressByCoin(coin, address, cb) {
+  fetchAddressByChain(chain, address, cb) {
     if (!this.db) return cb();
 
     this.db
@@ -847,7 +847,7 @@ export class Storage {
         if (!result || _.isEmpty(result)) return cb();
         if (result.length > 1) {
           result = _.find(result, address => {
-            return coin == (address.coin || 'btc');
+            return chain == (address.chain || address.coin || 'btc');
           });
         } else {
           result = _.head(result);

--- a/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
+++ b/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
@@ -530,7 +530,7 @@ describe('Fiat rate service', function() {
     it('should get the rates of all coins supported', function(done) {
       service.getRates({}, function(err, res) {
         should.not.exist(err);
-        Object.keys(res).length.should.equal( Object.keys(Constants.COINS).length)
+        Object.keys(res).length.should.equal( Object.keys(Constants.BITPAY_SUPPORTED_COINS).length)
         done();
       });
     });
@@ -539,7 +539,7 @@ describe('Fiat rate service', function() {
           code: 'EUR'
         }, function(err, res) {
           should.not.exist(err);
-          Object.keys(res).length.should.equal( Object.keys(Constants.COINS).length)
+          Object.keys(res).length.should.equal( Object.keys(Constants.BITPAY_SUPPORTED_COINS).length)
           Object.keys(res).forEach(key=>{
             res[key].length.should.equal(1);
           })

--- a/packages/bitcore-wallet-service/test/integration/helpers.js
+++ b/packages/bitcore-wallet-service/test/integration/helpers.js
@@ -596,7 +596,7 @@ helpers.clientSign = function(txp, derivedXPrivKey) {
       signatures = [];
       for (const rawTx of tx) {
         const signed = CWC.Transactions.getSignature({
-          chain,
+          chain: chain.toUpperCase(),
           tx: rawTx,
           key: { privKey: privKey.toString('hex') },
         });

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -4719,7 +4719,7 @@ describe('Wallet service', function() {
         describe('Fee levels', function() {
           var level, expected, expectedNormal;
           before(() => {
-            if (Constants.UTXO_COINS[coin.toUpperCase()]) {
+            if (Constants.UTXO_CHAINS[coin.toUpperCase()]) {
               const normal = coin == 'doge' ? 1e8: 200e2;   // normal BCH, DOGE
               helpers.stubFeeLevels({
                 1: 400e2,
@@ -5435,7 +5435,7 @@ describe('Wallet service', function() {
       });
     });
 
-    if(Constants.UTXO_COINS[coin.toUpperCase()]) {
+    if(Constants.UTXO_CHAINS[coin.toUpperCase()]) {
       describe('UTXO Selection ' + coin, function() {
         var server, wallet;
         beforeEach(function(done) {

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -1033,7 +1033,7 @@ describe('Wallet service', function() {
         });
         server.joinWallet(copayerOpts, function(err) {
           should.exist(err);
-          err.message.should.contain('different coin');
+          err.message.should.contain('different chain');
           done();
         });
       });


### PR DESCRIPTION
- stop using `coin` when it really means `chain`
- `chain` always lowercase
- REF `COINS`, `ERC20`, `USD_STABLECOINS` and `EUR_STABLECOINS`, constants -> replaced by `BITPAY_SUPPORTED_COINS`, `BITPAY_SUPPORTED_ERC20`, `BITPAY_USD_STABLECOINS` and `BITPAY_EUR_STABLECOINS` ( only used for getting bitpay rates )
- Always get bitcore libs using `chain` -> `Bitcore_[chain]`
- Keep `Utils` `getChain` function only for backwards compatibility
- Add `chain` to : address, copayer and wallet models 
- Use lowercase `chain` in txproposal model 