### PR TITLE
Ref: "Buy crypto" rule added to services data

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4604,15 +4604,15 @@ export class WalletService implements IWalletService {
       externalServicesConfig.swapCrypto = {...externalServicesConfig.swapCrypto, ...{ disabled: true, disabledTitle:'Unavailable', disabledMessage:'Swaps are currently unavailable in your area.'}};
     }
 
-    // Buy crypto rules: Sardine
-    const sardineUsaBannedStates = ['NY'];
+    // Buy crypto rules
+    const buyCryptoUsaBannedStates = ['NY'];
     if (
       // Logged in with bitpayId
-      (['US', 'USA'].includes(opts?.bitpayIdLocationCountry?.toUpperCase()) && sardineUsaBannedStates.includes(opts?.bitpayIdLocationState?.toUpperCase())) ||
+      (['US', 'USA'].includes(opts?.bitpayIdLocationCountry?.toUpperCase()) && buyCryptoUsaBannedStates.includes(opts?.bitpayIdLocationState?.toUpperCase())) ||
       // Logged out (IP restriction)
-      (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && sardineUsaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
+      (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && buyCryptoUsaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
     ) {
-      externalServicesConfig.buyCrypto.sardine = {...externalServicesConfig.buyCrypto.sardine, ...{ disabled: true, disabledMessage:'This service is currently unavailable in your area.'}};
+      externalServicesConfig.buyCrypto = {...externalServicesConfig.buyCrypto, ...{ disabled: true, disabledTitle:'Unavailable', disabledMessage:'This service is currently unavailable in your area.'}};
     }
 
     return cb(null, externalServicesConfig);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4612,7 +4612,7 @@ export class WalletService implements IWalletService {
       // Logged out (IP restriction)
       (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && sardineUsaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
     ) {
-      externalServicesConfig.buyCrypto.sardine = {...externalServicesConfig.buyCrypto.sardine, ...{ disabled: true, disabledMessage:'Sardine is currently unavailable in your area.'}};
+      externalServicesConfig.buyCrypto.sardine = {...externalServicesConfig.buyCrypto.sardine, ...{ disabled: true, disabledMessage:'This service is currently unavailable in your area.'}};
     }
 
     return cb(null, externalServicesConfig);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4587,19 +4587,32 @@ export class WalletService implements IWalletService {
     let externalServicesConfig: ExternalServicesConfig = _.cloneDeep(config.services);
 
     const isLoggedIn = !!opts?.bitpayIdLocationCountry;
-    const usaBannedStates = ['HI', 'LA', 'NY'];
+
+    // Swap crypto rules
+    const swapUsaBannedStates = ['HI', 'LA', 'NY'];
 
     if (
       // Logged in with bitpayId
-      (['US', 'USA'].includes(opts?.bitpayIdLocationCountry?.toUpperCase()) && usaBannedStates.includes(opts?.bitpayIdLocationState?.toUpperCase())) ||
+      (['US', 'USA'].includes(opts?.bitpayIdLocationCountry?.toUpperCase()) && swapUsaBannedStates.includes(opts?.bitpayIdLocationState?.toUpperCase())) ||
       // Logged out (IP restriction)
-      (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && usaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
+      (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && swapUsaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
     ) {
       externalServicesConfig.swapCrypto = {...externalServicesConfig.swapCrypto, ...{ disabled: true, disabledMessage:'Swaps are currently unavailable in your area.'}};
     }
 
     if (opts?.platform?.os === 'ios' && opts?.currentAppVersion === '14.11.5') {
       externalServicesConfig.swapCrypto = {...externalServicesConfig.swapCrypto, ...{ disabled: true, disabledTitle:'Unavailable', disabledMessage:'Swaps are currently unavailable in your area.'}};
+    }
+
+    // Buy crypto rules: Sardine
+    const sardineUsaBannedStates = ['NY'];
+    if (
+      // Logged in with bitpayId
+      (['US', 'USA'].includes(opts?.bitpayIdLocationCountry?.toUpperCase()) && sardineUsaBannedStates.includes(opts?.bitpayIdLocationState?.toUpperCase())) ||
+      // Logged out (IP restriction)
+      (!isLoggedIn && ['US', 'USA'].includes(opts?.currentLocationCountry?.toUpperCase()) && sardineUsaBannedStates.includes(opts?.currentLocationState?.toUpperCase()))
+    ) {
+      externalServicesConfig.buyCrypto.sardine = {...externalServicesConfig.buyCrypto.sardine, ...{ disabled: true, disabledMessage:'Sardine is currently unavailable in your area.'}};
     }
 
     return cb(null, externalServicesConfig);

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -10737,6 +10737,10 @@ describe('Wallet service', function() {
               disabled: false,
               removed: false
             },
+            sardine: {
+              disabled: false,
+              removed: false
+            },
             simplex: {
               disabled: false,
               removed: false
@@ -10757,8 +10761,8 @@ describe('Wallet service', function() {
       });
 
       describe('User logged out', () => {
-        const usaBannedStates = ['HI', 'LA', 'NY'];
-        for (const bannedState of usaBannedStates) {
+        const swapUsaBannedStates = ['HI', 'LA', 'NY'];
+        for (const bannedState of swapUsaBannedStates) {
           it(`should return swap crypto disabled if the user is located in ${bannedState}`, () => {
             const opts = {
               currentLocationCountry: 'US',
@@ -10797,6 +10801,36 @@ describe('Wallet service', function() {
             should.not.exist(err);
             should.exist(config.swapCrypto);
             config.swapCrypto.disabled.should.equal(false);
+          });
+        });
+
+        const sardineUsaBannedStates = ['NY'];
+        for (const bannedState of sardineUsaBannedStates) {
+          it(`should return Sardine disabled if the user is located in ${bannedState}`, () => {
+            const opts = {
+              currentLocationCountry: 'US',
+              currentLocationState: bannedState,
+            };
+      
+            server.getServicesData(opts, (err, config) => {
+              should.not.exist(err);
+              should.exist(config.buyCrypto.sardine);
+              config.buyCrypto.sardine.disabled.should.equal(true);
+              config.buyCrypto.sardine.disabledMessage.should.equal('Sardine is currently unavailable in your area.');
+            });
+          });
+        };
+
+        it('should return Sardine enabled if the user is in USA located outside NY', () => {
+          const opts = {
+            currentLocationCountry: 'US',
+            currentLocationState: 'FL',
+          };
+    
+          server.getServicesData(opts, (err, config) => {
+            should.not.exist(err);
+            should.exist(config.buyCrypto.sardine);
+            config.buyCrypto.sardine.disabled.should.equal(false);
           });
         });
       });
@@ -10939,6 +10973,37 @@ describe('Wallet service', function() {
             should.not.exist(err);
             should.exist(config.swapCrypto);
             config.swapCrypto.disabled.should.equal(false);
+          });
+        });
+
+        it('should return Sardine disabled if the user is registred in NY and located outside NY', () => {
+          const opts = {
+            currentLocationCountry: 'US',
+            currentLocationState: 'FL',
+            bitpayIdLocationCountry: 'US',
+            bitpayIdLocationState: 'NY',
+          };
+    
+          server.getServicesData(opts, (err, config) => {
+            should.not.exist(err);
+            should.exist(config.buyCrypto.sardine);
+            config.buyCrypto.sardine.disabled.should.equal(true);
+            config.buyCrypto.sardine.disabledMessage.should.equal('Sardine is currently unavailable in your area.');
+          });
+        });
+
+        it('should return Sardine enabled if the user is registred outside NY and located in NY', () => {
+          const opts = {
+            currentLocationCountry: 'US',
+            currentLocationState: 'NY',
+            bitpayIdLocationCountry: 'US',
+            bitpayIdLocationState: 'FL',
+          };
+    
+          server.getServicesData(opts, (err, config) => {
+            should.not.exist(err);
+            should.exist(config.buyCrypto.sardine);
+            config.buyCrypto.sardine.disabled.should.equal(false);
           });
         });
       });

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -10816,7 +10816,7 @@ describe('Wallet service', function() {
               should.not.exist(err);
               should.exist(config.buyCrypto.sardine);
               config.buyCrypto.sardine.disabled.should.equal(true);
-              config.buyCrypto.sardine.disabledMessage.should.equal('Sardine is currently unavailable in your area.');
+              config.buyCrypto.sardine.disabledMessage.should.equal('This service is currently unavailable in your area.');
             });
           });
         };
@@ -10988,7 +10988,7 @@ describe('Wallet service', function() {
             should.not.exist(err);
             should.exist(config.buyCrypto.sardine);
             config.buyCrypto.sardine.disabled.should.equal(true);
-            config.buyCrypto.sardine.disabledMessage.should.equal('Sardine is currently unavailable in your area.');
+            config.buyCrypto.sardine.disabledMessage.should.equal('This service is currently unavailable in your area.');
           });
         });
 

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -10804,9 +10804,9 @@ describe('Wallet service', function() {
           });
         });
 
