### PR TITLE
Fix: use type of Number for amount

### DIFF
--- a/packages/crypto-wallet-core/src/transactions/erc20/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/erc20/index.ts
@@ -12,7 +12,7 @@ export class ERC20TxProvider extends ETHTxProvider {
   }
 
   create(params: {
-    recipients: Array<{ address: string; amount: string }>;
+    recipients: Array<{ address: string; amount: number }>;
     nonce: number;
     gasPrice: number;
     data: string;
@@ -24,13 +24,13 @@ export class ERC20TxProvider extends ETHTxProvider {
   }) {
     const { tokenAddress, contractAddress } = params;
     const data = this.encodeData(params);
-    const recipients = [{ address: contractAddress || tokenAddress, amount: '0' }];
+    const recipients = [{ address: contractAddress || tokenAddress, amount: 0 }];
     const newParams = { ...params, recipients, data };
     return super.create(newParams);
   }
 
   encodeData(params: {
-    recipients: Array<{ address: string; amount: string }>;
+    recipients: Array<{ address: string; amount: number }>;
     tokenAddress: string;
     contractAddress?: string;
   }) {

--- a/packages/crypto-wallet-core/src/transactions/eth-multisig/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth-multisig/index.ts
@@ -11,7 +11,7 @@ export class ETHMULTISIGTxProvider extends ETHTxProvider {
   }
 
   create(params: {
-    recipients: Array<{ address: string; amount: string }>;
+    recipients: Array<{ address: string; amount: number }>;
     nonce: number;
     gasPrice: number;
     data: string;
@@ -21,7 +21,7 @@ export class ETHMULTISIGTxProvider extends ETHTxProvider {
     chainId?: number;
   }) {
     const { multisigContractAddress } = params;
-    const recipients = [{ address: multisigContractAddress, amount: '0' }];
+    const recipients = [{ address: multisigContractAddress, amount: 0 }];
     const newParams = { ...params, recipients };
     return super.create(newParams);
   }

--- a/packages/crypto-wallet-core/src/transactions/eth/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/eth/index.ts
@@ -7,7 +7,7 @@ const utils = require('web3-utils');
 const { toBN } = Web3.utils;
 export class ETHTxProvider {
   create(params: {
-    recipients: Array<{ address: string; amount: string }>;
+    recipients: Array<{ address: string; amount: number }>;
     nonce: number;
     gasPrice: number;
     data: string;


### PR DESCRIPTION
For testing, it's using a number as amount:

https://github.com/bitpay/bitcore/blob/0eb0a014d50868aeb40aac8aacbbc0549a525f47/packages/crypto-wallet-core/test/transactions.ts#L334 

```
const recipients = [{ address: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A', amount: 3896000000000000 }];
```