### PR TITLE
[Node] Fix big abi param value

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/models/transaction.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/models/transaction.ts
@@ -388,6 +388,7 @@ export class EVMTransactionModel extends BaseTransaction<IEVMTransaction> {
       internal: tx.internal
         ? tx.internal.map(t => ({ ...t, decodedData: this.abiDecode(t.action.input || '0x') }))
         : [],
+      calls: tx.calls ? tx.calls.map(t => ({ ...t, decodedData: this.abiDecode(t.input || '0x') })) : [],
       decodedData: valueOrDefault(decodedData, undefined),
       receipt: valueOrDefault(tx.receipt, undefined)
     };

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -100,6 +100,14 @@ export class GethRPC implements IRpc {
 
     delete trace.calls;
     trace.abiType = trace.input ? EVMTransactionStorage.abiDecode(trace.input) : undefined;
+    if (trace.abiType) {
+      for (let param of trace.abiType.params) {
+        if (param.value && param.value.length > 100) {
+          // Need to truncate this so it doesn't blow up the index.
+          param.value = param.value.substring(0, 100) + '...';
+        }
+      }
+    }
     (trace as IGethTxTraceFlat).depth = depth;
     retval.push(trace as IGethTxTraceFlat);
 

--- a/packages/bitcore-node/src/providers/chain-state/evm/types.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/types.ts
@@ -224,6 +224,7 @@ export interface EVMTransactionJSON {
   decodedData?: IAbiDecodedData;
   data: string;
   internal: Array<DecodedTrace>;
+  calls?: Array<IGethTxTraceFlat>;
   receipt?: IEVMTransaction['receipt'];
 }
 


### PR DESCRIPTION
If the param value is too big, it will cause a mongo index error. We really only care about the indexing of addresses, so we can safely truncate the param if it's too big.

I've also added calls to the retval for the tx api along with a decoding so that the non-truncated value will still be returned.