### PR TITLE
bump bn.js version to 5.1.3 in bitcore-lib

### DIFF
--- a/packages/bitcore-lib/package.json
+++ b/packages/bitcore-lib/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "bech32": "=2.0.0",
     "bip-schnorr": "=0.6.4",
-    "bn.js": "=4.11.8",
+    "bn.js": "=5.1.3",
     "bs58": "^4.0.1",
     "buffer-compare": "=1.1.1",
     "elliptic": "^6.5.3",


### PR DESCRIPTION
In conjunction with the same update in elliptic (pending in https://github.com/indutny/elliptic/pull/246,  and https://github.com/indutny/elliptic/pull/210) this fixes issue #3357 

I assume this may possibly be needed in other areas of the monorepo since I see bn.js is used in other modules as well, but I have only tested this in bitcore-lib and only with the elliptic update linked above.