### PR TITLE
[BCN] Fix gas estimation

### DIFF
--- a/.docker/rippled.Dockerfile
+++ b/.docker/rippled.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-stretch
+FROM node:18-bullseye
 
 RUN apt-get update
 RUN apt-get install sudo
@@ -10,7 +10,7 @@ USER docker
 RUN sudo apt -y update
 RUN sudo apt -y install apt-transport-https ca-certificates wget gnupg
 RUN wget -q -O - "https://repos.ripple.com/repos/api/gpg/key/public" | sudo apt-key add -
-RUN echo "deb https://repos.ripple.com/repos/rippled-deb stretch stable" | sudo tee -a /etc/apt/sources.list.d/ripple.list
+RUN echo "deb https://repos.ripple.com/repos/rippled-deb bullseye stable" | sudo tee -a /etc/apt/sources.list.d/ripple.list
 RUN sudo apt -y update
 RUN sudo apt -y install rippled
 

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -24,7 +24,7 @@ services:
       # -fallbackfee=0.00001
 
   erigon:
-    image: thorax/erigon:v2.43.0
+    image: thorax/erigon:v2022.10.01
     command:
       /usr/local/bin/erigon
       --chain=dev

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -24,7 +24,7 @@ services:
       # -fallbackfee=0.00001
 
   erigon:
-    image: thorax/erigon:v2022.10.01
+    image: thorax/erigon:latest
     command:
       /usr/local/bin/erigon
       --chain=dev

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -6,7 +6,7 @@ services:
     image: mongo:3.6.23
 
   bitcoin:
-    image: ruimarinho/bitcoin-core:0.16
+    image: ruimarinho/bitcoin-core:24
     command:
       -printtoconsole
       -regtest=1

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -24,7 +24,7 @@ services:
       # -fallbackfee=0.00001
 
   erigon:
-    image: thorax/erigon:latest
+    image: thorax/erigon:v2.43.0
     command:
       /usr/local/bin/erigon
       --chain=dev

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -21,7 +21,7 @@ services:
       -rpcbind=0.0.0.0
       -rpcuser=bitcorenodetest
       -rpcpassword=local321
-      # -fallbackfee=0.00001
+      -fallbackfee=0.00001
 
   erigon:
     image: thorax/erigon:v2022.10.01

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   db:
-    image: mongo:6.0.5
+    image: mongo:3.6.23
 
   bitcoin:
     image: ruimarinho/bitcoin-core:24

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -37,7 +37,7 @@ services:
       --ws
 
   geth:
-    image: 0labs/geth:v1.10.23
+    image: 0labs/geth:v1.11.5
     volumes:
       - ./.docker/geth-keystore:/keystore
     command:

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -24,7 +24,7 @@ services:
       # -fallbackfee=0.00001
 
   erigon:
-    image: thorax/erigon:v2022.08.01
+    image: thorax/erigon:v2022.10.01
     command:
       /usr/local/bin/erigon
       --chain=dev

--- a/docker-compose.test.base.yml
+++ b/docker-compose.test.base.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   db:
-    image: mongo:3.6.23
+    image: mongo:6.0.5
 
   bitcoin:
     image: ruimarinho/bitcoin-core:24

