### PR TITLE
[Insight] Add tx replacement links; Testnet banner; Minor tweaks

### DIFF
--- a/packages/insight/src/components/info.tsx
+++ b/packages/insight/src/components/info.tsx
@@ -27,7 +27,7 @@ const Message = styled(motion.div)<{type: string}>`
   }}
 `;
 
-const Info = ({message, type}: {message?: string; type: string}) => {
+const Info = ({message, type, onClick}: {message?: string; type: string, onClick?: () => void}) => {
   const infoAnime = {
     initial: {
       opacity: 0,
@@ -36,13 +36,14 @@ const Info = ({message, type}: {message?: string; type: string}) => {
     animate: {
       opacity: 1,
       height: 'auto',
+      cursor: onClick ? 'pointer' : 'inherit'
     },
   };
 
   message = message || 'Uh Oh, Something went wrong. Please try again.';
 
   return (
-    <Message type={type} variants={infoAnime} initial='initial' animate='animate'>
+    <Message type={type} variants={infoAnime} initial='initial' animate='animate' onClick={onClick}>
       {message}
     </Message>
   );

--- a/packages/insight/src/components/layout.tsx
+++ b/packages/insight/src/components/layout.tsx
@@ -73,6 +73,15 @@ const ParallaxDiv = styled(Parallax)`
   background-color: ${({theme: {dark}}) => (dark ? '#090909' : Feather)};
 `;
 
+const TestnetDiv = styled.div`
+  width: 100%;
+  background: red;
+  color: white;
+  padding: 6px;
+  text-align: center;
+  border-radius: 10px;
+`;
+
 const Layout = ({children}: {children?: ReactNode}) => {
   const theme = useTheme();
   const url = theme.dark ? PlusBackgroundDark : PlusBackgroundLight;
@@ -82,6 +91,11 @@ const Layout = ({children}: {children?: ReactNode}) => {
 
   const isHomePage = () => {
     return location.pathname === '/';
+  };
+
+  const isTestnet = () => {
+    const network = location.pathname.split('/')[2]?.toLowerCase();
+    return network && network !== 'mainnet';
   };
 
   const searchAnime = {
@@ -140,6 +154,11 @@ const Layout = ({children}: {children?: ReactNode}) => {
                 <motion.div variants={ErrorExitAnime} exit='exit'>
                   <Info message={searchError} type={'error'} />
                 </motion.div>
+              )}
+            </AnimatePresence>
+            <AnimatePresence>
+              {isTestnet() && (
+                <TestnetDiv>This is a test network. Testnet currencies have no real-world value.</TestnetDiv>
               )}
             </AnimatePresence>
             {children}

--- a/packages/insight/src/components/transaction-details-eth.tsx
+++ b/packages/insight/src/components/transaction-details-eth.tsx
@@ -23,7 +23,7 @@ const TransactionDetailsEth = ({
   network: string;
 }) => {
   const navigate = useNavigate();
-  const {txid, blockTime, coinbase, from, to, fee, confirmations, value} = transaction;
+  const {txid, blockTime, blockHeight, coinbase, from, to, fee, confirmations, value} = transaction;
 
   const goToAddress = (address: any) => {
     return navigate(`/${currency}/${network}/address/${address}`);
@@ -41,7 +41,7 @@ const TransactionDetailsEth = ({
         </TileDescription>
 
         <TileDescription textAlign='right' value padding='0 0 0 0.25rem'>
-          Mined on: {getFormattedDate(blockTime)}
+          {`${blockHeight > -1 ? 'Mined' : 'Seen'} on: ${getFormattedDate(blockTime)}`}
         </TileDescription>
       </TransactionTileHeader>
 

--- a/packages/insight/src/components/transaction-details.tsx
+++ b/packages/insight/src/components/transaction-details.tsx
@@ -58,7 +58,7 @@ const TransactionDetails = ({
 }) => {
   const navigate = useNavigate();
   const [formattedInputs, setFormattedInputs] = useState<any[]>();
-  const {outputs, txid, blockTime, coinbase, inputs, confirmations, fee, value} = transaction;
+  const {outputs, txid, blockTime, blockHeight, coinbase, inputs, confirmations, fee, value} = transaction;
   const goToAddress = (address: any) => {
     return navigate(`/${currency}/${network}/address/${address}`);
   };
@@ -120,7 +120,7 @@ const TransactionDetails = ({
         </TileDescription>
 
         <TileDescription textAlign='right' value padding='0 0 0 0.25rem'>
-          Mined on: {getFormattedDate(blockTime)}
+          {`${blockHeight > -1 ? 'Mined' : 'Seen'} on: ${getFormattedDate(blockTime)}`}
         </TileDescription>
       </TransactionTileHeader>
 

--- a/packages/insight/src/components/transaction-summary-eth.tsx
+++ b/packages/insight/src/components/transaction-summary-eth.tsx
@@ -12,7 +12,7 @@ const TransactionSummaryEth = ({transaction}: {transaction: TransactionEth}) => 
       <SharedTile title='Gas Limit' description={gasLimit} />
       <SharedTile
         title='Gas Price'
-        description={`${(gasPrice / 1e9).toFixed(8)} Gwei`}
+        description={`${(gasPrice / 1e9).toFixed(2)} Gwei`}
       />
       <SharedTile title='Fee' description={`${getConvertedValue(fee, 'ETH').toFixed(8)} ETH`} />
       {confirmations > 0 ? (

--- a/packages/insight/src/components/transaction-summary-eth.tsx
+++ b/packages/insight/src/components/transaction-summary-eth.tsx
@@ -3,16 +3,18 @@ import {getConvertedValue, getFormattedDate} from '../utilities/helper-methods';
 import {SharedTile} from './shared';
 
 const TransactionSummaryEth = ({transaction}: {transaction: TransactionEth}) => {
-  const {gasLimit, gasPrice, from, to, blockTime, confirmations} = transaction;
+  const {gasLimit, gasPrice, fee, from, to, nonce, blockTime, confirmations} = transaction;
   return (
     <>
+      <SharedTile title='From' description={from} />
+      <SharedTile title='To' description={to} />
+      <SharedTile title='Nonce' description={nonce} />
       <SharedTile title='Gas Limit' description={gasLimit} />
       <SharedTile
         title='Gas Price'
-        description={`${getConvertedValue(gasPrice, 'ETH').toFixed(8)} ETH`}
+        description={`${(gasPrice / 1e9).toFixed(8)} Gwei`}
       />
-      <SharedTile title='From' description={from} />
-      <SharedTile title='To' description={to} />
+      <SharedTile title='Fee' description={`${getConvertedValue(fee, 'ETH').toFixed(8)} ETH`} />
       {confirmations > 0 ? (
         <SharedTile title='Mined Time' description={getFormattedDate(blockTime)} />
       ) : null}

--- a/packages/insight/src/components/transaction-summary.tsx
+++ b/packages/insight/src/components/transaction-summary.tsx
@@ -5,10 +5,11 @@ const TransactionSummary = ({transaction}: {transaction: Transaction}) => {
   const {size, fee} = transaction;
   return (
     <>
-      <SharedTile title='Size' description={`${size} (bytes)`} />
+      <SharedTile title='Size' description={`${size} bytes`} />
       {fee >= 0 && size ? (
-        <SharedTile title='Fee Rate' description={`${(fee / size).toFixed(2)} sats/bytes`} />
+        <SharedTile title='Fee Rate' description={`${(fee / size).toFixed(2)} sats/byte`} />
       ) : null}
+      <SharedTile title='Fee' description={`${fee} sats`} />
     </>
   );
 };

--- a/packages/insight/src/pages/transaction.tsx
+++ b/packages/insight/src/pages/transaction.tsx
@@ -14,7 +14,7 @@ import {DisplayFlex, ConfirmationLabel} from '../assets/styles/global';
 import {TransactionBodyCol, TransactionTileBody} from '../assets/styles/transaction';
 import {motion} from 'framer-motion';
 import {routerFadeIn} from '../utilities/animations';
-import {Link, useLocation, useParams, useSearchParams} from 'react-router-dom';
+import {Link, useLocation, useNavigate, useParams, useSearchParams} from 'react-router-dom';
 import {useAppDispatch} from '../utilities/hooks';
 import React, {useEffect, useState} from 'react';
 import {changeCurrency, changeNetwork} from '../store/app.actions';
@@ -28,6 +28,7 @@ const getTxData = (state: any): Promise<any> => {
 };
 
 const TransactionHash: React.FC = () => {
+  const navigate = useNavigate();
   const params = useParams<{currency: string; network: string; tx: string}>();
   const {tx} = params;
   let {currency, network} = params;
@@ -95,6 +96,13 @@ const TransactionHash: React.FC = () => {
       });
   }, [network, currency, tx]);
 
+  const goToTx = (tx: any) => {
+    return navigate({
+      pathname: `/${currency}/${network}/tx/${tx}`,
+      search: '',
+    });
+  };
+
   return (
     <>
       {!isLoading ? (
@@ -122,10 +130,14 @@ const TransactionHash: React.FC = () => {
               <SecondaryTitle>Summary</SecondaryTitle>
 
               {transaction.confirmations === -3 && (
+                transaction.replacedByTxid ?
                 <Info
-                  message={
-                    'This transaction is invalid and will never confirm, because some of its inputs are already spent.'
-                  }
+                  message={`This transaction was replaced by ${transaction.replacedByTxid}`}
+                  type={'error'}
+                  onClick={() => goToTx(transaction.replacedByTxid)}
+                /> :
+                <Info
+                  message={`This transaction was replaced by another transaction that ${transaction.chain === 'ETH' ? 'used the same nonce' : 'spent some of it\'s inputs'}.`}
                   type={'error'}
                 />
               )}

--- a/packages/insight/src/utilities/models.ts
+++ b/packages/insight/src/utilities/models.ts
@@ -27,6 +27,7 @@ export interface TransactionEth extends ApiTransaction {
   to: string;
   from: string;
   height?: number;
+  nonce: number;
 }
 
 export interface ApiCoin {


### PR DESCRIPTION
This PR:

* Adds a link to the replacement tx when a tx has been RBF'd or replaced by nonce
* Adds a banner when on testnet
* Adds some useful fields to ETH and UTXO tx page
* Minor copy tweaks for accuracy