### PR TITLE
Insight fix

### DIFF
--- a/packages/insight/src/components/transaction-details.tsx
+++ b/packages/insight/src/components/transaction-details.tsx
@@ -196,7 +196,7 @@ const TransactionDetails = ({
                           </ScriptText>
                         ) : null}
                         {vo.script.asm ? <ScriptText>{vo.script.asm}</ScriptText> : null}
-                        {showDetails && vo.spentTxid && vo.spentTxid !== '' ? (
+                        {showDetails && vo.spentTxid && vo.spentTxid !== '' && vo.spentHeight > 0 ? (
                           <TextElipsis>
                             <b>Tx ID </b>
                             <SpanLink onClick={() => goToTx(vo.spentTxid)}>{vo.spentTxid}</SpanLink>
@@ -208,10 +208,11 @@ const TransactionDetails = ({
 
                   <TileDescription value textAlign='right'>
                     {getConvertedValue(vo.value, currency)} {currency}{' '}
-                    {vo.spentTxid ? '(S)' : '(U)'}
+                    {vo.spentHeight > 0 ? '(S)' : '(U)'}
                   </TileDescription>
 
-                  {showDetails && vo.spentTxid && vo.spentTxid !== '' && (
+                  {showDetails && vo.spentTxid && vo.spentTxid !== '' 
+                  && vo.spentHeight > 0 && (
                     <ArrowDiv margin='auto 0 auto .5rem'>
                       <img
                         src={ArrowSvg}

--- a/packages/insight/src/components/transaction-details.tsx
+++ b/packages/insight/src/components/transaction-details.tsx
@@ -196,7 +196,7 @@ const TransactionDetails = ({
                           </ScriptText>
                         ) : null}
                         {vo.script.asm ? <ScriptText>{vo.script.asm}</ScriptText> : null}
-                        {showDetails && vo.spentTxid && vo.spentTxid !== '' && vo.spentHeight > 0 ? (
+                        {showDetails && vo.spentTxid && vo.spentTxid !== '' && vo.spentHeight >= 0 ? (
                           <TextElipsis>
                             <b>Tx ID </b>
                             <SpanLink onClick={() => goToTx(vo.spentTxid)}>{vo.spentTxid}</SpanLink>
@@ -208,11 +208,11 @@ const TransactionDetails = ({
 
                   <TileDescription value textAlign='right'>
                     {getConvertedValue(vo.value, currency)} {currency}{' '}
-                    {vo.spentHeight > 0 ? '(S)' : '(U)'}
+                    {vo.spentHeight >= 0 ? '(S)' : '(U)'}
                   </TileDescription>
 
                   {showDetails && vo.spentTxid && vo.spentTxid !== '' 
-                  && vo.spentHeight > 0 && (
+                  && vo.spentHeight >= 0 && (
                     <ArrowDiv margin='auto 0 auto .5rem'>
                       <img
                         src={ArrowSvg}


### PR DESCRIPTION
Added a check based on the spentHeight to correctly show an unspent tx as unspent. Currently the way Bitcore Node handles coins that are spent by an invalid transaction is by moving them back to an unspent status (spentHeight = -2) but it does not remove the spentTxid which points to the invalid tx. Bitcore Node may be reworked at some point to better handle this event.

@lanchana Let me know if this solution may be problematic.