### PR TITLE
Fix: convert a scientific notation to Number if necessary

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -377,6 +377,10 @@ export class EthChain implements IChain {
   checkUtxos(opts) {}
 
   checkValidTxAmount(output): boolean {
+    if (_.isString(output.amount)) {
+      // Convert a scientific notation as string to Number if necessary
+      output.amount = Number(output.amount);
+    }
     if (!_.isNumber(output.amount) || _.isNaN(output.amount) || output.amount < 0) {
       return false;
     }


### PR DESCRIPTION
For some reason, BWS receives `outputs.amount` as string if it's a scientific notation (big number like 1e+21). 

This PR check if it's a string and try to convert to `Number`.

It doesn't happen on these versions of node running my own BWS local: v12.22.8 and v16.15.1. 

Error

```
{"message":"Client Err: 400 /v3/txproposals/ {\"code\":\"BADREQUEST\",\"message\":\"Invalid amount\",\"name\":\"BADREQUEST\"}","level":"info"}
```

Only happens on production.