### PR TITLE
[REF] default fee matic

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -87,27 +87,27 @@ module.exports = {
       {
         name: 'urgent',
         nbBlocks: 1,
-        defaultValue: 10000000000
+        defaultValue: 300000000000
       },
       {
         name: 'priority',
         nbBlocks: 2,
-        defaultValue: 5000000000
+        defaultValue: 250000000000
       },
       {
         name: 'normal',
         nbBlocks: 3,
-        defaultValue: 1000000000
+        defaultValue: 200000000000
       },
       {
         name: 'economy',
         nbBlocks: 4,
-        defaultValue: 1000000000
+        defaultValue: 200000000000
       },
       {
         name: 'superEconomy',
         nbBlocks: 4,
-        defaultValue: 1000000000
+        defaultValue: 200000000000
       }
     ],
     xrp: [


### PR DESCRIPTION
Since https://api-matic.bitcore.io/api/MATIC/mainnet/fee/1 is not currently working, we need a more reliable default fee. Numbers are base on this https://polygonscan.com/chart/gasprice