### PR TITLE
[BWS] WalletService type in routes

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -171,7 +171,9 @@ export class ExpressApp {
       return WalletService.getInstance(opts);
     };
 
-    const getServerWithAuth = (req, res, opts, cb?: (err: any, data?: any) => void) => {
+    type ServerCallback = (server: WalletService, err?: Error) => void;
+    type ServerOpts = { allowSession?: boolean; silentFailure?: boolean; onlySupportStaff?: boolean; onlyMarketingStaff?: boolean };
+    const getServerWithAuth = (req, res, opts: ServerOpts | ServerCallback, cb?: ServerCallback | undefined) => {
       if (_.isFunction(opts)) {
         cb = opts;
         opts = {};
@@ -201,6 +203,7 @@ export class ExpressApp {
         auth.session = credentials.session;
       }
       WalletService.getInstanceWithAuth(auth, (err, server) => {
+        opts = opts as ServerOpts;
         if (err) {
           if (opts.silentFailure) {
             return cb(null, err);
@@ -390,7 +393,7 @@ export class ExpressApp {
 
     router.post('/v2/wallets/:id/copayers/', (req, res) => {
       req.body.walletId = req.params['id'];
-      let server;
+      let server: WalletService;
       try {
         server = getServer(req, res);
       } catch (ex) {

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -172,7 +172,7 @@ export class ExpressApp {
     };
 
     type ServerCallback = (server: WalletService, err?: Error) => void;
-    type ServerOpts = { allowSession?: boolean; silentFailure?: boolean; onlySupportStaff?: boolean; onlyMarketingStaff?: boolean };
+    interface ServerOpts { allowSession?: boolean; silentFailure?: boolean; onlySupportStaff?: boolean; onlyMarketingStaff?: boolean }
     const getServerWithAuth = (req, res, opts: ServerOpts | ServerCallback, cb?: ServerCallback | undefined) => {
       if (_.isFunction(opts)) {
         cb = opts;

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -13,6 +13,8 @@ const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;
 
+type TxProposalStatus = 'temporary' | 'pending' | 'accepted' | 'rejected' | 'broadcasted';
+
 export interface ITxProposal {
   type: string;
   creatorName: string;
@@ -44,7 +46,7 @@ export interface ITxProposal {
   walletN: number;
   requiredSignatures: number;
   requiredRejections: number;
-  status: string;
+  status: TxProposalStatus;
   actions: [];
   feeLevel: number;
   feePerKb: number;
@@ -108,7 +110,7 @@ export class TxProposal {
   walletN: number;
   requiredSignatures: number;
   requiredRejections: number;
-  status: string;
+  status: TxProposalStatus;
   actions: any[] = [];
   feeLevel: number;
   feePerKb: number;


### PR DESCRIPTION
This adds the WalletService type to the expressapp.ts routes file to allow easy mapping into the `server` var that's prevalent throughout the file.