### PR TITLE
[BCN] Add replacedByTxid to RBF'd txs

### DIFF
--- a/packages/bitcore-node/src/models/baseTransaction.ts
+++ b/packages/bitcore-node/src/models/baseTransaction.ts
@@ -15,6 +15,7 @@ export interface ITransaction {
   fee: number;
   value: number;
   wallets: ObjectID[];
+  replacedByTxid?: string;
 }
 
 export abstract class BaseTransaction<T extends ITransaction> extends BaseModel<T> {

--- a/packages/bitcore-node/src/types/Transaction.ts
+++ b/packages/bitcore-node/src/types/Transaction.ts
@@ -14,4 +14,5 @@ export interface TransactionJSON {
   inputCount: number;
   outputCount: number;
   value: number;
+  replacedByTxid?: string;
 }


### PR DESCRIPTION
Currently, there is no good way to identify which transaction replaced an existing one in the mempool. If I have a system that is monitoring a tx and that tx is RBF'd, all our API endpoint returns is a blockHeight of -3 (conflicting) without a pointer to the conflicting tx.

This PR adds the `replacedByTxid` field to the transaction schema and records it when a tx is RBF'd. This required a refactor of the `pruneMempool` method to reliably record the `replacedByTxid` where appropriate. The result is a simpler, more elegant `pruneMempool` method.