### PR TITLE
Bug fix for non-archive node block syncing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,5 +76,6 @@ COPY  ./packages/bitcore-p2p-doge/package-lock.json ./packages/bitcore-p2p-doge/
 
 
 RUN npm install
+RUN npm run bootstrap
 ADD . .
 RUN npm run compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,5 @@ COPY  ./packages/bitcore-p2p-doge/package-lock.json ./packages/bitcore-p2p-doge/
 
 
 RUN npm install
-RUN npm run bootstrap
 ADD . .
 RUN npm run compile

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/p2p.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/p2p.ts
@@ -295,7 +295,7 @@ export class EVMP2pWorker extends BaseP2PWorker<IEVMBlock> {
         }
       }
     } catch (err) {
-      logger.error(`Error syncing ${chain} ${network}`, err.message);
+      logger.error(`Error syncing ${chain} ${network} -- ${err.message || err}`);
       await wait(2000);
       this.syncing = false;
       return this.sync();

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -36,7 +36,7 @@ export class GethRPC implements IRpc {
   }
 
   public getBlock(blockNumber: number): Promise<GethBlock> {
-    return this.web3.eth.getBlock(blockNumber, true) as unknown as Promise<GethBlock>;
+    return (this.web3.eth.getBlock(blockNumber, true) as unknown) as Promise<GethBlock>;
   }
 
   private async traceBlock(blockNumber: number): Promise<IGethTxTraceResponse[]> {
@@ -44,8 +44,8 @@ export class GethRPC implements IRpc {
       method: 'debug_traceBlockByNumber',
       params: [this.web3.utils.toHex(blockNumber), { tracer: 'callTracer' }],
       jsonrpc: '2.0',
-      id: 1,
-    }).catch((err) => {
+      id: 1
+    }).catch(err => {
       if (err.message && err.message == 'The method debug_traceBlockByNumber does not exist/is not available') {
         // Must not be an archive node
         logger.debug(err.message);
@@ -59,14 +59,14 @@ export class GethRPC implements IRpc {
 
   public async getTransactionsFromBlock(blockNumber: number): Promise<IGethTxTrace[]> {
     const tracedTxs = await this.traceBlock(blockNumber);
-    const txs = tracedTxs && tracedTxs.length > 0 ? tracedTxs.filter((tx) => tx.result) : [];
-    return txs.map((tx) => this.transactionFromGethTrace(tx));
+    const txs = tracedTxs && tracedTxs.length > 0 ? tracedTxs.filter(tx => tx.result) : [];
+    return txs.map(tx => this.transactionFromGethTrace(tx));
   }
 
   public send<T>(data: IJsonRpcRequest) {
     return new Promise<T>((resolve, reject) => {
       const provider = this.web3.eth.currentProvider as any;
-      provider.send(data, function (err, data) {
+      provider.send(data, function(err, data) {
         if (err || data.error) return reject(err || data.error);
         resolve(data.result as T);
       } as Callback<IJsonRpcResponse>);

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -40,20 +40,22 @@ export class GethRPC implements IRpc {
   }
 
   private async traceBlock(blockNumber: number): Promise<IGethTxTraceResponse[]> {
-    const result = await this.send<IGethTxTraceResponse[]>({
-      method: 'debug_traceBlockByNumber',
-      params: [this.web3.utils.toHex(blockNumber), { tracer: 'callTracer' }],
-      jsonrpc: '2.0',
-      id: 1
-    }).catch(err => {
-      if (err.message && err.message == 'The method debug_traceBlockByNumber does not exist/is not available') {
+    let result = [] as IGethTxTraceResponse[];
+    try {
+      result = await this.send<IGethTxTraceResponse[]>({
+        method: 'debug_traceBlockByNumber',
+        params: [this.web3.utils.toHex(blockNumber), { tracer: 'callTracer' }],
+        jsonrpc: '2.0',
+        id: 1
+      });
+    } catch (e) {
+      if (e.message && e.message == 'The method debug_traceBlockByNumber does not exist/is not available') {
         // Must not be an archive node
-        logger.debug(err.message);
+        logger.debug(e.message);
       } else {
-        logger.error(err.message || err);
+        logger.error(e.message || e);
       }
-      return [];
-    });
+    }
     return result;
   }
 

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -49,8 +49,11 @@ export class GethRPC implements IRpc {
         id: 1
       });
     } catch (e) {
-      const debugOnlyErrors = ['The method debug_traceBlockByNumber does not exist/is not available', 'required historical state unavailable (reexec=128)'];
-      if ((typeof e == 'string' && debugOnlyErrors.includes(e)) || ( e.message && debugOnlyErrors.includes(e.message))) {
+      const debugOnlyErrors = [
+        'The method debug_traceBlockByNumber does not exist/is not available',
+        'required historical state unavailable (reexec=128)'
+      ];
+      if ((typeof e == 'string' && debugOnlyErrors.includes(e)) || (e.message && debugOnlyErrors.includes(e.message))) {
         // Must not be an archive node or has not enabled debug methods
         logger.debug(e.message || e);
       } else {

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -49,16 +49,7 @@ export class GethRPC implements IRpc {
         id: 1
       });
     } catch (e) {
-      const debugOnlyErrors = [
-        'The method debug_traceBlockByNumber does not exist/is not available',
-        'required historical state unavailable (reexec=128)'
-      ];
-      if ((typeof e == 'string' && debugOnlyErrors.includes(e)) || (e.message && debugOnlyErrors.includes(e.message))) {
-        // Must not be an archive node or has not enabled debug methods
         logger.debug(e.message || e);
-      } else {
-        logger.error(e.message || e);
-      }
     }
     return result;
   }

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -49,9 +49,10 @@ export class GethRPC implements IRpc {
         id: 1
       });
     } catch (e) {
-      if (e.message && e.message == 'The method debug_traceBlockByNumber does not exist/is not available') {
-        // Must not be an archive node
-        logger.debug(e.message);
+      const debugOnlyErrors = ['The method debug_traceBlockByNumber does not exist/is not available', 'required historical state unavailable (reexec=128)'];
+      if ((typeof e == 'string' && debugOnlyErrors.includes(e)) || ( e.message && debugOnlyErrors.includes(e.message))) {
+        // Must not be an archive node or has not enabled debug methods
+        logger.debug(e.message || e);
       } else {
         logger.error(e.message || e);
       }

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -49,7 +49,7 @@ export class GethRPC implements IRpc {
         id: 1
       });
     } catch (e) {
-        logger.debug(e.message || e);
+      logger.debug(e.message || e);
     }
     return result;
   }

--- a/packages/bitcore-node/test/integration/matic/csp.spec.ts
+++ b/packages/bitcore-node/test/integration/matic/csp.spec.ts
@@ -9,10 +9,10 @@ import { MongoBound } from '../../../src/models/base';
 import { CacheStorage } from '../../../src/models/cache';
 import { IWallet, WalletStorage } from '../../../src/models/wallet';
 import { WalletAddressStorage } from '../../../src/models/walletAddress';
+import { MATIC } from '../../../src/modules/matic/api/csp';
+import { IEVMTransaction } from '../../../src/providers/chain-state/evm//types';
 import { EVMBlockStorage } from '../../../src/providers/chain-state/evm/models/block';
 import { EVMTransactionStorage } from '../../../src/providers/chain-state/evm/models/transaction';
-import { IEVMTransaction } from '../../../src/providers/chain-state/evm//types';
-import { MATIC } from '../../../src/modules/matic/api/csp';
 import { StreamWalletTransactionsParams } from '../../../src/types/namespaces/ChainStateProvider';
 import { intAfterHelper, intBeforeHelper } from '../../helpers/integration';
 


### PR DESCRIPTION
This logs a debug-level error when we get the 'The method debug_traceBlockByNumber does not exist/is not available' error from a non-archive node.

It returns a noisier error if the method fails for some other reason.