### PR TITLE
[Bitcore-Node] ETH Syncing Updates

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/models/block.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/models/block.ts
@@ -207,8 +207,8 @@ export class EVMBlockModel extends BaseBlock<IEVMBlock> {
         let prevBlock: IEVMBlock | undefined;
         const outOfSync: number[] = [];
         timeout = setInterval(
-          () => logger.info(`${chain}:${network} Block verification height: ${block.height}`),
-          1000 * 10
+          () => logger.info(`${chain}:${network} Block verification progress: ${((maxHeight - block.height) / (maxHeight - startHeight) * 100).toFixed(1)}%`),
+          1000 * 2
         );
         // we are descending in blockHeight as we iterate
         for (let syncHeight = maxHeight; syncHeight >= startHeight; syncHeight--) {

--- a/packages/bitcore-node/src/providers/chain-state/evm/models/block.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/models/block.ts
@@ -207,7 +207,13 @@ export class EVMBlockModel extends BaseBlock<IEVMBlock> {
         let prevBlock: IEVMBlock | undefined;
         const outOfSync: number[] = [];
         timeout = setInterval(
-          () => logger.info(`${chain}:${network} Block verification progress: ${((maxHeight - block.height) / (maxHeight - startHeight) * 100).toFixed(1)}%`),
+          () =>
+            logger.info(
+              `${chain}:${network} Block verification progress: ${(
+                ((maxHeight - block.height) / (maxHeight - startHeight)) *
+                100
+              ).toFixed(1)}%`
+            ),
           1000 * 2
         );
         // we are descending in blockHeight as we iterate

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -1502,7 +1502,7 @@ export class ExpressApp {
       getServerWithAuth(req, res, async server => {
         let response;
         try {
-          response = await server.moonpayGetQuote(req)
+          response = await server.moonpayGetQuote(req);
           return res.json(response);
         } catch (ex) {
           return returnError(ex, res, req);
@@ -1514,7 +1514,7 @@ export class ExpressApp {
       getServerWithAuth(req, res, server => {
         let response;
         try {
-          response = server.moonpayGetSignedPaymentUrl(req)
+          response = server.moonpayGetSignedPaymentUrl(req);
           return res.json(response);
         } catch (ex) {
           return returnError(ex, res, req);
@@ -1522,7 +1522,7 @@ export class ExpressApp {
       });
     });
 
-    router.post('/v1/service/moonpay/transactionDetails', async(req, res) => {
+    router.post('/v1/service/moonpay/transactionDetails', async (req, res) => {
       let server, response;
       try {
         server = getServer(req, res);
@@ -1533,7 +1533,7 @@ export class ExpressApp {
       }
     });
 
-    router.post('/v1/service/moonpay/accountDetails', async(req, res) => {
+    router.post('/v1/service/moonpay/accountDetails', async (req, res) => {
       let server, response;
       try {
         server = getServer(req, res);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4544,15 +4544,15 @@ export class WalletService {
     delete req.body.env;
 
     const keys: {
-      API: string,
-      WIDGET_API: string,
-      API_KEY: string,
-      SECRET_KEY: string,
+      API: string;
+      WIDGET_API: string;
+      API_KEY: string;
+      SECRET_KEY: string;
     } = {
       API: config.moonpay[env].api,
       WIDGET_API: config.moonpay[env].widgetApi,
       API_KEY: config.moonpay[env].apiKey,
-      SECRET_KEY: config.moonpay[env].secretKey,
+      SECRET_KEY: config.moonpay[env].secretKey
     };
 
     return keys;
@@ -4564,14 +4564,12 @@ export class WalletService {
       const API = keys.API;
       const API_KEY = keys.API_KEY;
 
-      if (
-        !checkRequired(req.body, ['currencyAbbreviation', 'baseCurrencyAmount', 'baseCurrencyCode'])
-      ) {
+      if (!checkRequired(req.body, ['currencyAbbreviation', 'baseCurrencyAmount', 'baseCurrencyCode'])) {
         return reject(new ClientError("Moonpay's request missing arguments"));
       }
 
       const headers = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       };
 
       let qs = [];
@@ -4602,20 +4600,27 @@ export class WalletService {
     });
   }
 
-  moonpayGetSignedPaymentUrl(req): {urlWithSignature: string} {
+  moonpayGetSignedPaymentUrl(req): { urlWithSignature: string } {
     const keys = this.moonpayGetKeys(req);
     const SECRET_KEY = keys.SECRET_KEY;
     const API_KEY = keys.API_KEY;
     const WIDGET_API = keys.WIDGET_API;
 
     if (
-      !checkRequired(req.body, ['currencyCode', 'walletAddress', 'baseCurrencyCode', 'baseCurrencyAmount', 'externalTransactionId', 'redirectURL'])
+      !checkRequired(req.body, [
+        'currencyCode',
+        'walletAddress',
+        'baseCurrencyCode',
+        'baseCurrencyAmount',
+        'externalTransactionId',
+        'redirectURL'
+      ])
     ) {
       throw new ClientError("Moonpay's request missing arguments");
     }
 
     const headers = {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     };
 
     let qs = [];
@@ -4627,8 +4632,9 @@ export class WalletService {
     qs.push('externalTransactionId=' + encodeURIComponent(req.body.externalTransactionId));
     qs.push('redirectURL=' + encodeURIComponent(req.body.redirectURL));
     if (req.body.lockAmount) qs.push('lockAmount=' + encodeURIComponent(req.body.lockAmount));
-    if (req.body.showWalletAddressForm) qs.push('showWalletAddressForm=' + encodeURIComponent(req.body.showWalletAddressForm));
-    
+    if (req.body.showWalletAddressForm)
+      qs.push('showWalletAddressForm=' + encodeURIComponent(req.body.showWalletAddressForm));
+
     const URL_SEARCH: string = `?${qs.join('&')}`;
 
     const URLSignatureHash: string = Bitcore.crypto.Hash.sha256hmac(
@@ -4638,7 +4644,7 @@ export class WalletService {
 
     const urlWithSignature = `${WIDGET_API}${URL_SEARCH}&signature=${encodeURIComponent(URLSignatureHash)}`;
 
-    return {urlWithSignature};
+    return { urlWithSignature };
   }
 
   moonpayGetTransactionDetails(req): Promise<any> {
@@ -4647,23 +4653,21 @@ export class WalletService {
       const API = keys.API;
       const API_KEY = keys.API_KEY;
 
-      if (
-        !checkRequired(req.body, ['transactionId']) && !checkRequired(req.body, ['externalId'])
-      ) {
+      if (!checkRequired(req.body, ['transactionId']) && !checkRequired(req.body, ['externalId'])) {
         return reject(new ClientError("Moonpay's request missing arguments"));
       }
 
       const headers = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       };
       let URL: string;
 
       let qs = [];
       qs.push('apiKey=' + API_KEY);
       if (req.body.transactionId) {
-      URL = API + `/v1/transactions/${req.body.transactionId}?${qs.join('&')}`;
+        URL = API + `/v1/transactions/${req.body.transactionId}?${qs.join('&')}`;
       } else if (req.body.externalId) {
-      URL = API + `/v1/transactions/ext/${req.body.externalId}?${qs.join('&')}`;
+        URL = API + `/v1/transactions/ext/${req.body.externalId}?${qs.join('&')}`;
       }
 
       this.request.get(
@@ -4690,7 +4694,7 @@ export class WalletService {
       const API_KEY = keys.API_KEY;
 
       const headers = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       };
 
       let qs = [];


### PR DESCRIPTION
This fixes a couple issues found in the multi-threaded ETH syncing functionality.

1. A index was not being used properly so the mongo instance threw `MongoError: errmsg: "Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit."`. This would force the sync process to exit without performing the verification step. If later restarted without multithreaded syncing enabled, it would begin to rollback ~100 blocks at a time because periodic blocks lacked the nextBlockHash property (the getBlockSyncGaps method is what throws the mongo error and later in that method it sets the nextBlockHash).
2. During the multithreaded sync, after all the blocks had been obtained, when any block gaps were returned it would not reliably sync the returned blocks (due to a race condition?)

I also added some logging around the process of filling block gaps.