### PR TITLE
add check for  undefined value

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/emailservice.ts
@@ -326,7 +326,7 @@ export class EmailService {
       }
 
       if (_.includes(['NewIncomingTx', 'NewOutgoingTx'], notification.type) && data.txid) {
-        const urlTemplate = this.publicTxUrlTemplate[wallet.chain][wallet.network];
+        const urlTemplate = this.publicTxUrlTemplate[wallet.chain]?.[wallet.network];
         if (urlTemplate) {
           try {
             data.urlForTx = Mustache.render(urlTemplate, data);

--- a/packages/bitcore-wallet-service/src/lib/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/emailservice.ts
@@ -333,6 +333,8 @@ export class EmailService {
           } catch (ex) {
             logger.warn('Could not render public url for tx', ex);
           }
+        } else {
+          logger.warn(`Could not find template for chain "${wallet.chain}" on network "${wallet.network}"`);
         }
       }
 


### PR DESCRIPTION
Making sure that `this.publicTxUrlTemplate[wallet.chain]` exists before attempting to get wallet.network. 