### PR TITLE
[BWS] Make common.ts a module

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
 import { V8 } from './blockchainexplorers/v8';
 import { ChainService } from './chain/index';
+import { Common } from './common';
 
 const $ = require('preconditions').singleton();
-const Common = require('./common');
 const Defaults = Common.Defaults;
 const PROVIDERS = {
   v8: {

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -3,11 +3,11 @@ import _ from 'lodash';
 import * as request from 'request-promise-native';
 import io = require('socket.io-client');
 import { ChainService } from '../chain/index';
+import { Common } from '../common';
 import logger from '../logger';
 import { Client } from './v8/client';
 
 const $ = require('preconditions').singleton();
-const Common = require('../common');
 const Bitcore = require('bitcore-lib');
 const Bitcore_ = {
   btc: Bitcore,

--- a/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainmonitor.ts
@@ -4,6 +4,7 @@ import 'source-map-support/register';
 
 import { BlockChainExplorer } from './blockchainexplorer';
 import { ChainService } from './chain/index';
+import { Common } from './common';
 import { Lock } from './lock';
 import logger from './logger';
 import { MessageBroker } from './messagebroker';
@@ -12,7 +13,6 @@ import { WalletService } from './server';
 import { Storage } from './storage';
 
 const $ = require('preconditions').singleton();
-const Common = require('./common');
 const Constants = Common.Constants;
 
 const throttle = (fn: (bcmContext: any, chain: string, network: string, hash: string) => void) => {

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -2,11 +2,12 @@ import * as async from 'async';
 import { BitcoreLib } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IChain, INotificationData } from '..';
+import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import logger from '../../logger';
 import { TxProposal } from '../../model';
+
 const $ = require('preconditions').singleton();
-const Common = require('../../common');
 const Constants = Common.Constants;
 const Utils = Common.Utils;
 const Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
@@ -6,8 +6,9 @@ import logger from '../../logger';
 import { TxProposal } from '../../model';
 import { BtcChain } from '../btc';
 const $ = require('preconditions').singleton();
+import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
-const Common = require('../../common');
+
 const Constants = Common.Constants;
 const Utils = Common.Utils;
 const Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -3,12 +3,12 @@ import { Web3 } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IAddress } from 'src/lib/model/address';
 import { IChain, INotificationData } from '..';
+import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import logger from '../../logger';
 import { ERC20Abi } from './abi-erc20';
 import { InvoiceAbi } from './abi-invoice';
 
-const Common = require('../../common');
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 const Errors = require('../../errors/errordefinitions');

--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -1,3 +1,4 @@
+import { Common } from '../common';
 import { ITxProposal, IWallet, TxProposal } from '../model';
 import { WalletService } from '../server';
 import { BchChain } from './bch';
@@ -8,7 +9,7 @@ import { LtcChain } from './ltc';
 import { MaticChain } from './matic';
 import { XrpChain } from './xrp';
 
-const Common = require('../common');
+
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 

--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -9,7 +9,6 @@ import { LtcChain } from './ltc';
 import { MaticChain } from './matic';
 import { XrpChain } from './xrp';
 
-
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 

--- a/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
@@ -1,9 +1,9 @@
 import { Transactions, Validation } from 'crypto-wallet-core';
 import _ from 'lodash';
+import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import { EthChain } from '../eth';
 
-const Common = require('../../common');
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 const Errors = require('../../errors/errordefinitions');

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -2,9 +2,9 @@ import { Transactions, Validation } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IAddress } from 'src/lib/model/address';
 import { IChain, INotificationData } from '..';
+import { Common } from '../../common';
 import logger from '../../logger';
 
-const Common = require('../../common');
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 const Errors = require('../../errors/errordefinitions');

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as CWC from 'crypto-wallet-core';
 
-module.exports = {
+export const Constants = {
   CHAINS: {
     BTC: 'btc',
     BCH: 'bch',

--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = {
+export const Defaults = {
   MIN_FEE_PER_KB: 0,
 
   MAX_KEYS: 100,

--- a/packages/bitcore-wallet-service/src/lib/common/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/index.ts
@@ -1,6 +1,11 @@
-module.exports = {
-  Constants: require('./constants'),
-  Defaults: require('./defaults'),
-  Services: require('./services'),
-  Utils: require('./utils')
+import { Constants } from './constants';
+import { Defaults } from './defaults';
+import { Services } from './services';
+import { Utils } from './utils';
+
+export const Common = {
+  Constants,
+  Defaults,
+  Services,
+  Utils
 };

--- a/packages/bitcore-wallet-service/src/lib/common/services.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/services.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = {
+export const Services = {
   // Recommended whitelist of contracts as spenders for ERC20 tokens
   ERC20_SPENDER_APPROVAL_WHITELIST: [
     {

--- a/packages/bitcore-wallet-service/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/utils.ts
@@ -281,4 +281,3 @@ export class Utils {
     return coin == 'bch' ? result.toLegacyAddress() : result.toString();
   }
 }
-module.exports = Utils;

--- a/packages/bitcore-wallet-service/src/lib/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/emailservice.ts
@@ -6,6 +6,7 @@ import 'source-map-support/register';
 // sending function from `.send` to `.sendMail`.
 // import * as nodemailer from nodemailer';
 import request from 'request';
+import { Common } from './common';
 import { Lock } from './lock';
 import logger from './logger';
 import { MessageBroker } from './messagebroker';
@@ -21,9 +22,9 @@ export interface Recipient {
 const Mustache = require('mustache');
 const fs = require('fs');
 const path = require('path');
-const Utils = require('./common/utils');
-const Defaults = require('./common/defaults');
-const Constants = require('./common/constants');
+const Utils = Common.Utils;
+const Defaults = Common.Defaults;
+const Constants = Common.Constants;
 const defaultRequest = require('request');
 
 const EMAIL_TYPES = {

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import 'source-map-support/register';
 import { logger, transport } from './logger';
 
+import { Common } from './common';
 import { ClientError } from './errors/clienterror';
 import { LogMiddleware } from './middleware';
 import { WalletService } from './server';
@@ -13,7 +14,6 @@ const bodyParser = require('body-parser');
 const compression = require('compression');
 const config = require('../config');
 const RateLimit = require('express-rate-limit');
-const Common = require('./common');
 const rp = require('request-promise-native');
 const Defaults = Common.Defaults;
 

--- a/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/fiatrateservice.ts
@@ -1,10 +1,10 @@
 import * as async from 'async';
 import _ from 'lodash';
 import * as request from 'request';
+import { Common } from './common';
 import { Storage } from './storage';
 
 const $ = require('preconditions').singleton();
-const Common = require('./common');
 const Defaults = Common.Defaults;
 const Constants = Common.Constants;
 import logger from './logger';

--- a/packages/bitcore-wallet-service/src/lib/lock.ts
+++ b/packages/bitcore-wallet-service/src/lib/lock.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
+import { Common } from './common';
 import { Storage } from './storage';
 
 const $ = require('preconditions').singleton();
-const Common = require('./common');
 const Defaults = Common.Defaults;
 const Errors = require('./errors/errordefinitions');
 const ACQUIRE_RETRY_STEP = 50; // ms

--- a/packages/bitcore-wallet-service/src/lib/model/address.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/address.ts
@@ -1,10 +1,10 @@
 import { Deriver } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { ChainService } from '../chain/index';
+import { Common } from '../common';
 import { AddressManager } from './addressmanager';
 
 const $ = require('preconditions').singleton();
-const Common = require('../common');
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;

--- a/packages/bitcore-wallet-service/src/lib/model/addressmanager.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/addressmanager.ts
@@ -1,8 +1,9 @@
 import _ from 'lodash';
+import { Common } from '../common';
 
 const $ = require('preconditions').singleton();
-const Constants = require('../common/constants');
-const Utils = require('../common/utils');
+const Constants = Common.Constants;
+const Utils = Common.Utils;
 
 export interface IAddressManager {
   version: number;

--- a/packages/bitcore-wallet-service/src/lib/model/copayer.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/copayer.ts
@@ -1,9 +1,9 @@
+import { Common } from '../common';
 import { Address } from './address';
 import { AddressManager } from './addressmanager';
 
 const $ = require('preconditions').singleton();
 const sjcl = require('sjcl');
-const Common = require('../common');
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;

--- a/packages/bitcore-wallet-service/src/lib/model/session.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/session.ts
@@ -1,7 +1,8 @@
 import _ from 'lodash';
+import { Common } from '../common';
 
 const Uuid = require('uuid');
-const Defaults = require('../common/defaults');
+const Defaults = Common.Defaults;
 
 export interface ISession {
   id: number;

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -1,6 +1,7 @@
 import { Transactions } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { ChainService } from '../chain/index';
+import { Common } from '../common';
 import logger from '../logger';
 import { TxProposalLegacy } from './txproposal_legacy';
 import { TxProposalAction } from './txproposalaction';
@@ -8,7 +9,6 @@ import { TxProposalAction } from './txproposalaction';
 const $ = require('preconditions').singleton();
 const Uuid = require('uuid');
 
-const Common = require('../common');
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal_legacy.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal_legacy.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
+import { Common } from '../common';
 import logger from '../logger';
 
 const $ = require('preconditions').singleton();
-const Common = require('../common');
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 import { TxProposalAction } from './txproposalaction';

--- a/packages/bitcore-wallet-service/src/lib/model/wallet.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/wallet.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { ChainService } from '../chain/index';
+import { Common } from '../common';
 import logger from '../logger';
 import { Address } from './address';
 import { AddressManager } from './addressmanager';
@@ -8,7 +9,6 @@ import { Copayer } from './copayer';
 const $ = require('preconditions').singleton();
 const Uuid = require('uuid');
 const config = require('../../config');
-const Common = require('../common');
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;

--- a/packages/bitcore-wallet-service/src/lib/pushnotificationsservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/pushnotificationsservice.ts
@@ -5,6 +5,7 @@ import 'source-map-support/register';
 
 import request from 'request';
 import { ChainService } from './chain';
+import { Common } from './common';
 import logger from './logger';
 import { MessageBroker } from './messagebroker';
 import { INotification, IPreferences } from './model';
@@ -13,9 +14,9 @@ import { Storage } from './storage';
 const Mustache = require('mustache');
 const defaultRequest = require('request');
 const path = require('path');
-const Utils = require('./common/utils');
-const Defaults = require('./common/defaults');
-const Constants = require('./common/constants');
+const Utils = Common.Utils;
+const Defaults = Common.Defaults;
+const Constants = Common.Constants;
 const sjcl = require('sjcl');
 
 const PUSHNOTIFICATIONS_TYPES = {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -88,11 +88,12 @@ export interface IWalletService {
   walletId: string;
   copayerId: string;
   appName: string;
-  appVersion: string;
-  parsedClientVersion: { agent: number; major: number; minor: number };
+  appVersion: { agent?: string; major?: number; minor?: number };
+  parsedClientVersion: { agent?: string; major?: number; minor?: number };
   clientVersion: string;
   copayerIsSupportStaff: boolean;
   copayerIsMarketingStaff: boolean;
+  request: any;
 }
 function boolToNum(x: boolean) {
   return x ? 1 : 0;
@@ -101,7 +102,7 @@ function boolToNum(x: boolean) {
  * Creates an instance of the Bitcore Wallet Service.
  * @constructor
  */
-export class WalletService {
+export class WalletService implements IWalletService {
   lock: any;
   storage: Storage;
   blockchainExplorer: V8;
@@ -118,7 +119,7 @@ export class WalletService {
   clientVersion: string;
   copayerIsSupportStaff: boolean;
   copayerIsMarketingStaff: boolean;
-  request;
+  request: any;
 
   constructor() {
     if (!initialized) {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -113,7 +113,7 @@ export class WalletService {
   walletId: string;
   copayerId: string;
   appName: string;
-  appVersion: { agent?: string; major?: number; minor?: number };;
+  appVersion: { agent?: string; major?: number; minor?: number };
   parsedClientVersion: { agent?: string; major?: number; minor?: number };
   clientVersion: string;
   copayerIsSupportStaff: boolean;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -6,6 +6,7 @@ import logger from './logger';
 import { BlockChainExplorer } from './blockchainexplorer';
 import { V8 } from './blockchainexplorers/v8';
 import { ChainService } from './chain/index';
+import { Common } from './common';
 import { ClientError } from './errors/clienterror';
 import { FiatRateService } from './fiatrateservice';
 import { Lock } from './lock';
@@ -47,7 +48,6 @@ const Bitcore_ = {
   ltc: require('bitcore-lib-ltc')
 };
 
-const Common = require('./common');
 const Utils = Common.Utils;
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
@@ -113,8 +113,8 @@ export class WalletService {
   walletId: string;
   copayerId: string;
   appName: string;
-  appVersion: string;
-  parsedClientVersion: { agent: string; major: number; minor: number };
+  appVersion: { agent?: string; major?: number; minor?: number };;
+  parsedClientVersion: { agent?: string; major?: number; minor?: number };
   clientVersion: string;
   copayerIsSupportStaff: boolean;
   copayerIsMarketingStaff: boolean;

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -2,6 +2,7 @@ import * as async from 'async';
 import _ from 'lodash';
 import { Db } from 'mongodb';
 import * as mongodb from 'mongodb';
+import { Common } from './common';
 import logger from './logger';
 import {
   Address,
@@ -39,7 +40,6 @@ const collections = {
   LOCKS: 'locks'
 };
 
-const Common = require('./common');
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 

--- a/packages/bitcore-wallet-service/test/chain/bch.js
+++ b/packages/bitcore-wallet-service/test/chain/bch.js
@@ -10,7 +10,7 @@ const { ChainService } = require('../../ts_build/lib/chain');
 const { BchChain } = require('../../ts_build/lib/chain/bch');
 const { TxProposal } = require('../../ts_build/lib/model/txproposal');
 
-const Common = require('../../ts_build/lib/common');
+const { Common } = require('../../ts_build/lib/common');
 const Constants = Common.Constants;
 
 describe('Chain BCH', function() {

--- a/packages/bitcore-wallet-service/test/chain/btc.js
+++ b/packages/bitcore-wallet-service/test/chain/btc.js
@@ -10,7 +10,7 @@ const { ChainService } = require('../../ts_build/lib/chain');
 const { BtcChain } = require('../../ts_build/lib/chain/btc');
 const { TxProposal } = require('../../ts_build/lib/model/txproposal');
 
-const Common = require('../../ts_build/lib/common');
+const { Common } = require('../../ts_build/lib/common');
 const Constants = Common.Constants;
 
 const segWitToAddress = 'BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4'; //'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';

--- a/packages/bitcore-wallet-service/test/chain/doge.js
+++ b/packages/bitcore-wallet-service/test/chain/doge.js
@@ -8,7 +8,7 @@ const { ChainService } = require('../../ts_build/lib/chain');
 const { DogeChain } = require('../../ts_build/lib/chain/doge');
 const { TxProposal } = require('../../ts_build/lib/model/txproposal');
 
-const Common = require('../../ts_build/lib/common');
+const { Common } = require('../../ts_build/lib/common');
 const Constants = Common.Constants;
 
 describe('Chain DOGE', () => {

--- a/packages/bitcore-wallet-service/test/chain/ltc.js
+++ b/packages/bitcore-wallet-service/test/chain/ltc.js
@@ -8,7 +8,7 @@ const { ChainService } = require('../../ts_build/lib/chain');
 const { LtcChain } = require('../../ts_build/lib/chain/ltc');
 const { TxProposal } = require('../../ts_build/lib/model/txproposal');
 
-const Common = require('../../ts_build/lib/common');
+const { Common } = require('../../ts_build/lib/common');
 const Constants = Common.Constants;
 
 describe('Chain LTC', () => {

--- a/packages/bitcore-wallet-service/test/expressapp.js
+++ b/packages/bitcore-wallet-service/test/expressapp.js
@@ -10,7 +10,7 @@ var proxyquire = require('proxyquire');
 var config = require('../ts_build/config.js');
 var log = require('npmlog');
 
-var Common = require('../ts_build/lib/common');
+var { Common } = require('../ts_build/lib/common');
 var Defaults = Common.Defaults;
 var { WalletService } = require('../ts_build/lib/server');
 

--- a/packages/bitcore-wallet-service/test/integration/bcmonitor.js
+++ b/packages/bitcore-wallet-service/test/integration/bcmonitor.js
@@ -9,7 +9,7 @@ var should = chai.should();
 
 var { WalletService } = require('../../ts_build/lib/server');
 var { BlockchainMonitor } = require('../../ts_build/lib/blockchainmonitor');
-var { Constants } = require('../../ts_build/lib/common');
+var { Constants } = require('../../ts_build/lib/common/constants');
 
 var helpers = require('./helpers');
 var storage, blockchainExplorer, blockchainExplorerEVM, bcmonitor;

--- a/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
+++ b/packages/bitcore-wallet-service/test/integration/fiatrateservice.js
@@ -8,7 +8,7 @@ var should = chai.should();
 var log = require('npmlog');
 log.debug = log.verbose;
 log.level = 'info';
-var Common = require('../../ts_build/lib/common');
+var { Common } = require('../../ts_build/lib/common');
 var Defaults = Common.Defaults;
 var Constants = Common.Constants;
 

--- a/packages/bitcore-wallet-service/test/integration/helpers.js
+++ b/packages/bitcore-wallet-service/test/integration/helpers.js
@@ -23,7 +23,7 @@ var Bitcore_ = {
 };
 
 var { ChainService } = require('../../ts_build/lib/chain/index');
-var Common = require('../../ts_build/lib/common');
+var { Common } = require('../../ts_build/lib/common');
 var Utils = Common.Utils;
 var Constants = Common.Constants;
 var Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/test/integration/history.js
+++ b/packages/bitcore-wallet-service/test/integration/history.js
@@ -15,7 +15,7 @@ var Bitcore_ = {
   bch: require('bitcore-lib-cash')
 };
 
-var Common = require('../../ts_build/lib/common');
+var { Common } = require('../../ts_build/lib/common');
 var Utils = Common.Utils;
 var Constants = Common.Constants;
 var Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -27,7 +27,7 @@ const Bitcore_ = {
 
 const { WalletService } = require('../../ts_build/lib/server');
 const { Storage } = require('../../ts_build/lib/storage')
-const Common = require('../../ts_build/lib/common');
+const { Common } = require('../../ts_build/lib/common');
 const Utils = Common.Utils;
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/test/utils.js
+++ b/packages/bitcore-wallet-service/test/utils.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var chai = require('chai');
 var sinon = require('sinon');
 var should = chai.should();
-var Utils = require('../ts_build/lib/common/utils');
+var { Utils } = require('../ts_build/lib/common/utils');
 const { logger } = require('../ts_build/lib/logger');
 
 describe('Utils', function() {

--- a/packages/bitcore-wallet-service/test/v8.js
+++ b/packages/bitcore-wallet-service/test/v8.js
@@ -7,7 +7,7 @@ var should = chai.should();
 var { V8 } = require('../ts_build/lib/blockchainexplorers/v8');
 var B = require('bitcore-lib-cash');
 const { Readable } = require('stream');
-var Common = require('../ts_build/lib/common');
+var { Common } = require('../ts_build/lib/common');
 var Defaults = Common.Defaults;
 
 const V8UTXOS = [


### PR DESCRIPTION
This makes the common.ts a module which allows for a much better dev experience to be able to easily reference commonly used constants, util functions, etc.