### PR TITLE
Ref: Changelly to v2

### DIFF
--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -225,9 +225,7 @@ const Config = () => {
     //     api: 'https://api.changelly.com'
     //   },
     //   v2: {
-    //     apiKeyBase64: 'changelly_api_key_base64_v2',
     //     secret: 'changelly_secret_v2',
-    //     publicKey: 'changelly_public_key_v2',
     //     api: 'https://api.changelly.com/v2'
     //   }
     // },

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -219,9 +219,17 @@ const Config = () => {
     //   }
     // },
     // changelly: {
-    //   apiKey: 'changelly_api_key',
-    //   secret: 'changelly_secret',
-    //   api: 'https://api.changelly.com'
+    //   v1: {
+    //     apiKey: 'changelly_api_key',
+    //     secret: 'changelly_secret',
+    //     api: 'https://api.changelly.com'
+    //   },
+    //   v2: {
+    //     apiKeyBase64: 'changelly_api_key_base64_v2',
+    //     secret: 'changelly_secret_v2',
+    //     publicKey: 'changelly_public_key_v2',
+    //     api: 'https://api.changelly.com/v2'
+    //   }
     // },
     // oneInch: {
     //   api: 'https://bitpay.api.enterprise.1inch.exchange',

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1,4 +1,5 @@
 import * as async from 'async';
+import * as crypto from 'crypto'
 import * as _ from 'lodash';
 import 'source-map-support/register';
 import logger from './logger';
@@ -30,7 +31,6 @@ import {
 import { Storage } from './storage';
 
 const config = require('../config');
-const crypto = require('crypto');
 const Uuid = require('uuid');
 const $ = require('preconditions').singleton();
 const deprecatedServerMessage = require('../deprecated-serverMessages');
@@ -5188,8 +5188,6 @@ export class WalletService implements IWalletService {
 
     const keys = {
       API: config.changelly.v2.api,
-      API_KEY_BASE64: config.changelly.v2.apiKeyBase64,
-      PUBLIC_KEY: config.changelly.v2.publicKey,
       SECRET: config.changelly.v2.secret
     };
 
@@ -5212,10 +5210,9 @@ export class WalletService implements IWalletService {
     if (!message || !secret) throw new Error('Missing parameters to sign Changelly v2 request');
 
     const privateKey = crypto.createPrivateKey({
-      key: secret,
+      key: Buffer.from(secret, 'hex'),
       format: 'der',
       type: 'pkcs8',
-      encoding: 'hex'
     });
     
     const publicKey = crypto.createPublicKey(privateKey).export({
@@ -5223,11 +5220,7 @@ export class WalletService implements IWalletService {
         format: 'der'
     });
 
-    const signature = crypto.sign('sha256', Buffer.from(JSON.stringify(message)), {
-      key: privateKey,
-      type: 'pkcs8',
-      format: 'der'
-    });
+    const signature = crypto.sign('sha256', Buffer.from(JSON.stringify(message)), privateKey);
 
     return {signature, publicKey};
   }

--- a/packages/bitcore-wallet-service/test/integration/changelly.js
+++ b/packages/bitcore-wallet-service/test/integration/changelly.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chai = require('chai');
+const crypto = require('crypto');
 const should = chai.should();
 const { WalletService } = require('../../ts_build/lib/server');
 const TestData = require('../testdata');
@@ -8,6 +9,18 @@ const helpers = require('./helpers');
 
 let config = require('../../ts_build/config.js');
 let server, wallet, fakeRequest, req;
+
+var { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: {
+    type: 'pkcs1',
+    format: 'der'
+  },
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'der'
+  }
+  });
 
 describe('Changelly integration', () => {
   before((done) => {
@@ -18,9 +31,17 @@ describe('Changelly integration', () => {
   beforeEach((done) => {
     config.suspendedChains = [];
     config.changelly = {
-      apiKey: 'xxxx',
-      secret: 'xxxx',
-      api: 'xxxx'
+      v1: {
+        apiKey: 'apiKeyV1',
+        secret: 'secretV1',
+        api: 'apiV1'
+      },
+      v2: {
+        apiKeyBase64: crypto.createHash('sha256').update(publicKey).digest('base64'),
+        secret: privateKey.toString('hex'),
+        publicKey: publicKey.toString('base64'),
+        api: 'apiV2'
+      }
     }
 
     fakeRequest = {
@@ -71,9 +92,18 @@ describe('Changelly integration', () => {
       });
     });
 
+    it('should work properly if req is OK for v2', () => {
+      server.request = fakeRequest;
+      req.body.useV2 = true;
+      server.changellyGetCurrencies(req).then(data => {
+        should.exist(data);
+      }).catch(err => {
+        should.not.exist(err);
+      });
+    });
+
     it('should return error if there is some missing arguments', () => {
       delete req.body.id;
-
       server.request = fakeRequest;
       server.changellyGetCurrencies(req).then(data => {
         should.not.exist(data);
@@ -125,6 +155,17 @@ describe('Changelly integration', () => {
 
     it('should work properly if req is OK', () => {
       server.request = fakeRequest;
+      server.changellyGetPairsParams(req).then(data => {
+        should.exist(data);
+      }).catch(err => {
+        should.not.exist(err);
+      });
+    });
+
+
+    it('should work properly if req is OK for v2', () => {
+      server.request = fakeRequest;
+      req.body.useV2 = true;
       server.changellyGetPairsParams(req).then(data => {
         should.exist(data);
       }).catch(err => {
@@ -187,6 +228,16 @@ describe('Changelly integration', () => {
 
     it('should work properly if req is OK', () => {
       server.request = fakeRequest;
+      server.changellyGetFixRateForAmount(req).then(data => {
+        should.exist(data);
+      }).catch(err => {
+        should.not.exist(err);
+      });
+    });
+
+    it('should work properly if req is OK for v2', () => {
+      server.request = fakeRequest;
+      req.body.useV2 = true;
       server.changellyGetFixRateForAmount(req).then(data => {
         should.exist(data);
       }).catch(err => {
@@ -259,6 +310,16 @@ describe('Changelly integration', () => {
       });
     });
 
+    it('should work properly if req is OK for v2', () => {
+      server.request = fakeRequest;
+      req.body.useV2 = true;
+      server.changellyCreateFixTransaction(req).then(data => {
+        should.exist(data);
+      }).catch(err => {
+        should.not.exist(err);
+      });
+    });
+
     it('should return error if there is some missing arguments', () => {
       delete req.body.coinFrom;
 
@@ -312,6 +373,16 @@ describe('Changelly integration', () => {
 
     it('should work properly if req is OK', () => {
       server.request = fakeRequest;
+      server.changellyGetStatus(req).then(data => {
+        should.exist(data);
+      }).catch(err => {
+        should.not.exist(err);
+      });
+    });
+
+    it('should work properly if req is OK for v2', () => {
+      server.request = fakeRequest;
+      req.body.useV2 = true;
       server.changellyGetStatus(req).then(data => {
         should.exist(data);
       }).catch(err => {

--- a/packages/bitcore-wallet-service/test/integration/changelly.js
+++ b/packages/bitcore-wallet-service/test/integration/changelly.js
@@ -10,7 +10,7 @@ const helpers = require('./helpers');
 let config = require('../../ts_build/config.js');
 let server, wallet, fakeRequest, req;
 
-var { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+let { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
   modulusLength: 2048,
   publicKeyEncoding: {
     type: 'pkcs1',
@@ -37,9 +37,7 @@ describe('Changelly integration', () => {
         api: 'apiV1'
       },
       v2: {
-        apiKeyBase64: crypto.createHash('sha256').update(publicKey).digest('base64'),
         secret: privateKey.toString('hex'),
-        publicKey: publicKey.toString('base64'),
         api: 'apiV2'
       }
     }


### PR DESCRIPTION
As the first step for this migration, I made a refactor that will only use the `V2` credentials if we pass the `useV2` parameter. In this way users will continue to use `V1` until we perform the necessary tests. Once we are sure that `V2` works correctly, I'll make the necessary changes so that `V2` is usable by everyone.