### PR TITLE
[REF] support paypro matic currency codes

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -1732,7 +1732,7 @@ export class API extends EventEmitter {
     if (!txp.payProUrl || this.doNotVerifyPayPro) return Promise.resolve();
 
     const chain = txp.chain || Utils.getChain(txp.coin); // getChain -> backwards compatibility
-    const currency = txp.coin;
+    const currency = Utils.getCurrencyCodeFromCoinAndChain(txp.coin, chain);
     const payload = {
       address: txp.from
     };
@@ -2097,7 +2097,10 @@ export class API extends EventEmitter {
           this._applyAllSignatures(txp, t);
 
           const chain = txp.chain || Utils.getChain(txp.coin); // getChain -> backwards compatibility
-          const currency = txp.coin;
+          const currency = Utils.getCurrencyCodeFromCoinAndChain(
+            txp.coin,
+            chain
+          );
           const rawTxUnsigned = t_unsigned.uncheckedSerialize();
           const serializedTx = t.serialize({
             disableSmallFees: true,

--- a/packages/bitcore-wallet-client/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/constants.ts
@@ -68,5 +68,9 @@ export const Constants = {
   EVM_CHAINS: ['eth', 'matic'],
   ETH_TOKEN_OPTS: CWC.Constants.ETH_TOKEN_OPTS,
   MATIC_TOKEN_OPTS: CWC.Constants.MATIC_TOKEN_OPTS,
-  UNITS: CWC.Constants.UNITS
+  UNITS: CWC.Constants.UNITS,
+  EVM_CHAINSUFFIXMAP: {
+    eth: 'e',
+    matic: 'm'
+  }
 };

--- a/packages/bitcore-wallet-client/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/utils.ts
@@ -503,4 +503,16 @@ export class Utils {
       return { uncheckedSerialize: () => unsignedTxs };
     }
   }
+
+  static getCurrencyCodeFromCoinAndChain(coin: string, chain: string): string {
+    if (coin.toLowerCase() === chain.toLowerCase()) {
+      return coin.toUpperCase();
+    }
+    const suffix = Constants.EVM_CHAINSUFFIXMAP[chain.toLowerCase()];
+    const coinIsAChain = !!Constants.EVM_CHAINSUFFIXMAP[coin.toLowerCase()];
+    if (suffix && (coinIsAChain || chain.toLowerCase() !== 'eth')) {
+      return `${coin.toUpperCase()}_${suffix}`;
+    }
+    return coin.toUpperCase();
+  }
 }

--- a/packages/bitcore-wallet-client/src/lib/payproV2.ts
+++ b/packages/bitcore-wallet-client/src/lib/payproV2.ts
@@ -208,7 +208,7 @@ export class PayProV2 {
     payload,
     unsafeBypassValidation = false
   }) {
-    if (currency?.toLowerCase() === 'usdp') currency = 'pax'; // TODO workaround. Remove this when usdp is accepted as an option
+    if (currency === 'USDP') currency = 'PAX'; // TODO workaround. Remove this when usdp is accepted as an option
     let { rawBody, headers } = await PayProV2._asyncRequest({
       url: paymentUrl,
       method: 'post',
@@ -220,7 +220,7 @@ export class PayProV2 {
       },
       args: JSON.stringify({
         chain: chain?.toUpperCase(),
-        currency: currency?.toUpperCase(),
+        currency,
         payload
       })
     });
@@ -250,7 +250,7 @@ export class PayProV2 {
     unsignedTransactions,
     unsafeBypassValidation = false
   }) {
-    if (currency?.toLowerCase() === 'usdp') currency = 'pax'; // TODO workaround. Remove this when usdp is accepted as an option
+    if (currency === 'USDP') currency = 'PAX'; // TODO workaround. Remove this when usdp is accepted as an option
     let { rawBody, headers } = await PayProV2._asyncRequest({
       url: paymentUrl,
       method: 'post',
@@ -262,7 +262,7 @@ export class PayProV2 {
       },
       args: JSON.stringify({
         chain: chain?.toUpperCase(),
-        currency: currency?.toUpperCase(),
+        currency,
         transactions: unsignedTransactions
       })
     });
@@ -293,7 +293,7 @@ export class PayProV2 {
     unsafeBypassValidation = false,
     bpPartner
   }) {
-    if (currency?.toLowerCase() === 'usdp') currency = 'pax'; // TODO workaround. Remove this when usdp is accepted as an option
+    if (currency === 'USDP') currency = 'PAX'; // TODO workaround. Remove this when usdp is accepted as an option
     let { rawBody, headers } = await this._asyncRequest({
       url: paymentUrl,
       method: 'post',
@@ -307,7 +307,7 @@ export class PayProV2 {
       },
       args: JSON.stringify({
         chain: chain?.toUpperCase(),
-        currency: currency?.toUpperCase(),
+        currency,
         transactions: signedTransactions
       })
     });


### PR DESCRIPTION
Eth chain ->  ['ETH', 'USDC', 'GUSD', 'PAX', 'BUSD', 'DAI', 'WBTC', 'SHIB', 'MATIC_e', 'APE', 'EUROC'];
Matic chain -> ['MATIC', 'ETH_m', 'USDC_m', 'BUSD_m', 'DAI_m', 'WBTC_m', 'SHIB_m'];