### PR TITLE
[FIX] missing coins in rates list

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
@@ -168,7 +168,7 @@ export class FiatRateService {
         async.map(
           currencies,
           (currency, cb) => {
-            let c = coin;
+            let c = coin.split('_')[0];
             if (coin === 'wbtc_e' || coin === 'wbtc_m') {
               logger.info('Using btc for wbtc rate.');
               c = 'btc';


### PR DESCRIPTION
Ape and Shib rates are missing in the app.

`BITPAY_SUPPORTED_COINS` constant should include all coins from `fiatrateservice.ts` line 60 list ( those are the actual coins we store using bitpay rates endpoint )

`const coins = ['btc', 'bch', 'eth', 'matic', 'xrp', 'doge', 'ltc', 'shib', 'ape'];`