--- a/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
@@ -22,7 +22,7 @@ EthRoutes.post('/api/ETH/:network/gas', async (req, res) => {
     const gasLimit = await ETH.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
   } catch (err: any) {
-    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or something)
+    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or similar)
       res.status(400).send(err.message);
     } else {
       logger.error('Gas Error::%o', err);

--- a/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
@@ -22,7 +22,7 @@ EthRoutes.post('/api/ETH/:network/gas', async (req, res) => {
     const gasLimit = await ETH.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
   } catch (err: any) {
-    if (err?.code) { // Preventable error from geth (probably due to insufficient funds or something)
+    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or something)
       res.status(400).send(err.message);
     } else {
       logger.error('Gas Error::%o', err);

--- a/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
+++ b/packages/bitcore-node/src/modules/ethereum/api/eth-routes.ts
@@ -21,8 +21,13 @@ EthRoutes.post('/api/ETH/:network/gas', async (req, res) => {
   try {
     const gasLimit = await ETH.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
-  } catch (err) {
-    res.status(500).send(err);
+  } catch (err: any) {
+    if (err?.code) { // Preventable error from geth (probably due to insufficient funds or something)
+      res.status(400).send(err.message);
+    } else {
+      logger.error('Gas Error::%o', err);
+      res.status(500).send(err);
+    }
   }
 });
 
@@ -32,6 +37,7 @@ EthRoutes.get('/api/ETH/:network/token/:tokenAddress', async (req, res) => {
     const tokenInfo = await ETH.getERC20TokenInfo(network, tokenAddress);
     res.json(tokenInfo);
   } catch (err) {
+    logger.error('Token Info Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -42,6 +48,7 @@ EthRoutes.get('/api/ETH/:network/token/:tokenAddress/allowance/:ownerAddress/for
     const allowance = await ETH.getERC20TokenAllowance(network, tokenAddress, ownerAddress, spenderAddress);
     res.json(allowance);
   } catch (err) {
+    logger.error('Token Allowance Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -52,6 +59,7 @@ EthRoutes.get('/api/ETH/:network/ethmultisig/info/:multisigContractAddress', asy
     const multisigInfo = await Gnosis.getMultisigEthInfo(network, multisigContractAddress);
     res.json(multisigInfo);
   } catch (err) {
+    logger.error('Multisig Info Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -62,6 +70,7 @@ EthRoutes.get('/api/ETH/:network/ethmultisig/:sender/instantiation/:txId', async
     const multisigInstantiationInfo = await Gnosis.getMultisigContractInstantiationInfo(network, sender, txId);
     res.json(multisigInstantiationInfo);
   } catch (err) {
+    logger.error('Multisig Instantiation Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -72,6 +81,7 @@ EthRoutes.get('/api/ETH/:network/ethmultisig/txps/:multisigContractAddress', asy
     const multisigTxpsInfo = await Gnosis.getMultisigTxpsInfo(network, multisigContractAddress);
     res.json(multisigTxpsInfo);
   } catch (err) {
+    logger.error('Multisig Txps Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -90,6 +100,7 @@ EthRoutes.get('/api/ETH/:network/ethmultisig/transactions/:multisigContractAddre
       args: req.query
     });
   } catch (err) {
+    logger.error('Multisig Transactions Error::%o', err);
     return res.status(500).send(err);
   }
 });

--- a/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
+++ b/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
@@ -22,7 +22,7 @@ MaticRoutes.post('/api/MATIC/:network/gas', async (req, res) => {
     const gasLimit = await MATIC.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
   } catch (err: any) {
-    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or something)
+    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or similar)
       res.status(400).send(err.message);
     } else {
       logger.error('Gas Error::%o', err);

--- a/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
+++ b/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
@@ -22,7 +22,7 @@ MaticRoutes.post('/api/MATIC/:network/gas', async (req, res) => {
     const gasLimit = await MATIC.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
   } catch (err: any) {
-    if (err?.code) { // Preventable error from geth (probably due to insufficient funds or something)
+    if (err?.code != null) { // Preventable error from geth (probably due to insufficient funds or something)
       res.status(400).send(err.message);
     } else {
       logger.error('Gas Error::%o', err);

--- a/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
+++ b/packages/bitcore-node/src/modules/matic/api/matic-routes.ts
@@ -21,8 +21,13 @@ MaticRoutes.post('/api/MATIC/:network/gas', async (req, res) => {
   try {
     const gasLimit = await MATIC.estimateGas({ network, from, to, value, data, gasPrice });
     res.json(gasLimit);
-  } catch (err) {
-    res.status(500).send(err);
+  } catch (err: any) {
+    if (err?.code) { // Preventable error from geth (probably due to insufficient funds or something)
+      res.status(400).send(err.message);
+    } else {
+      logger.error('Gas Error::%o', err);
+      res.status(500).send(err);
+    }
   }
 });
 
@@ -32,6 +37,7 @@ MaticRoutes.get('/api/MATIC/:network/token/:tokenAddress', async (req, res) => {
     const tokenInfo = await MATIC.getERC20TokenInfo(network, tokenAddress);
     res.json(tokenInfo);
   } catch (err) {
+    logger.error('Token Info Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -42,6 +48,7 @@ MaticRoutes.get('/api/MATIC/:network/ethmultisig/info/:multisigContractAddress',
     const multisigInfo = await Gnosis.getMultisigEthInfo(network, multisigContractAddress);
     res.json(multisigInfo);
   } catch (err) {
+    logger.error('Multisig Info Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -52,6 +59,7 @@ MaticRoutes.get('/api/MATIC/:network/ethmultisig/:sender/instantiation/:txId', a
     const multisigInstantiationInfo = await Gnosis.getMultisigContractInstantiationInfo(network, sender, txId);
     res.json(multisigInstantiationInfo);
   } catch (err) {
+    logger.error('Multisig Instantiation Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -62,6 +70,7 @@ MaticRoutes.get('/api/MATIC/:network/ethmultisig/txps/:multisigContractAddress',
     const multisigTxpsInfo = await Gnosis.getMultisigTxpsInfo(network, multisigContractAddress);
     res.json(multisigTxpsInfo);
   } catch (err) {
+    logger.error('Multisig Txps Error::%o', err);
     res.status(500).send(err);
   }
 });
@@ -80,6 +89,7 @@ MaticRoutes.get('/api/MATIC/:network/ethmultisig/transactions/:multisigContractA
       args: req.query
     });
   } catch (err) {
+    logger.error('Multisig Transactions Error::%o', err);
     return res.status(500).send(err);
   }
 });

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/csp.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/csp.ts
@@ -463,13 +463,13 @@ export class BaseEVMStateProvider extends InternalStateProvider implements IChai
   async estimateGas(params): Promise<number> {
     return new Promise(async (resolve, reject) => {
       try {
-        let { network, value, from, data, gasPrice, to } = params;
+        let { network, value, from, data, /*gasPrice,*/ to } = params;
         const { web3 } = await this.getWeb3(network);
         const dataDecoded = EVMTransactionStorage.abiDecode(data);
 
         if (dataDecoded && dataDecoded.type === 'INVOICE' && dataDecoded.name === 'pay') {
           value = dataDecoded.params[0].value;
-          gasPrice = dataDecoded.params[1].value;
+          // gasPrice = dataDecoded.params[1].value;
         } else if (data && data.type === 'MULTISEND') {
           try {
             let method, gasLimit;
@@ -495,6 +495,14 @@ export class BaseEVMStateProvider extends InternalStateProvider implements IChai
           }
         }
 
+        let _value;
+        if (data) {
+          // Gas estimation might fail with `insufficient funds` if value is higher than balance for a normal send.
+          // We want this method to give a blind fee estimation, though, so we should not include the value
+          // unless it's needed for estimating smart contract execution.
+          _value = web3.utils.toHex(value)
+        }
+
         const opts = {
           method: 'eth_estimateGas',
           params: [
@@ -502,18 +510,18 @@ export class BaseEVMStateProvider extends InternalStateProvider implements IChai
               data,
               to: to && to.toLowerCase(),
               from: from && from.toLowerCase(),
-              gasPrice: web3.utils.toHex(gasPrice),
-              value: web3.utils.toHex(value)
+              // gasPrice: web3.utils.toHex(gasPrice), // Setting this lower than the baseFee of the last block will cause an error. Better to just leave it out.
+              value: _value
             }
           ],
           jsonrpc: '2.0',
-          id: 1
+          id: 'bitcore-' + Date.now()
         };
 
         let provider = web3.currentProvider as any;
         provider.send(opts, (err, data) => {
           if (err) return reject(err);
-          if (!data.result) return reject(data.message);
+          if (!data.result) return reject(data.error || data);
           return resolve(Number(data.result));
         });
       } catch (err) {

--- a/packages/bitcore-node/test/integration/models/wallet.spec.ts
+++ b/packages/bitcore-node/test/integration/models/wallet.spec.ts
@@ -96,24 +96,24 @@ describe('Wallet Model', function() {
         name: walletName,
         chain,
         network
-      });
+      }, { sort: { _id: -1 }});
 
-      if (findWalletResult && findWalletResult._id) {
-        const findAddressResult = await WalletAddressStorage.collection
-          .find({
-            wallet: findWalletResult._id,
-            chain,
-            network,
-            address: address1
-          })
-          .toArray();
+      expect(findWalletResult?._id).to.exist;
+      const findAddressResult = await WalletAddressStorage.collection
+        .find({
+          wallet: findWalletResult?._id,
+          chain,
+          network,
+          address: address1
+        })
+        .toArray();
 
-        expect(findAddressResult[0]).to.have.deep.property('chain', chain);
-        expect(findAddressResult[0]).to.have.deep.property('network', network);
-        expect(findAddressResult[0]).to.have.deep.property('wallet', findWalletResult._id);
-        expect(findAddressResult[0]).to.have.deep.property('address', address1);
-        expect(findAddressResult[0]).to.have.deep.property('processed', true);
-      }
+      expect(findAddressResult[0]).to.exist;
+      expect(findAddressResult[0]).to.have.deep.property('chain', chain);
+      expect(findAddressResult[0]).to.have.deep.property('network', network);
+      expect(findAddressResult[0]).to.have.deep.property('wallet', findWalletResult?._id);
+      expect(findAddressResult[0]).to.have.deep.property('address', address1);
+      expect(findAddressResult[0]).to.have.deep.property('processed', true);
     });
   });
 });

--- a/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
+++ b/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
@@ -226,6 +226,17 @@ describe('ETH Chain State Provider', function() {
         await ETH.estimateGas({ network });
         throw new Error('should have thrown');
       } catch (err) {
+        expect(err).to.deep.equal({ message: 'need some param' });
+      }
+    });
+
+    it('should reject if response body is missing result and has error', async () => {
+      web3Stub.currentProvider.send.callsArgWith(1, null, { error: { code: 2, message: 'need some param' } });
+  
+      try {
+        await ETH.estimateGas({ network });
+        throw new Error('should have thrown');
+      } catch (err) {
         expect(err).to.equal('need some param');
       }
     });

--- a/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
+++ b/packages/bitcore-node/test/unit/modules/ethereum/csp.spec.ts
@@ -237,7 +237,7 @@ describe('ETH Chain State Provider', function() {
         await ETH.estimateGas({ network });
         throw new Error('should have thrown');
       } catch (err) {
-        expect(err).to.equal('need some param');
+        expect(err).to.deep.equal({ code: 2, message: 'need some param' });
       }
     });
 

