### PR TITLE
Filter out conflicting coins when fetching unspent outputs.

### DIFF
--- a/packages/bitcore-node/docs/api-documentation.md
+++ b/packages/bitcore-node/docs/api-documentation.md
@@ -280,6 +280,8 @@ curl -v localhost:3000/api/BTC/mainnet/address/12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJ
 
 GET `/api/BTC/mainnet/address/:address/?unspent=true`
 
+**if you want to filter out conflicting utxos, you can add `excludeConflicting=true` to the end of the url.**
+
 <details>
 <summary><b>Response</b></summary>
 <br>

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -69,6 +69,9 @@ export class InternalStateProvider implements IChainStateService {
     if (args.unspent) {
       query.spentHeight = { $lt: SpentHeightIndicators.minimum };
     }
+    if (args.excludeConflicting) {
+      query.mintHeight = { $gt: SpentHeightIndicators.conflicting };
+    }
     return query;
   }
 


### PR DESCRIPTION
Filter out conflicting coins when fetching unspent outputs

[#3576](https://github.com/bitpay/bitcore/issues/3576)