### PR TITLE
[BCN] Optimize pruneMempool

### DIFF
--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -597,8 +597,10 @@ export class TransactionModel extends BaseTransaction<IBtcTransaction> {
 
   async findAllRelatedOutputs(forTx: string) {
     const seen = {};
-    const allRelatedCoins: ICoin[] = await CoinStorage.collection.find({ mintTxid: forTx, mintHeight: { $ne: SpentHeightIndicators.conflicting } }).toArray();
-    for (let coin of allRelatedCoins) {
+    const allRelatedCoins: ICoin[] = [];
+    const txCoins = await CoinStorage.collection.find({ mintTxid: forTx, mintHeight: { $ne: SpentHeightIndicators.conflicting } }).toArray();
+    for (let coin of txCoins) {
+      allRelatedCoins.push(coin);
       seen[coin.mintTxid] = true;
       if (coin.spentTxid && !seen[coin.spentTxid]) {
         const outputs = await this.findAllRelatedOutputs(coin.spentTxid);

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -1,7 +1,7 @@
 import * as async from 'async';
+import * as crypto from 'crypto';
 import _ from 'lodash';
 import * as request from 'request-promise-native';
-import * as crypto from 'crypto';
 import io = require('socket.io-client');
 import { ChainService } from '../chain/index';
 import { Common } from '../common';

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -1,6 +1,7 @@
 import * as async from 'async';
 import _ from 'lodash';
 import * as request from 'request-promise-native';
+import * as crypto from 'crypto';
 import io = require('socket.io-client');
 import { ChainService } from '../chain/index';
 import { Common } from '../common';
@@ -97,14 +98,15 @@ export class V8 {
     });
 
     const k = 'addAddresses' + addresses.length;
-    console.time(k);
+    const perfKey = getPerformanceKey(k);
+    console.time(perfKey);
     client
       .importAddresses({
         payload,
         pubKey: wallet.beAuthPublicKey2
       })
       .then(ret => {
-        console.timeEnd(k);
+        console.timeEnd(perfKey);
         return cb(null, ret);
       })
       .catch(err => {
@@ -184,7 +186,8 @@ export class V8 {
   getUtxos(wallet, height, cb, params: { includeSpent?: boolean } = {}) {
     $.checkArgument(cb);
     const client = this._getAuthClient(wallet);
-    console.time('V8getUtxos');
+    const perfKey = getPerformanceKey('V8getUtxos');
+    console.time(perfKey);
     client
       .getCoins({
         pubKey: wallet.beAuthPublicKey2,
@@ -192,7 +195,7 @@ export class V8 {
         ...params
       })
       .then(utxos => {
-        console.timeEnd('V8getUtxos');
+        console.timeEnd(perfKey);
         return cb(null, this._transformUtxos(utxos, height));
       })
       .catch(cb);
@@ -201,11 +204,12 @@ export class V8 {
   getCoinsForTx(txId, cb) {
     $.checkArgument(cb);
     const client = this._getClient();
-    console.time('V8getCoinsForTx');
+    const perfKey = getPerformanceKey('V8getCoinsForTx');
+    console.time(perfKey);
     client
       .getCoinsForTx({ txId, payload: {} })
       .then(coins => {
-        console.timeEnd('V8getCoinsForTx');
+        console.timeEnd(perfKey);
         return cb(null, coins);
       })
       .catch(cb);
@@ -216,11 +220,12 @@ export class V8 {
    */
   getCheckData(wallet, cb) {
     const client = this._getAuthClient(wallet);
-    console.time('WalletCheck');
+    const perfKey = getPerformanceKey('WalletCheck');
+    console.time(perfKey);
     client
       .getCheckData({ pubKey: wallet.beAuthPublicKey2, payload: {} })
       .then(checkInfo => {
-        console.timeEnd('WalletCheck');
+        console.timeEnd(perfKey);
         return cb(null, checkInfo);
       })
       .catch(cb);
@@ -295,7 +300,8 @@ export class V8 {
   }
 
   getTransactions(wallet, startBlock, cb) {
-    console.time('V8 getTxs');
+    const perfKey = getPerformanceKey('V8getTxs');
+    console.time(perfKey);
     if (startBlock) {
       logger.debug(`getTxs: startBlock ${startBlock}`);
     } else {
@@ -345,7 +351,7 @@ export class V8 {
         if (tx.height >= 0) txs.push(tx);
         else if (tx.height >= -2) unconf.push(tx);
       });
-      console.timeEnd('V8 getTxs');
+      console.timeEnd(perfKey);
       // blockTime on unconf is 'seenTime';
       return cb(null, _.flatten(_.orderBy(unconf, 'blockTime', 'desc').concat(txs.reverse())));
     });
@@ -615,4 +621,8 @@ const _parseErr = (err, res) => {
   }
   logger.warn('V8 ' + res.request.href + ' Returned Status: ' + res.statusCode);
   return 'Error querying the blockchain';
+};
+
+const getPerformanceKey = (name: string) => {
+  return name + '-' + crypto.randomBytes(5).toString('hex');
 };

--- a/tslint.json
+++ b/tslint.json
@@ -46,7 +46,8 @@
     "space-before-function-paren": [false, "never"],
     "array-type": false,
     "eofline": false,
-    "new-parens": false
+    "new-parens": false,
+    "no-conditional-assignment": false
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
This PR optimizes TransactionStorage.pruneMempool by streamifying the data instead of storing all relevant txs and coins in memory.


I've also snuck in a logging fix for BWS. For high call volume, consecutive calls to `console.time()` with the same keys before `console.timeEnd()` would throw noisy errors in the logs such as:
```
(node:25) Warning: Label 'V8getUtxos' already exists for console.time()
```
which then cause
```
(node:25) Warning: No such label 'V8getUtxos' for console.timeEnd()
```

I fixed this by putting randomly generated identifiers in the key strings to prevent consecutive call conflicts.