--- a/packages/bitcore-node/test/unit/modules/matic/csp.spec.ts
+++ b/packages/bitcore-node/test/unit/modules/matic/csp.spec.ts
@@ -226,7 +226,7 @@ describe('MATIC Chain State Provider', function() {
         await MATIC.estimateGas({ network });
         throw new Error('should have thrown');
       } catch (err) {
-        expect(err).to.equal({ message: 'need some param' });
+        expect(err).to.deep.equal({ message: 'need some param' });
       }
     });
 
@@ -237,7 +237,7 @@ describe('MATIC Chain State Provider', function() {
         await MATIC.estimateGas({ network });
         throw new Error('should have thrown');
       } catch (err) {
-        expect(err).to.equal('need some param');
+        expect(err).to.deep.equal({ code: 2, message: 'need some param' });
       }
     });
 

--- a/packages/bitcore-node/test/unit/modules/matic/csp.spec.ts
+++ b/packages/bitcore-node/test/unit/modules/matic/csp.spec.ts
@@ -226,6 +226,17 @@ describe('MATIC Chain State Provider', function() {
         await MATIC.estimateGas({ network });
         throw new Error('should have thrown');
       } catch (err) {
+        expect(err).to.equal({ message: 'need some param' });
+      }
+    });
+
+    it('should reject if response body is missing result and has error', async () => {
+      web3Stub.currentProvider.send.callsArgWith(1, null, { error: { code: 2, message: 'need some param' } });
+  
+      try {
+        await MATIC.estimateGas({ network });
+        throw new Error('should have thrown');
+      } catch (err) {
         expect(err).to.equal('need some param');
       }
     });


### PR DESCRIPTION
Some errors seen:

`error: { code: -32000, message: 'insufficient funds for transfer' }`
`error: { code: -32000, message: 'err: max fee per gas less than block base fee: address <redacted address>, maxFeePerGas: 38300000000 baseFee: 39828234137 (supplied gas 215685)' }`
`error: { code: -32000, message: 'gas required exceeds allowance (63)' }`
`error: { code: 3,  message: 'execution reverted: Must have enough tokens to pay',  data: '<redacted>' }`

This fixes the first two. I'm not sure there's much we can do to mask the last two errors but pass it through BWS better. That might be a subsequent PR.

This also updates some pipeline pieces.