### PR TITLE
Bws internal fix

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -468,8 +468,8 @@ export class EthChain implements IChain {
       amount = tx.abiType.params[1].value;
     } else if (tx.abiType && tx.abiType.type === 'MULTISIG' && tx.abiType.name === 'confirmTransaction') {
       multisigContractAddress = tx.to;
-      address = Web3.utils.toChecksumAddress(tx.internal[0].action.to);
-      amount = tx.internal[0].action.value;
+      address = tx.internal ? Web3.utils.toChecksumAddress(tx.internal[0].action.to) : Web3.utils.toChecksumAddress(tx.calls[0].to);
+      amount = tx.internal ? tx.internal[0].action.value : tx.calls[0].value;
     } else {
       address = tx.to;
       amount = tx.value;

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -467,11 +467,16 @@ export class EthChain implements IChain {
       address = Web3.utils.toChecksumAddress(tx.abiType.params[0].value);
       amount = tx.abiType.params[1].value;
     } else if (tx.abiType && tx.abiType.type === 'MULTISIG' && tx.abiType.name === 'confirmTransaction') {
+      let amount = 0,
+        address = '0x0';
       multisigContractAddress = tx.to;
-      address = tx.internal
-        ? Web3.utils.toChecksumAddress(tx.internal[0].action.to)
-        : Web3.utils.toChecksumAddress(tx.calls[0].to);
-      amount = tx.internal ? tx.internal[0].action.value : tx.calls[0].value;
+      if (tx.internal) {
+        address = Web3.utils.toChecksumAddress(tx.internal[0].action.to);
+        amount = tx.internal[0].action.value;
+      } else if (tx.calls) {
+        address = Web3.utils.toChecksumAddress(tx.calls[0].to);
+        amount = tx.calls[0].value;
+      }
     } else {
       address = tx.to;
       amount = tx.value;

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -467,13 +467,13 @@ export class EthChain implements IChain {
       address = Web3.utils.toChecksumAddress(tx.abiType.params[0].value);
       amount = tx.abiType.params[1].value;
     } else if (tx.abiType && tx.abiType.type === 'MULTISIG' && tx.abiType.name === 'confirmTransaction') {
-      let amount = 0,
-        address = '0x0';
       multisigContractAddress = tx.to;
-      if (tx.internal) {
+      address = '0x0';
+      amount = 0;
+      if (tx.internal && tx.internal.length > 0) {
         address = Web3.utils.toChecksumAddress(tx.internal[0].action.to);
         amount = tx.internal[0].action.value;
-      } else if (tx.calls) {
+      } else if (tx.calls && tx.calls.length > 0) {
         address = Web3.utils.toChecksumAddress(tx.calls[0].to);
         amount = tx.calls[0].value;
       }

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -468,7 +468,9 @@ export class EthChain implements IChain {
       amount = tx.abiType.params[1].value;
     } else if (tx.abiType && tx.abiType.type === 'MULTISIG' && tx.abiType.name === 'confirmTransaction') {
       multisigContractAddress = tx.to;
-      address = tx.internal ? Web3.utils.toChecksumAddress(tx.internal[0].action.to) : Web3.utils.toChecksumAddress(tx.calls[0].to);
+      address = tx.internal
+        ? Web3.utils.toChecksumAddress(tx.internal[0].action.to)
+        : Web3.utils.toChecksumAddress(tx.calls[0].to);
       amount = tx.internal ? tx.internal[0].action.value : tx.calls[0].value;
     } else {
       address = tx.to;


### PR DESCRIPTION
This checks if internal array exists before using it. Same with the calls array. There does exist a way for this to have neither if blocks were synced by non-archive node.