### PR TITLE
Fix: validate TX amount if BN for ETH only

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -377,10 +377,20 @@ export class EthChain implements IChain {
   checkUtxos(opts) {}
 
   checkValidTxAmount(output): boolean {
-    if (!_.isNumber(output.amount) || _.isNaN(output.amount) || output.amount < 0) {
+    try {
+      if (
+        output.amount == null ||
+        output.amount < 0 ||
+        isNaN(output.amount) ||
+        Web3.utils.toBN(output.amount).toString() !== output.amount.toString()
+      ) {
+        throw new Error('output.amount is not a valid value: ' + output.amount);
+      }
+      return true;
+    } catch (err) {
+      logger.warn(`Invalid output amount (${output.amount}) in checkValidTxAmount. Err: ${err.message}`);
       return false;
     }
-    return true;
   }
 
   isUTXOChain() {


### PR DESCRIPTION
This PR fix issue when sending amount with more than 18 digits in BN format.

https://github.com/bitpay/bitpay-app/pull/425

```
{"message":"Client Err: 400 /v3/txproposals/ {\"code\":\"BADREQUEST\",\"message\":\"Invalid amount\",\"name\":\"BADREQUEST\"}","level":"info"}
```