### PR TITLE
BCMonitor Updates

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
@@ -14,15 +14,29 @@ import { Storage } from './storage';
 const $ = require('preconditions').singleton();
 const Common = require('./common');
 const Constants = Common.Constants;
-const Utils = Common.Utils;
-const Defaults = Common.Defaults;
 
-type throttledNewBlocksFnType = (that: any, chain: any, network: any, hash: any) => void;
+const throttle = (fn: (bcmContext: any, chain: string, network: string, hash: string) => void) => {
+  let lastCalled = 0;
+  return (...args) => {
+    const bcmContext = args[0],
+      chain = args[1],
+      network = args[2],
+      hash = args[3];
+    let msDelay = bcmContext.getChainThrottleSetting(chain, network) * 1000;
+    let now = new Date().getTime();
+    if (now - lastCalled < msDelay) {
+      return;
+    }
+    lastCalled = now;
+    return fn(bcmContext, chain, network, hash);
+  };
+};
 
-var throttledNewBlocks = _.throttle((that, chain, network, hash) => {
-  that._notifyNewBlock(chain, network, hash);
-  // that._handleTxConfirmations(chain, network, hash); // no need to throttledNewBlocks
-}, Defaults.NEW_BLOCK_THROTTLE_TIME_MIN * 60 * 1000) as throttledNewBlocksFnType;
+type throttledNewBlocksFnType = (bcmContext: any, chain: string, network: string, hash: string) => void;
+const throttledNewBlocks = throttle((bcmContext, chain, network, hash) => {
+  bcmContext._notifyNewBlock(chain, network, hash);
+  bcmContext._handleTxConfirmations(chain, network, hash);
+}) as throttledNewBlocksFnType;
 
 export class BlockchainMonitor {
   explorers: any;
@@ -30,6 +44,8 @@ export class BlockchainMonitor {
   messageBroker: MessageBroker;
   lock: Lock;
   walletId: string;
+  blockThrottleSettings: { [chain: string]: { [network: string]: number } } =
+    Constants.CHAIN_NEW_BLOCK_THROTTLE_TIME_SECONDS;
   last: Array<string>;
   Ni: number;
   N: number;
@@ -309,70 +325,56 @@ export class BlockchainMonitor {
   _handleTxConfirmations(chain, network, hash) {
     if (!ChainService.notifyConfirmations(chain, network)) return;
 
-    const processTriggeredSubs = (subs, cb) => {
-      async.mapSeries(
-        subs,
-        (sub: any, cb) => {
-          logger.debug('New tx confirmation ' + sub.txid);
-          sub.isActive = false;
-          async.waterfall(
-            [
-              next => {
-                this.storage.storeTxConfirmationSub(sub, err => {
-                  if (err) return cb(err);
-                  const notification = Notification.create({
-                    type: 'TxConfirmation',
-                    walletId: sub.walletId,
-                    creatorId: sub.copayerId,
-                    isCreator: sub.isCreator,
-                    data: {
-                      txid: sub.txid,
-                      chain,
-                      network,
-                      amount: sub.amount
-                    }
-                  });
-                  next(null, notification);
-                });
-              },
-              (notification, next) => {
-                this._storeAndBroadcastNotification(notification, next);
-              }
-            ],
-            cb
-          );
-        },
+    const processTriggeredSub = (sub, cb) => {
+      logger.debug('New tx confirmation ' + sub.txid);
+      sub.isActive = false;
+      async.waterfall(
+        [
+          next => {
+            this.storage.storeTxConfirmationSub(sub, err => {
+              if (err) return cb(err);
+              const notification = Notification.create({
+                type: 'TxConfirmation',
+                walletId: sub.walletId,
+                creatorId: sub.copayerId,
+                isCreator: sub.isCreator,
+                data: {
+                  txid: sub.txid,
+                  chain,
+                  network,
+                  amount: sub.amount
+                }
+              });
+              next(null, notification);
+            });
+          },
+          (notification, next) => {
+            this._storeAndBroadcastNotification(notification, next);
+          }
+        ],
         cb
       );
     };
     const explorer = this.explorers[chain][network];
     if (!explorer) return;
 
-    explorer.getTxidsInBlock(hash, (err, txids) => {
+    explorer.getTxidsInBlock(hash, async (err, txids) => {
       if (err) {
         logger.error('Could not fetch txids from block ' + hash, err);
         return;
       }
 
-      this.storage.fetchActiveTxConfirmationSubs(null, (err, subs) => {
-        if (err) return;
-        if (_.isEmpty(subs)) return;
-        const indexedSubs = _.groupBy(subs, 'txid');
-        const triggered = [];
-        _.each(txids, txid => {
-          if (indexedSubs[txid]) {
-            _.each(indexedSubs[txid], indexedSub => {
-              triggered.push(indexedSub);
-            });
-          }
-        });
-        processTriggeredSubs(_.uniqBy(triggered, 'walletId'), err => {
+      const stream = this.storage.streamActiveTxConfirmationSubs(null, txids);
+      let txSub = await stream.next();
+      while (txSub != null) {
+        processTriggeredSub(txSub, err => {
           if (err) {
-            logger.error('Could not process tx confirmations', err);
+            logger.error('Could not process tx confirmation', err);
           }
           return;
         });
-      });
+        txSub = await stream.next();
+      }
     });
   }
 
@@ -385,7 +387,7 @@ export class BlockchainMonitor {
       return;
     }
 
-    if (network == 'testnet') {
+    if (this.getChainThrottleSetting(chain, network) > 0) {
       throttledNewBlocks(this, chain, network, hash);
     } else {
       this._notifyNewBlock(chain, network, hash);
@@ -398,5 +400,16 @@ export class BlockchainMonitor {
       this.messageBroker.send(notification);
       if (cb) return cb();
     });
+  }
+
+  getChainThrottleSetting(chain, network) {
+    const config = this.blockThrottleSettings;
+    if (typeof config[chain] === 'object') {
+      if (typeof config[chain][network] === 'number') {
+        return config[chain][network];
+      }
+    }
+    // Defaults to no throttling
+    return 0;
   }
 }

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -123,5 +123,16 @@ module.exports = {
   CONFIRMATIONS_TO_START_CACHING: {
     eth: 100,
     matic: 150
-  }
+  },
+
+  // Individual chain settings for block throttling
+  CHAIN_NEW_BLOCK_THROTTLE_TIME_SECONDS: {
+    btc: { testnet: 300, livenet: 0 },
+    bch: { testnet: 300, livenet: 0 },
+    eth: { testnet: 300, livenet: 0 },
+    matic: { testnet: 300, livenet: 12 }, // MATIC set to 12 because blocks normally occur every 1-2 seconds
+    xrp: { testnet: 300, livenet: 0 },
+    doge: { testnet: 300, livenet: 0 },
+    ltc: { testnet: 300, livenet: 0 }
+  } as { [chain: string]: { [network: string]: number } }
 };

--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -245,8 +245,6 @@ module.exports = {
 
   BE_KEY_SALT: 'bws-auth-keysalt',
 
-  NEW_BLOCK_THROTTLE_TIME_MIN: 5,
-
   BROADCAST_RETRY_TIME: 350, // ms
 
   /*

--- a/packages/bitcore-wallet-service/test/integration/bcmonitor.js
+++ b/packages/bitcore-wallet-service/test/integration/bcmonitor.js
@@ -1,4 +1,4 @@
-'use strict'; 
+'use strict';
 var _ = require('lodash');
 var async = require('async');
 
@@ -12,10 +12,10 @@ var { BlockchainMonitor } = require('../../ts_build/lib/blockchainmonitor');
 var { Constants } = require('../../ts_build/lib/common');
 
 var helpers = require('./helpers');
-var storage, blockchainExplorer, blockchainExplorerEVM;
+var storage, blockchainExplorer, blockchainExplorerEVM, bcmonitor;
 
 var socket = {
-  handlers: {},
+  handlers: {}
 };
 socket.on = function(eventName, handler) {
   this.handlers[eventName] = handler;
@@ -29,19 +29,17 @@ describe('Blockchain monitor', function() {
     helpers.before(function(res) {
       storage = res.storage;
       blockchainExplorer = res.blockchainExplorer;
-      blockchainExplorerEVM =  _.cloneDeep(blockchainExplorer);
-
+      blockchainExplorerEVM = _.cloneDeep(blockchainExplorer);
 
       blockchainExplorer.initSocket = function(callbacks) {
-        socket.handlers['coin']= function(data) {
+        socket.handlers['coin'] = function(data) {
           callbacks.onIncomingPayments(data);
         };
-        socket.handlers['block'] =  callbacks.onBlock;
-      }
+        socket.handlers['block'] = callbacks.onBlock;
+      };
 
       blockchainExplorerEVM.initSocket = function(callbacks) {
-       socket.handlers['tx']= function(data) {
-
+        socket.handlers['tx'] = function(data) {
           // copied from v8.tx
           const tx = data.tx;
           // script output, or similar.
@@ -67,7 +65,7 @@ describe('Blockchain monitor', function() {
         };
         // no uses in eth, interferes with btc
         //socket.handlers['block'] =  callbacks.onBlock;
-      }
+      };
       done();
     });
   });
@@ -95,37 +93,43 @@ describe('Blockchain monitor', function() {
       LOCKS: 'locks'
     };
 
+    async.each(
+      _.values(collections),
+      (x, icb) => {
+        storage.db.collection(x).deleteMany({}, icb);
+      },
+      err => {
+        should.not.exist(err);
+        helpers.createAndJoinWallet(2, 3, function(s, w) {
+          server = s;
+          wallet = w;
 
-    async.each(_.values(collections), (x, icb)=> {
-      storage.db.collection(x).deleteMany({}, icb);
-    }, (err) => {
-      should.not.exist(err);
-      helpers.createAndJoinWallet(2, 3, function(s, w) {
-        server = s;
-        wallet = w;
-
-        var bcmonitor = new BlockchainMonitor();
-        bcmonitor.start({
-          lockOpts: {},
-          messageBroker: server.messageBroker,
-          storage: storage,
-          blockchainExplorers: {
-            'btc': {
-              'livenet': blockchainExplorer
+          bcmonitor = new BlockchainMonitor();
+          bcmonitor.start(
+            {
+              lockOpts: {},
+              messageBroker: server.messageBroker,
+              storage: storage,
+              blockchainExplorers: {
+                btc: {
+                  livenet: blockchainExplorer
+                },
+                eth: {
+                  livenet: blockchainExplorerEVM
+                },
+                matic: {
+                  livenet: blockchainExplorerEVM
+                }
+              }
             },
-            'eth': {
-              'livenet': blockchainExplorerEVM
-            },
-            'matic': {
-              'livenet': blockchainExplorerEVM
+            function(err) {
+              should.not.exist(err);
+              done();
             }
-          },
-        }, function(err) {
-          should.not.exist(err);
-          done();
+          );
         });
-      });
-    });
+      }
+    );
   });
 
   it('should notify copayers of incoming txs', function(done) {
@@ -134,7 +138,7 @@ describe('Blockchain monitor', function() {
 
       var incoming = {
         txid: '123',
-        out: { 'address': address.address, amount: 1500 },
+        out: { address: address.address, amount: 1500 }
       };
       socket.handlers['coin'](incoming);
 
@@ -155,14 +159,13 @@ describe('Blockchain monitor', function() {
     });
   });
 
-
   it('should not notify copayers of incoming txs btc, amount =0', function(done) {
     server.createAddress({}, function(err, address) {
       should.not.exist(err);
 
       var incoming = {
         txid: '123',
-        out: { 'address': address.address, amount: 0 },
+        out: { address: address.address, amount: 0 }
       };
       socket.handlers['coin'](incoming);
 
@@ -180,7 +183,7 @@ describe('Blockchain monitor', function() {
   });
 
   it('should notify copayers of incoming txs ETH, amount =0', function(done) {
-    helpers.createAndJoinWallet(1, 1, {coin: 'eth'}, function(s, w) {
+    helpers.createAndJoinWallet(1, 1, { coin: 'eth' }, function(s, w) {
       s.createAddress({}, function(err, address) {
         should.not.exist(err);
 
@@ -188,10 +191,10 @@ describe('Blockchain monitor', function() {
           tx: {
             chain: 'ETH',
             network: 'mainnet',
-            to:  address.address, 
+            to: address.address,
             value: 0,
-            txid: '123',
-          },
+            txid: '123'
+          }
         };
         socket.handlers['tx'](incoming);
 
@@ -201,10 +204,10 @@ describe('Blockchain monitor', function() {
             var notification = _.find(notifications, {
               type: 'NewIncomingTx'
             });
-          should.exist(notification);
-          notification.data.txid.should.equal('123');
-          notification.data.address.should.equal(address.address);
-          notification.data.amount.should.equal(0);
+            should.exist(notification);
+            notification.data.txid.should.equal('123');
+            notification.data.address.should.equal(address.address);
+            notification.data.amount.should.equal(0);
             done();
           });
         }, 100);
@@ -217,9 +220,9 @@ describe('Blockchain monitor', function() {
       should.not.exist(err);
 
       var incoming = {
-        txid: '123',
+        txid: '123'
       };
-      incoming.out = {address : address.address, amount: 15000};
+      incoming.out = { address: address.address, amount: 15000 };
       socket.handlers['coin'](incoming);
       setTimeout(function() {
         socket.handlers['coin'](incoming);
@@ -241,33 +244,33 @@ describe('Blockchain monitor', function() {
   });
 
   it('should not notify copayers of incoming txs more than once', function(done) {
-    helpers.createAndJoinWallet(1, 1, {coin:'eth'}, function(s, w) {
+    helpers.createAndJoinWallet(1, 1, { coin: 'eth' }, function(s, w) {
       s.createAddress({}, function(err, address) {
         should.not.exist(err);
-        var incoming = {tx: {
-          chain: 'ETH',
-          network: 'mainnet',
-          blockHeight: -1,
-          blockHash: null,
-          data: 'MHhhOTA1OWNiYjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDk4MmZhMTBhZDliOTc1NzQ5YzhmY2UxM2YyMmQ3ZWNlNGVhMjM5MjEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTU1Y2Mw',
-          txid: '0x2fb6db15ac76eea2118e04b5a93036eb75c3ea56652bf99bcb9798ae77019378',
-          blockTime: '2019-12-04T19:19:25.504Z',
-          blockTimeNormalized: '2019-12-04T19:19:25.504Z',
-          fee: 198995000000000,
-          transactionIndex: 0,
-          value: 0,
-          wallets: ['5d8b6c452522995f80c27bf5', '5d924a407eca6e5f89d2be5c'],
-          to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          from: '0xC877cBCF020A8AA259A1Efab1559B2A3A7259086',
-          gasLimit: 39799,
-          gasPrice: 5000000000,
-          nonce: 52,
-          internal: [],
-          abiType: { type: 'ERC20', name: 'transfer', params: [
-            {value:  address.address},
-            {value: 1e10},
-          ] }
-        }};
+        var incoming = {
+          tx: {
+            chain: 'ETH',
+            network: 'mainnet',
+            blockHeight: -1,
+            blockHash: null,
+            data:
+              'MHhhOTA1OWNiYjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDk4MmZhMTBhZDliOTc1NzQ5YzhmY2UxM2YyMmQ3ZWNlNGVhMjM5MjEwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMTU1Y2Mw',
+            txid: '0x2fb6db15ac76eea2118e04b5a93036eb75c3ea56652bf99bcb9798ae77019378',
+            blockTime: '2019-12-04T19:19:25.504Z',
+            blockTimeNormalized: '2019-12-04T19:19:25.504Z',
+            fee: 198995000000000,
+            transactionIndex: 0,
+            value: 0,
+            wallets: ['5d8b6c452522995f80c27bf5', '5d924a407eca6e5f89d2be5c'],
+            to: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            from: '0xC877cBCF020A8AA259A1Efab1559B2A3A7259086',
+            gasLimit: 39799,
+            gasPrice: 5000000000,
+            nonce: 52,
+            internal: [],
+            abiType: { type: 'ERC20', name: 'transfer', params: [{ value: address.address }, { value: 1e10 }] }
+          }
+        };
         socket.handlers['tx'](incoming);
         socket.handlers['tx'](incoming);
         setTimeout(function() {
@@ -285,15 +288,14 @@ describe('Blockchain monitor', function() {
     });
   });
 
-
   it('should parse v8 amount ', function(done) {
     server.createAddress({}, function(err, address) {
       should.not.exist(err);
 
       var incoming = {
-        txid: '123',
+        txid: '123'
       };
-      incoming.out = {address : address.address, amount: 1500};
+      incoming.out = { address: address.address, amount: 1500 };
       socket.handlers['coin'](incoming);
       setTimeout(function() {
         server.getNotifications({}, function(err, notifications) {
@@ -309,7 +311,49 @@ describe('Blockchain monitor', function() {
     });
   });
 
+  it('should notify copayers of tx confirmation test', function(done) {
+    server.createAddress({}, function(err, address) {
+      should.not.exist(err);
 
+      // var incoming = {
+      //   txid: '123',
+      //   vout: [{}]
+      // };
+      // incoming.vout[0][address.address] = 1500;
+
+      server.txConfirmationSubscribe(
+        {
+          txid: '123'
+        },
+        function(err) {
+          should.not.exist(err);
+
+          blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+          socket.handlers['block']('block1');
+
+          setTimeout(function() {
+            blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+            socket.handlers['block']('block2');
+
+            setTimeout(function() {
+              server.getNotifications({}, function(err, notifications) {
+                should.not.exist(err);
+                var notifications = _.filter(notifications, {
+                  type: 'TxConfirmation'
+                });
+                notifications.length.should.equal(1);
+                var n = notifications[0];
+                n.walletId.should.equal(wallet.id);
+                n.creatorId.should.equal(server.copayerId);
+                n.data.txid.should.equal('123');
+                done();
+              });
+            }, 50);
+          }, 50);
+        }
+      );
+    });
+  }).timeout(999999);
 
   it('should notify copayers of tx confirmation', function(done) {
     server.createAddress({}, function(err, address) {
@@ -317,38 +361,108 @@ describe('Blockchain monitor', function() {
 
       var incoming = {
         txid: '123',
-        vout: [{}],
+        vout: [{}]
       };
       incoming.vout[0][address.address] = 1500;
 
-      server.txConfirmationSubscribe({
-        txid: '123'
-      }, function(err) {
-        should.not.exist(err);
+      server.txConfirmationSubscribe(
+        {
+          txid: '123'
+        },
+        function(err) {
+          should.not.exist(err);
 
-        blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
-        socket.handlers['block']('block1');
-
-        setTimeout(function() {
           blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
-          socket.handlers['block']('block2');
+          socket.handlers['block']('block1');
 
           setTimeout(function() {
-            server.getNotifications({}, function(err, notifications) {
-              should.not.exist(err);
-              var notifications = _.filter(notifications, {
-                type: 'TxConfirmation'
+            blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+            socket.handlers['block']('block2');
+
+            setTimeout(function() {
+              server.getNotifications({}, function(err, notifications) {
+                should.not.exist(err);
+                var notifications = _.filter(notifications, {
+                  type: 'TxConfirmation'
+                });
+                notifications.length.should.equal(1);
+                var n = notifications[0];
+                n.walletId.should.equal(wallet.id);
+                n.creatorId.should.equal(server.copayerId);
+                n.data.txid.should.equal('123');
+                done();
               });
-              notifications.length.should.equal(1);
-              var n = notifications[0];
-              n.walletId.should.equal(wallet.id);
-              n.creatorId.should.equal(server.copayerId);
-              n.data.txid.should.equal('123');
-              done();
-            });
+            }, 50);
           }, 50);
-        }, 50);
-      });
+        }
+      );
+    });
+  });
+
+  describe('Block Notify Throttling', function() {
+    it('should throttle _notifyNewBlock if setting requires', function(done) {
+      const notifyNewBlockSpy = sinon.spy(bcmonitor, '_notifyNewBlock');
+      bcmonitor.blockThrottleSettings = { btc: { livenet: 2 } };
+
+      blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+      socket.handlers['block']('block1');
+      setTimeout(function() {
+        // it always calls _notifyNewBlock the first time
+        notifyNewBlockSpy.calledOnce.should.be.true;
+        socket.handlers['block']('block2');
+        socket.handlers['block']('block3');
+        socket.handlers['block']('block4');
+        setTimeout(function() {
+          notifyNewBlockSpy.calledTwice.should.be.false;
+          socket.handlers['block']('block5');
+          setTimeout(function() {
+            notifyNewBlockSpy.calledTwice.should.be.true;
+            done();
+          }, 100);
+        }, 2000);
+      }, 100);
+    });
+
+    it('should not throttle _notifyNewBlock if setting doesn"t exist', function(done) {
+      const notifyNewBlockSpy = sinon.spy(bcmonitor, '_notifyNewBlock');
+      bcmonitor.blockThrottleSettings = { btc: {} };
+
+      blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+      socket.handlers['block']('block1');
+      setTimeout(function() {
+        // it always calls _notifyNewBlock the first time
+        notifyNewBlockSpy.calledOnce.should.be.true;
+        socket.handlers['block']('block2');
+        setTimeout(function() {
+          notifyNewBlockSpy.calledTwice.should.be.true;
+          socket.handlers['block']('block3');
+          setTimeout(function() {
+            notifyNewBlockSpy.calledThrice.should.be.true;
+            done();
+          }, 100);
+        }, 100);
+      }, 100);
+    });
+
+    it('should not throttle _notifyNewBlock if setting is zero', function(done) {
+      const notifyNewBlockSpy = sinon.spy(bcmonitor, '_notifyNewBlock');
+      bcmonitor.blockThrottleSettings = { btc: { livenet: 0 } };
+
+      blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
+      socket.handlers['block']('block1');
+      setTimeout(function() {
+        // it always calls _notifyNewBlock the first time
+        notifyNewBlockSpy.calledOnce.should.be.true;
+        socket.handlers['block']('block2');
+        setTimeout(function() {
+          notifyNewBlockSpy.calledTwice.should.be.true;
+          socket.handlers['block']('block3');
+          setTimeout(function() {
+            notifyNewBlockSpy.calledThrice.should.be.true;
+            done();
+          }, 100);
+        }, 100);
+      }, 100);
     });
   });
 });

--- a/packages/bitcore-wallet-service/test/integration/bcmonitor.js
+++ b/packages/bitcore-wallet-service/test/integration/bcmonitor.js
@@ -311,50 +311,6 @@ describe('Blockchain monitor', function() {
     });
   });
 
-  it('should notify copayers of tx confirmation test', function(done) {
-    server.createAddress({}, function(err, address) {
-      should.not.exist(err);
-
-      // var incoming = {
-      //   txid: '123',
-      //   vout: [{}]
-      // };
-      // incoming.vout[0][address.address] = 1500;
-
-      server.txConfirmationSubscribe(
-        {
-          txid: '123'
-        },
-        function(err) {
-          should.not.exist(err);
-
-          blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
-          socket.handlers['block']('block1');
-
-          setTimeout(function() {
-            blockchainExplorer.getTxidsInBlock = sinon.stub().callsArgWith(1, null, ['123', '456']);
-            socket.handlers['block']('block2');
-
-            setTimeout(function() {
-              server.getNotifications({}, function(err, notifications) {
-                should.not.exist(err);
-                var notifications = _.filter(notifications, {
-                  type: 'TxConfirmation'
-                });
-                notifications.length.should.equal(1);
-                var n = notifications[0];
-                n.walletId.should.equal(wallet.id);
-                n.creatorId.should.equal(server.copayerId);
-                n.data.txid.should.equal('123');
-                done();
-              });
-            }, 50);
-          }, 50);
-        }
-      );
-    });
-  }).timeout(999999);
-
   it('should notify copayers of tx confirmation', function(done) {
     server.createAddress({}, function(err, address) {
       should.not.exist(err);


### PR DESCRIPTION
Removed some reliance on Lodash.
Refactored fetchActiveTxConfirmationSubs to use a stream instead of callbacks. 
Also added txid to index to avoid lots of in-memory processing.
Added tests for new block notification throttling and set defaults for each chain. MATIC at 12 seconds < please advise if less time is favored.