### PR TITLE
[CWC] Handle numbers given in scientific notation form

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -158,9 +158,9 @@ export class EthChain implements IChain {
         for (let output of opts.outputs) {
           if (opts.multiSendContractAddress) {
             outputAddresses.push(output.toAddress);
-            outputAmounts.push(toBN(BigInt(output.amount).toString()));
+            outputAmounts.push(toBN(output.amount));
             if (!opts.tokenAddress) {
-              totalValue = totalValue.add(toBN(BigInt(output.amount).toString()));
+              totalValue = totalValue.add(toBN(output.amount));
             }
             inGasLimit += output.gasLimit ? output.gasLimit : defaultGasLimit;
             continue;
@@ -458,7 +458,7 @@ export class EthChain implements IChain {
         output.amount == null ||
         output.amount < 0 ||
         isNaN(output.amount) ||
-        Web3.utils.toBN(BigInt(output.amount).toString()).toString() !== BigInt(output.amount).toString()
+        Web3.utils.toBN(output.amount).toString() !== output.amount.toString()
       ) {
         throw new Error('output.amount is not a valid value: ' + output.amount);
       }

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -158,9 +158,9 @@ export class EthChain implements IChain {
         for (let output of opts.outputs) {
           if (opts.multiSendContractAddress) {
             outputAddresses.push(output.toAddress);
-            outputAmounts.push(toBN(output.amount));
+            outputAmounts.push(toBN(BigInt(output.amount).toString()));
             if (!opts.tokenAddress) {
-              totalValue = totalValue.add(toBN(output.amount));
+              totalValue = totalValue.add(toBN(BigInt(output.amount).toString()));
             }
             inGasLimit += output.gasLimit ? output.gasLimit : defaultGasLimit;
             continue;
@@ -458,7 +458,7 @@ export class EthChain implements IChain {
         output.amount == null ||
         output.amount < 0 ||
         isNaN(output.amount) ||
-        Web3.utils.toBN(output.amount).toString() !== output.amount.toString()
+        Web3.utils.toBN(BigInt(output.amount).toString()).toString() !== BigInt(output.amount).toString()
       ) {
         throw new Error('output.amount is not a valid value: ' + output.amount);
       }

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -136,9 +136,9 @@ export class EthChain implements IChain {
     });
   }
 
-  getChangeAddress() {}
+  getChangeAddress() { }
 
-  checkDust(output, opts) {}
+  checkDust(output, opts) { }
 
   getFee(server, wallet, opts) {
     return new Promise(resolve => {
@@ -169,10 +169,10 @@ export class EthChain implements IChain {
               const to = opts.payProUrl
                 ? output.toAddress
                 : opts.tokenAddress
-                ? opts.tokenAddress
-                : opts.multisigContractAddress
-                ? opts.multisigContractAddress
-                : output.toAddress;
+                  ? opts.tokenAddress
+                  : opts.multisigContractAddress
+                    ? opts.multisigContractAddress
+                    : output.toAddress;
               const value = opts.tokenAddress || opts.multisigContractAddress ? 0 : output.amount;
               inGasLimit = await server.estimateGas({
                 coin,
@@ -450,7 +450,7 @@ export class EthChain implements IChain {
     });
   }
 
-  checkUtxos(opts) {}
+  checkUtxos(opts) { }
 
   checkValidTxAmount(output): boolean {
     try {

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -164,7 +164,6 @@ export class TxProposal {
     x.creatorId = opts.creatorId;
     x.coin = opts.coin;
     x.chain = opts.chain?.toLowerCase() || ChainService.getChain(x.coin); // getChain -> backwards compatibility
-    if(x.chain === 'eth') { opts.network = 'regtest'; }
     x.network = opts.network;
     x.signingMethod = opts.signingMethod;
     x.message = opts.message;

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -164,6 +164,7 @@ export class TxProposal {
     x.creatorId = opts.creatorId;
     x.coin = opts.coin;
     x.chain = opts.chain?.toLowerCase() || ChainService.getChain(x.coin); // getChain -> backwards compatibility
+    if(x.chain === 'eth') { opts.network = 'regtest'; }
     x.network = opts.network;
     x.signingMethod = opts.signingMethod;
     x.message = opts.message;

--- a/packages/crypto-wallet-core/src/transactions/erc20/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/erc20/index.ts
@@ -40,13 +40,13 @@ export class ERC20TxProvider extends ETHTxProvider {
       const amounts = [];
       for (let recipient of recipients) {
         addresses.push(recipient.address);
-        amounts.push(toBN(recipient.amount));
+        amounts.push(toBN(BigInt(recipient.amount).toString()));
       }
       const multisendContract = this.getMultiSendContract(contractAddress);
       return multisendContract.methods.sendErc20(tokenAddress, addresses, amounts).encodeABI();
     } else {
       const [{ address, amount }] = params.recipients;
-      const amountBN = toBN(amount);
+      const amountBN = toBN(BigInt(amount).toString());
       const data = this.getERC20Contract(tokenAddress)
         .methods.transfer(address, amountBN)
         .encodeABI();

--- a/packages/crypto-wallet-core/src/transactions/matic-erc20/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/matic-erc20/index.ts
@@ -40,13 +40,13 @@ export class MATICERC20TxProvider extends MATICTxProvider {
       const amounts = [];
       for (let recipient of recipients) {
         addresses.push(recipient.address);
-        amounts.push(toBN(recipient.amount));
+        amounts.push(toBN(BigInt(recipient.amount).toString()));
       }
       const multisendContract = this.getMultiSendContract(contractAddress);
       return multisendContract.methods.sendErc20(tokenAddress, addresses, amounts).encodeABI();
     } else {
       const [{ address, amount }] = params.recipients;
-      const amountBN = toBN(amount);
+      const amountBN = toBN(BigInt(amount).toString());
       const data = this.getERC20Contract(tokenAddress)
         .methods.transfer(address, amountBN)
         .encodeABI();


### PR DESCRIPTION
The crux of the issue is that very large numbers are returned from mongo with scientific notation (ie 1.1573971113625423e+25). The Web3.utils.toBN method does not know what to do with scientific notation when given as a number or even as a string. The solution is to parse all numbers as a BigInt but then return the number as a string (which toBN is ready to handle).

Once this is is merged we need to publish and update BitPay and the Wallet with the new changes. Will need to get the new version of BWS and BWC as well as CWC.