-        const sardineUsaBannedStates = ['NY'];
-        for (const bannedState of sardineUsaBannedStates) {
-          it(`should return Sardine disabled if the user is located in ${bannedState}`, () => {
+        const buyCryptoUsaBannedStates = ['NY'];
+        for (const bannedState of buyCryptoUsaBannedStates) {
+          it(`should return buy crypto disabled if the user is located in ${bannedState}`, () => {
             const opts = {
               currentLocationCountry: 'US',
               currentLocationState: bannedState,
@@ -10814,14 +10814,14 @@ describe('Wallet service', function() {
       
             server.getServicesData(opts, (err, config) => {
               should.not.exist(err);
-              should.exist(config.buyCrypto.sardine);
-              config.buyCrypto.sardine.disabled.should.equal(true);
-              config.buyCrypto.sardine.disabledMessage.should.equal('This service is currently unavailable in your area.');
+              should.exist(config.buyCrypto);
+              config.buyCrypto.disabled.should.equal(true);
+              config.buyCrypto.disabledMessage.should.equal('This service is currently unavailable in your area.');
             });
           });
         };
 
-        it('should return Sardine enabled if the user is in USA located outside NY', () => {
+        it('should return buy crypto enabled if the user is in USA located outside NY', () => {
           const opts = {
             currentLocationCountry: 'US',
             currentLocationState: 'FL',
@@ -10829,8 +10829,8 @@ describe('Wallet service', function() {
     
           server.getServicesData(opts, (err, config) => {
             should.not.exist(err);
-            should.exist(config.buyCrypto.sardine);
-            config.buyCrypto.sardine.disabled.should.equal(false);
+            should.exist(config.buyCrypto);
+            config.buyCrypto.disabled.should.equal(false);
           });
         });
       });
@@ -10976,7 +10976,7 @@ describe('Wallet service', function() {
           });
         });
 
-        it('should return Sardine disabled if the user is registred in NY and located outside NY', () => {
+        it('should return buy crypto disabled if the user is registred in NY and located outside NY', () => {
           const opts = {
             currentLocationCountry: 'US',
             currentLocationState: 'FL',
@@ -10986,13 +10986,13 @@ describe('Wallet service', function() {
     
           server.getServicesData(opts, (err, config) => {
             should.not.exist(err);
-            should.exist(config.buyCrypto.sardine);
-            config.buyCrypto.sardine.disabled.should.equal(true);
-            config.buyCrypto.sardine.disabledMessage.should.equal('This service is currently unavailable in your area.');
+            should.exist(config.buyCrypto);
+            config.buyCrypto.disabled.should.equal(true);
+            config.buyCrypto.disabledMessage.should.equal('This service is currently unavailable in your area.');
           });
         });
 
-        it('should return Sardine enabled if the user is registred outside NY and located in NY', () => {
+        it('should return buy crypto enabled if the user is registred outside NY and located in NY', () => {
           const opts = {
             currentLocationCountry: 'US',
             currentLocationState: 'NY',
@@ -11002,8 +11002,8 @@ describe('Wallet service', function() {
     
           server.getServicesData(opts, (err, config) => {
             should.not.exist(err);
-            should.exist(config.buyCrypto.sardine);
-            config.buyCrypto.sardine.disabled.should.equal(false);
+            should.exist(config.buyCrypto);
+            config.buyCrypto.disabled.should.equal(false);
           });
         });
       });


### PR DESCRIPTION
With this PR:

The blocking rule will be as follows:
- If the user is logged in but the account address is NY, "Buy crypto" will be blocked, regardless of current location
- If the user is logged out, the block will be based on the current location (IP). If it is in NY then it is blocked.

The message “This service is currently unavailable in your area.“ will be shown into a modal in the buy crypto root page for NY users, and they won't be able to use this feature.
