### PR TITLE
Feat: disable Wyre

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4898,6 +4898,12 @@ export class WalletService {
         }
       }
 
+      // Needed to temporarily disable Wyre implementation in bitpay app.
+      return resolve({
+        exceptionId: "disabled",
+        message: "This exchange is temporarily out of service."
+      });
+
       const URL: string = `${keys.API}/v3/orders/quote/partner?timestamp=${Date.now().toString()}`;
       const XApiSignature: string = URL + JSON.stringify(req.body);
       const XApiSignatureHash: string = Bitcore.crypto.Hash.sha256hmac(

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -11148,7 +11148,18 @@ describe('Wallet service', function() {
         }
       });
 
-      it('should work properly if req is OK', () => {
+      it('should return exceptionId while Wyre is disabled', async() => {
+        server.request = fakeRequest;
+        try {
+          const data = await server.wyreWalletOrderQuotation(req);
+          should.exist(data);
+          data.exceptionId.should.equal('disabled');
+        } catch (err) {
+          should.not.exist(err);
+        };
+      });
+
+      it.skip('should work properly if req is OK', () => {
         server.request = fakeRequest;
         server.wyreWalletOrderQuotation(req).then(data => {
           should.exist(data);
@@ -11169,7 +11180,7 @@ describe('Wallet service', function() {
         });
       });
 
-      it('should return error if post returns error', () => {
+      it.skip('should return error if post returns error', () => {
         req.body.amount = 50;
         const fakeRequest2 = {
           post: (_url, _opts, _cb) => { return _cb(new Error('Error')) },


### PR DESCRIPTION
This change is required to temporarily disable Wyre from the Bitpay app.
The "message" attribute will be displayed to users in the app, and they will not be able to continue the purchase process with this particular exchange.
In the future we will implement a remote config to disable/remove this type of integration directly from the config file, without having to wait for app releases.