### PR TITLE
[BWS] Dev cleanup

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/verifier.ts
+++ b/packages/bitcore-wallet-client/src/lib/verifier.ts
@@ -15,6 +15,16 @@ var log = require('./log');
  * @constructor
  */
 export class Verifier {
+  private static _useRegtest: boolean = false;
+
+  static useRegtest() {
+    this._useRegtest = true;
+  }
+
+  static useTestnet() {
+    this._useRegtest = false;
+  }
+  
   /**
    * Check address
    *
@@ -28,12 +38,17 @@ export class Verifier {
       'Failed state: credentials at <checkAddress>'
     );
 
+    let network = credentials.network;
+    if (network === 'testnet' && this._useRegtest) {
+      network = 'regtest';
+    }
+
     var local = Utils.deriveAddress(
       address.type || credentials.addressType,
       credentials.publicKeyRing,
       address.path,
       credentials.m,
-      credentials.network,
+      network,
       credentials.chain,
       escrowInputs
     );

--- a/packages/bitcore-wallet-service/bws.example.config.js
+++ b/packages/bitcore-wallet-service/bws.example.config.js
@@ -46,7 +46,8 @@ module.exports = {
         url: 'https://api.bitcore.io'
       },
       testnet: {
-        url: 'https://api.bitcore.io'
+        url: 'https://api.bitcore.io',
+        regtestEnabled: false
       }
     },
     eth: {
@@ -54,7 +55,8 @@ module.exports = {
         url: 'https://api-eth.bitcore.io'
       },
       testnet: {
-        url: 'https://api-eth.bitcore.io'
+        url: 'https://api-eth.bitcore.io',
+        regtestEnabled: false
       }
     },
     xrp: {
@@ -62,7 +64,8 @@ module.exports = {
         url: 'https://api-xrp.bitcore.io'
       },
       testnet: {
-        url: 'https://api-xrp.bitcore.io'
+        url: 'https://api-xrp.bitcore.io',
+        regtestEnabled: false
       }
     },
     doge: {
@@ -70,7 +73,8 @@ module.exports = {
         url: 'https://api.bitcore.io'
       },
       testnet: {
-        url: 'https://api.bitcore.io'
+        url: 'https://api.bitcore.io',
+        regtestEnabled: false
       }
     },
     ltc: {
@@ -78,7 +82,8 @@ module.exports = {
         url: 'https://api.bitcore.io'
       },
       testnet: {
-        url: 'https://api.bitcore.io'
+        url: 'https://api.bitcore.io',
+        regtestEnabled: false
       }
     },
     socketApiKey: 'socketApiKey'

--- a/packages/bitcore-wallet-service/src/bcmonitor/bcmonitor.ts
+++ b/packages/bitcore-wallet-service/src/bcmonitor/bcmonitor.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import _ from 'lodash';
-import logger from '../lib/logger';
 import config from '../config';
 import { BlockchainMonitor } from '../lib/blockchainmonitor';
+import logger from '../lib/logger';
 
 const bcm = new BlockchainMonitor();
 bcm.start(config, err => {

--- a/packages/bitcore-wallet-service/src/bcmonitor/bcmonitor.ts
+++ b/packages/bitcore-wallet-service/src/bcmonitor/bcmonitor.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import _ from 'lodash';
-import { BlockchainMonitor } from '../lib/blockchainmonitor';
 import logger from '../lib/logger';
+import config from '../config';
+import { BlockchainMonitor } from '../lib/blockchainmonitor';
 
-const config = require('../config');
 const bcm = new BlockchainMonitor();
 bcm.start(config, err => {
   if (err) throw err;

--- a/packages/bitcore-wallet-service/src/bws.ts
+++ b/packages/bitcore-wallet-service/src/bws.ts
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
 import 'source-map-support/register';
+import cluster from 'cluster';
 import logger from './lib/logger';
-
 import { ExpressApp } from './lib/expressapp';
+import config from './config';
 
-const config = require('./config');
 const port = process.env.BWS_PORT || config.port || 3232;
-const cluster = require('cluster');
 const serverModule = config.https ? require('https') : require('http');
 
 const serverOpts: {

--- a/packages/bitcore-wallet-service/src/bws.ts
+++ b/packages/bitcore-wallet-service/src/bws.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import cluster from 'cluster';
 import * as fs from 'fs';
 import 'source-map-support/register';
-import cluster from 'cluster';
-import logger from './lib/logger';
-import { ExpressApp } from './lib/expressapp';
 import config from './config';
+import { ExpressApp } from './lib/expressapp';
+import logger from './lib/logger';
 
 const port = process.env.BWS_PORT || config.port || 3232;
 const serverModule = config.https ? require('https') : require('http');

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -360,4 +360,4 @@ const Config = () => {
   return defaultConfig;
 };
 
-module.exports = Config();
+export default module.exports;

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { logger } from './lib/logger';
 
-const Config = () => {
+const Config = (): any => {
   let defaultConfig = {
     basePath: '/bws/api',
     disableLogs: false,
@@ -360,4 +360,4 @@ const Config = () => {
   return defaultConfig;
 };
 
-export default module.exports;
+export default Config();

--- a/packages/bitcore-wallet-service/src/deprecated-serverMessages.ts
+++ b/packages/bitcore-wallet-service/src/deprecated-serverMessages.ts
@@ -1,4 +1,4 @@
-module.exports = (wallet, appName, appVersion) => {
+export const serverMessages = (wallet, appName, appVersion) => {
   if (!appVersion || !appName) return;
 
   if (wallet.network == 'livenet' && appVersion.major == 5) {

--- a/packages/bitcore-wallet-service/src/emailservice/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/emailservice/emailservice.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import logger from '../lib/logger';
-var config = require('../config');
-const EmailService = require('../lib/emailservice');
+import config from '../config';
+import { EmailService } from '../lib/emailservice';
 
 const emailService = new EmailService();
 emailService.start(config, err => {

--- a/packages/bitcore-wallet-service/src/emailservice/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/emailservice/emailservice.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import logger from '../lib/logger';
 import config from '../config';
 import { EmailService } from '../lib/emailservice';
+import logger from '../lib/logger';
 
 const emailService = new EmailService();
 emailService.start(config, err => {

--- a/packages/bitcore-wallet-service/src/fiatrateservice/fiatrateservice.ts
+++ b/packages/bitcore-wallet-service/src/fiatrateservice/fiatrateservice.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import logger from '../lib/logger';
-const config = require('../config');
-
+import config from '../config';
 import { FiatRateService } from '../lib/fiatrateservice';
 
 const service = new FiatRateService();

--- a/packages/bitcore-wallet-service/src/fiatrateservice/fiatrateservice.ts
+++ b/packages/bitcore-wallet-service/src/fiatrateservice/fiatrateservice.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import logger from '../lib/logger';
 import config from '../config';
 import { FiatRateService } from '../lib/fiatrateservice';
+import logger from '../lib/logger';
 
 const service = new FiatRateService();
 service.init(config, err => {

--- a/packages/bitcore-wallet-service/src/lib/bchaddresstranslator.ts
+++ b/packages/bitcore-wallet-service/src/lib/bchaddresstranslator.ts
@@ -58,5 +58,3 @@ export class BCHAddressTranslator {
     else return ret[0];
   }
 }
-
-module.exports = BCHAddressTranslator;

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -1,19 +1,17 @@
-import _ from 'lodash';
 import { V8 } from './blockchainexplorers/v8';
 import { ChainService } from './chain/index';
-import { Common } from './common';
 
 const $ = require('preconditions').singleton();
-const Defaults = Common.Defaults;
+
 const PROVIDERS = {
   v8: {
     btc: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     bch: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     eth: {
       livenet: 'https://api-eth.bitcore.io',
@@ -28,12 +26,12 @@ const PROVIDERS = {
       testnet: 'https://api-xrp.bitcore.io'
     },
     doge: {
-      livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      livenet: 'https://api.bitcore.io',
+      testnet: 'https://api.bitcore.io'
     },
     ltc: {
       livenet: 'https://api.bitpay.com',
-      testnet: 'https://api.bitpay.com'
+      testnet: 'https://api.bitcore.io'
     }
   }
 };
@@ -44,20 +42,12 @@ export function BlockChainExplorer(opts) {
   const provider = opts.provider || 'v8';
   const chain = opts.chain?.toLowerCase() || ChainService.getChain(opts.coin); // getChain -> backwards compatibility
   const network = opts.network || 'livenet';
+  const url = opts.url || PROVIDERS[provider]?.[chain]?.[network];
 
-  $.checkState(PROVIDERS[provider], 'Provider ' + provider + ' not supported');
-  $.checkState(_.includes(_.keys(PROVIDERS[provider]), chain), 'Chain ' + chain + ' not supported by this provider');
+  $.checkState(url, `No url found for provider: ${provider}:${chain}:${network}`);
 
-  $.checkState(
-    _.includes(_.keys(PROVIDERS[provider][chain]), network),
-    'Network ' + network + ' not supported by this provider for chain ' + chain
-  );
-
-  const url = opts.url || PROVIDERS[provider][chain][network];
-
-  if (chain != 'bch' && opts.addressFormat) throw new Error('addressFormat only supported for bch');
-
-  if (chain == 'bch' && !opts.addressFormat) opts.addressFormat = 'cashaddr';
+  if (chain != 'bch' && opts.addressFormat) { throw new Error('addressFormat only supported for bch'); }
+  if (chain == 'bch' && !opts.addressFormat) { opts.addressFormat = 'cashaddr'; }
 
   switch (provider) {
     case 'v8':
@@ -69,8 +59,7 @@ export function BlockChainExplorer(opts) {
         userAgent: opts.userAgent,
         addressFormat: opts.addressFormat
       });
-
     default:
-      throw new Error('Provider ' + provider + ' not supported.');
+      throw new Error(`Provider not supported: ${provider}`);
   }
 }

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -30,7 +30,7 @@ const PROVIDERS = {
       testnet: 'https://api.bitcore.io'
     },
     ltc: {
-      livenet: 'https://api.bitpay.com',
+      livenet: 'https://api.bitcore.io',
       testnet: 'https://api.bitcore.io'
     }
   }

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -7,6 +7,7 @@ import { ChainService } from '../chain/index';
 import { Common } from '../common';
 import logger from '../logger';
 import { Client } from './v8/client';
+import config from '../../config';
 
 const $ = require('preconditions').singleton();
 const Bitcore = require('bitcore-lib');
@@ -19,14 +20,14 @@ const Bitcore_ = {
   doge: require('bitcore-lib-doge'),
   ltc: require('bitcore-lib-ltc')
 };
-const config = require('../../config');
+
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;
 
-function v8network(bwsNetwork) {
+function v8network(bwsNetwork, chain = 'btc') {
   if (bwsNetwork == 'livenet') return 'mainnet';
-  if (bwsNetwork == 'testnet' && config.blockchainExplorerOpts.btc.testnet.regtestEnabled) {
+  if (bwsNetwork == 'testnet' && config.blockchainExplorerOpts?.[chain.toLowerCase()]?.testnet?.regtestEnabled) {
     return 'regtest';
   }
   return bwsNetwork;
@@ -52,11 +53,11 @@ export class V8 {
     $.checkArgument(Utils.checkValueInCollection(opts.chain, Constants.CHAINS));
     $.checkArgument(opts.url);
 
-    this.apiPrefix = _.isUndefined(opts.apiPrefix) ? '/api' : opts.apiPrefix;
+    this.apiPrefix = opts.apiPrefix == null ? '/api' : opts.apiPrefix;
     this.chain = opts.chain;
 
     this.network = opts.network || 'livenet';
-    this.v8network = v8network(this.network);
+    this.v8network = v8network(this.network, this.chain);
 
     // v8 is always cashaddr
     this.addressFormat = this.chain == 'bch' ? 'cashaddr' : null;
@@ -252,13 +253,13 @@ export class V8 {
       })
       .catch(err => {
         if (count > 3) {
-          logger.error('FINAL Broadcast error: %o', err);
+          logger.error('[v8.js] FINAL Broadcast error: %o', err);
           return cb(err);
         } else {
           count++;
           // retry
           setTimeout(() => {
-            logger.info('Retrying broadcast after %o', count * Defaults.BROADCAST_RETRY_TIME);
+            logger.info('[v8.js] Retrying broadcast after %o', count * Defaults.BROADCAST_RETRY_TIME);
             return this.broadcast(rawTx, cb, count);
           }, count * Defaults.BROADCAST_RETRY_TIME);
         }
@@ -267,7 +268,7 @@ export class V8 {
 
   // This is for internal usage, addresses should be returned on internal representation
   getTransaction(txid, cb) {
-    console.log('[v8.js.207] GET TX', txid); // TODO
+    logger.debug('[v8.js] GET TX %o', txid);
     const client = this._getClient();
     client
       .getTx({ txid })
@@ -288,7 +289,7 @@ export class V8 {
   }
 
   getAddressUtxos(address, height, cb) {
-    console.log(' GET ADDR UTXO', address, height); // TODO
+    logger.debug('[v8.js] GET ADDR UTXO, %o, %o', address, height); // TODO
     const client = this._getClient();
 
     client
@@ -342,7 +343,7 @@ export class V8 {
         try {
           tx = JSON.parse(rawTx);
         } catch (e) {
-          logger.error('v8 error at JSON.parse:' + e + ' Parsing:' + rawTx + ':');
+          logger.error('[v8.js] Error at JSON.parse:' + e + ' Parsing:' + rawTx + ':');
           return cb(e);
         }
         // v8 field name differences
@@ -357,7 +358,7 @@ export class V8 {
     });
 
     txStream.on('error', e => {
-      logger.error('v8 error: %o', e);
+      logger.error('[v8.js] Error: %o', e);
       broken = true;
       return cb(e);
     });
@@ -365,7 +366,7 @@ export class V8 {
 
   getAddressActivity(address, cb) {
     const url = this.baseUrl + '/address/' + address + '/txs?limit=1';
-    logger.info('[v8.js %o] CHECKING ADDRESS ACTIVITY', url);
+    logger.debug('[v8.js] CHECKING ADDRESS ACTIVITY %o', url);
     this.request
       .get(url, {})
       .then(ret => {
@@ -378,7 +379,7 @@ export class V8 {
 
   getTransactionCount(address, cb) {
     const url = this.baseUrl + '/address/' + address + '/txs/count';
-    console.log('[v8.js.364:url:] CHECKING ADDRESS NONCE', url);
+    logger.debug('[v8.js] CHECKING ADDRESS NONCE %o', url);
     this.request
       .get(url, {})
       .then(ret => {
@@ -392,7 +393,7 @@ export class V8 {
 
   estimateGas(opts, cb) {
     const url = this.baseUrl + '/gas';
-    console.log('[v8.js.378:url:] CHECKING GAS LIMIT', url);
+    logger.debug('[v8.js] CHECKING GAS LIMIT %o', url);
     this.request
       .post(url, { body: opts, json: true })
       .then(gasLimit => {
@@ -406,7 +407,7 @@ export class V8 {
 
   getMultisigContractInstantiationInfo(opts, cb) {
     const url = `${this.baseUrl}/ethmultisig/${opts.sender}/instantiation/${opts.txId}`;
-    console.log('[v8.js.378:url:] CHECKING CONTRACT INSTANTIATION INFO', url);
+    logger.debug('[v8.js] CHECKING CONTRACT INSTANTIATION INFO %o', url);
     this.request
       .get(url, {})
       .then(contractInstantiationInfo => {
@@ -420,7 +421,7 @@ export class V8 {
 
   getMultisigContractInfo(opts, cb) {
     const url = this.baseUrl + '/ethmultisig/info/' + opts.multisigContractAddress;
-    console.log('[v8.js.378:url:] CHECKING CONTRACT INFO', url);
+    logger.debug('[v8.js] CHECKING CONTRACT INFO %o', url);
     this.request
       .get(url, {})
       .then(contractInfo => {
@@ -434,7 +435,7 @@ export class V8 {
 
   getTokenContractInfo(opts, cb) {
     const url = this.baseUrl + '/token/' + opts.tokenAddress;
-    console.log('[v8.js.378:url:] CHECKING CONTRACT INFO', url);
+    logger.debug('[v8.js] CHECKING CONTRACT INFO %o', url);
     this.request
       .get(url, {})
       .then(contractInfo => {
@@ -449,7 +450,7 @@ export class V8 {
   getTokenAllowance(opts, cb) {
     const url =
       this.baseUrl + '/token/' + opts.tokenAddress + '/allowance/' + opts.ownerAddress + '/for/' + opts.spenderAddress;
-    logger.info('[v8.js %o] CHECKING TOKEN ALLOWANCE', url);
+    logger.debug('[v8.js] CHECKING TOKEN ALLOWANCE %o', url);
     this.request
       .get(url, {})
       .then(allowance => {
@@ -463,7 +464,7 @@ export class V8 {
 
   getMultisigTxpsInfo(opts, cb) {
     const url = this.baseUrl + '/ethmultisig/txps/' + opts.multisigContractAddress;
-    logger.info('[v8.js %o] CHECKING CONTRACT TXPS INFO', url);
+    logger.debug('[v8.js] CHECKING CONTRACT TXPS INFO %o', url);
     this.request
       .get(url, {})
       .then(multisigTxpsInfo => {
@@ -491,13 +492,13 @@ export class V8 {
 
               // only process right responses.
               if (!_.isUndefined(ret.blocks) && ret.blocks != x) {
-                logger.info(`Ignoring response for ${x}: %o`, ret);
+                logger.info(`[v8.js] Ignoring response for ${x}: %o`, ret?.body || ret);
                 return icb();
               }
 
               result[x] = ret.feerate;
             } catch (e) {
-              logger.warn('fee error: %o', e);
+              logger.warn('[v8.js] Fee error: %o', e);
             }
 
             return icb();
@@ -616,10 +617,10 @@ export class V8 {
 
 const _parseErr = (err, res) => {
   if (err) {
-    logger.warn('V8 error: %o', err);
+    logger.warn('[v8.js] V8 raw error: %o', err);
     return 'V8 Error';
   }
-  logger.warn('V8 ' + res.request.href + ' Returned Status: ' + res.statusCode);
+  logger.warn('[v8.js] ' + res.request.href + ' Returned Status: ' + res.statusCode);
   return 'Error querying the blockchain';
 };
 

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -3,11 +3,11 @@ import * as crypto from 'crypto';
 import _ from 'lodash';
 import * as request from 'request-promise-native';
 import io = require('socket.io-client');
+import config from '../../config';
 import { ChainService } from '../chain/index';
 import { Common } from '../common';
 import logger from '../logger';
 import { Client } from './v8/client';
-import config from '../../config';
 
 const $ = require('preconditions').singleton();
 const Bitcore = require('bitcore-lib');

--- a/packages/bitcore-wallet-service/src/lib/chain/bch/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/bch/index.ts
@@ -1,8 +1,8 @@
 import { BitcoreLibCash } from 'crypto-wallet-core';
 import { IChain } from '..';
-import { BtcChain } from '../btc';
 import config from '../../../config';
 import { Errors } from '../../errors/errordefinitions';
+import { BtcChain } from '../btc';
 
 export class BchChain extends BtcChain implements IChain {
   constructor() {

--- a/packages/bitcore-wallet-service/src/lib/chain/bch/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/bch/index.ts
@@ -1,10 +1,8 @@
-import { BitcoreLib, BitcoreLibCash } from 'crypto-wallet-core';
-import _ from 'lodash';
+import { BitcoreLibCash } from 'crypto-wallet-core';
 import { IChain } from '..';
 import { BtcChain } from '../btc';
-const config = require('../../../config');
-
-const Errors = require('../../errors/errordefinitions');
+import config from '../../../config';
+import { Errors } from '../../errors/errordefinitions';
 
 export class BchChain extends BtcChain implements IChain {
   constructor() {
@@ -31,7 +29,7 @@ export class BchChain extends BtcChain implements IChain {
     } catch (ex) {
       throw Errors.INVALID_ADDRESS;
     }
-    if (addr.network.toString() != wallet.network) {
+    if (!this._isCorrectNetwork(wallet, addr)) {
       throw Errors.INCORRECT_ADDRESS_NETWORK;
     }
     if (!opts.noCashAddr) {

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -2,12 +2,12 @@ import * as async from 'async';
 import { BitcoreLib } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IChain } from '..';
+import config from '../../../config';
 import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
+import { Errors } from '../../errors/errordefinitions';
 import logger from '../../logger';
 import { TxProposal } from '../../model';
-import config from '../../../config';
-import { Errors } from '../../errors/errordefinitions';
 
 const $ = require('preconditions').singleton();
 const Constants = Common.Constants;

--- a/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
@@ -5,14 +5,13 @@ import { IChain } from '..';
 import logger from '../../logger';
 import { TxProposal } from '../../model';
 import { BtcChain } from '../btc';
-const $ = require('preconditions').singleton();
 import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
+import { Errors } from '../../errors/errordefinitions';
 
 const Constants = Common.Constants;
 const Utils = Common.Utils;
 const Defaults = Common.Defaults;
-const Errors = require('../../errors/errordefinitions');
 
 export class DogeChain extends BtcChain implements IChain {
   constructor(private bitcoreLibDoge = BitcoreLibDoge) {

--- a/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/doge/index.ts
@@ -2,12 +2,12 @@ import * as async from 'async';
 import { BitcoreLibDoge } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IChain } from '..';
-import logger from '../../logger';
-import { TxProposal } from '../../model';
-import { BtcChain } from '../btc';
 import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import { Errors } from '../../errors/errordefinitions';
+import logger from '../../logger';
+import { TxProposal } from '../../model';
+import { BtcChain } from '../btc';
 
 const Constants = Common.Constants;
 const Utils = Common.Utils;

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -2,17 +2,17 @@ import { Transactions, Validation } from 'crypto-wallet-core';
 import { Web3 } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IAddress } from 'src/lib/model/address';
-import { IChain, INotificationData } from '..';
+import { IChain } from '..';
 import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import logger from '../../logger';
 import { ERC20Abi } from './abi-erc20';
 import { InvoiceAbi } from './abi-invoice';
-const { toBN } = Web3.utils;
+import { Errors } from '../../errors/errordefinitions';
 
+const { toBN } = Web3.utils;
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
-const Errors = require('../../errors/errordefinitions');
 
 function requireUncached(module) {
   delete require.cache[require.resolve(module)];

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -5,10 +5,10 @@ import { IAddress } from 'src/lib/model/address';
 import { IChain } from '..';
 import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
+import { Errors } from '../../errors/errordefinitions';
 import logger from '../../logger';
 import { ERC20Abi } from './abi-erc20';
 import { InvoiceAbi } from './abi-invoice';
-import { Errors } from '../../errors/errordefinitions';
 
 const { toBN } = Web3.utils;
 const Constants = Common.Constants;

--- a/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
@@ -1,8 +1,8 @@
 import { Transactions, Validation } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { ClientError } from '../../errors/clienterror';
-import { EthChain } from '../eth';
 import { Errors } from '../../errors/errordefinitions';
+import { EthChain } from '../eth';
 
 
 export class MaticChain extends EthChain {

--- a/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/matic/index.ts
@@ -1,12 +1,9 @@
 import { Transactions, Validation } from 'crypto-wallet-core';
 import _ from 'lodash';
-import { Common } from '../../common';
 import { ClientError } from '../../errors/clienterror';
 import { EthChain } from '../eth';
+import { Errors } from '../../errors/errordefinitions';
 
-const Constants = Common.Constants;
-const Defaults = Common.Defaults;
-const Errors = require('../../errors/errordefinitions');
 
 export class MaticChain extends EthChain {
   /**

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -1,13 +1,12 @@
 import { Transactions, Validation } from 'crypto-wallet-core';
 import _ from 'lodash';
 import { IAddress } from 'src/lib/model/address';
-import { IChain, INotificationData } from '..';
+import { IChain } from '..';
 import { Common } from '../../common';
 import logger from '../../logger';
+import { Errors } from '../../errors/errordefinitions';
 
-const Constants = Common.Constants;
 const Defaults = Common.Defaults;
-const Errors = require('../../errors/errordefinitions');
 
 export class XrpChain implements IChain {
   /**

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -3,8 +3,8 @@ import _ from 'lodash';
 import { IAddress } from 'src/lib/model/address';
 import { IChain } from '..';
 import { Common } from '../../common';
-import logger from '../../logger';
 import { Errors } from '../../errors/errordefinitions';
+import logger from '../../logger';
 
 const Defaults = Common.Defaults;
 

--- a/packages/bitcore-wallet-service/src/lib/cleanfiatrates.ts
+++ b/packages/bitcore-wallet-service/src/lib/cleanfiatrates.ts
@@ -3,10 +3,10 @@ import * as _ from 'lodash';
 import moment from 'moment';
 import * as mongodb from 'mongodb';
 import logger from './logger';
+import config from '../config';
+import { Storage } from './storage';
 
-const config = require('../config');
 const ObjectID = mongodb.ObjectID;
-const storage = require('./storage');
 
 var objectIdDate = function(date) {
   return Math.floor(date.getTime() / 1000).toString(16) + '0000000000000000';
@@ -89,7 +89,7 @@ export class CleanFiatRates {
     const objectIdToDate = objectIdDate(this.to);
 
     this.db
-      .collection(storage.Storage.collections.FIAT_RATES2)
+      .collection(Storage.collections.FIAT_RATES2)
       .find({
         _id: {
           $gte: new ObjectID(objectIdFromDate),
@@ -140,7 +140,7 @@ export class CleanFiatRates {
   async _cleanFiatRates(datesToKeep, cb) {
     try {
       this.db
-        .collection(storage.Storage.collections.FIAT_RATES2)
+        .collection(Storage.collections.FIAT_RATES2)
         .remove({
           ts: {
             $nin: datesToKeep,

--- a/packages/bitcore-wallet-service/src/lib/cleanfiatrates.ts
+++ b/packages/bitcore-wallet-service/src/lib/cleanfiatrates.ts
@@ -2,8 +2,8 @@ import * as async from 'async';
 import * as _ from 'lodash';
 import moment from 'moment';
 import * as mongodb from 'mongodb';
-import logger from './logger';
 import config from '../config';
+import logger from './logger';
 import { Storage } from './storage';
 
 const ObjectID = mongodb.ObjectID;

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -83,7 +83,8 @@ export const Constants = {
 
   NETWORKS: {
     LIVENET: 'livenet',
-    TESTNET: 'testnet'
+    TESTNET: 'testnet',
+    REGTEST: 'regtest'
   },
 
   ADDRESS_FORMATS: ['copay', 'cashaddr', 'legacy'],

--- a/packages/bitcore-wallet-service/src/lib/emailservice.ts
+++ b/packages/bitcore-wallet-service/src/lib/emailservice.ts
@@ -534,5 +534,3 @@ export class EmailService {
     });
   }
 }
-
-module.exports = EmailService;

--- a/packages/bitcore-wallet-service/src/lib/errors/errordefinitions.ts
+++ b/packages/bitcore-wallet-service/src/lib/errors/errordefinitions.ts
@@ -1,7 +1,53 @@
-const _ = require('lodash');
 import { ClientError } from './clienterror';
 
-const errors = {
+
+interface Errors<T> {
+  AD_ALREADY_EXISTS: T;
+  BAD_SIGNATURES: T;
+  COPAYER_DATA_MISMATCH: T;
+  COPAYER_IN_WALLET: T;
+  COPAYER_REGISTERED: T;
+  COPAYER_VOTED: T;
+  DUST_AMOUNT: T;
+  MORE_THAT_ONE_OUTPUT: T;
+  INCORRECT_ADDRESS_NETWORK: T;
+  ONLY_CASHADDR: T;
+  INSUFFICIENT_FUNDS: T;
+  INSUFFICIENT_FUNDS_FOR_FEE: T;
+  INSUFFICIENT_ETH_FEE: T;
+  INSUFFICIENT_MATIC_FEE: T;
+  INVALID_ADDRESS: T;
+  INVALID_CHANGE_ADDRESS: T;
+  KEY_IN_COPAYER: T;
+  LOCKED_FUNDS: T;
+  LOCKED_ETH_FEE: T;
+  LOCKED_MATIC_FEE: T;
+  HISTORY_LIMIT_EXCEEDED: T;
+  MAIN_ADDRESS_GAP_REACHED: T;
+  NETWORK_SUSPENDED: T;
+  NOT_AUTHORIZED: T;
+  TOO_MANY_KEYS: T;
+  TX_ALREADY_BROADCASTED: T;
+  TX_CANNOT_CREATE: T;
+  TX_CANNOT_REMOVE: T;
+  TX_MAX_SIZE_EXCEEDED: T;
+  TX_NOT_ACCEPTED: T;
+  TX_NOT_FOUND: T;
+  TX_NOT_PENDING: T;
+  TX_NONCE_CONFLICT: T;
+  UNAVAILABLE_UTXOS: T;
+  NO_INPUT_PATHS: T;
+  UPGRADE_NEEDED: T;
+  WALLET_ALREADY_EXISTS: T;
+  WALLET_FULL: T;
+  WALLET_BUSY: T;
+  WALLET_NOT_COMPLETE: T;
+  WALLET_NOT_FOUND: T;
+  WALLET_NEED_SCAN: T;
+  WRONG_SIGNING_METHOD: T;
+};
+
+const errors: Errors<string> = {
   AD_ALREADY_EXISTS: 'Ad already exists',
   BAD_SIGNATURES: 'Bad signatures',
   COPAYER_DATA_MISMATCH: 'Copayer data mismatch',
@@ -47,14 +93,11 @@ const errors = {
   WRONG_SIGNING_METHOD: 'Wrong signed method for coin/network'
 };
 
-const errorObjects = _.fromPairs(
-  _.map(errors, (msg, code) => {
-    return [code, new ClientError(code, msg)];
-  })
-);
+const errorsObject = { codes: {} };
 
-errorObjects.codes = _.mapValues(errors, (v, k) => {
-  return k;
-});
+for (const [code, msg] of Object.entries(errors)) {
+  errorsObject[code] = new ClientError(code, msg);
+  errorsObject.codes[code] = code;
+}
 
-module.exports = errorObjects;
+export const Errors = errorsObject as Errors<ClientError> & { codes: Errors<string> };

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -8,10 +8,10 @@ import { logger, transport } from './logger';
 
 import { Common } from './common';
 import { ClientError } from './errors/clienterror';
+import { Errors } from'./errors/errordefinitions';
 import { LogMiddleware } from './middleware';
 import { WalletService } from './server';
 import { Stats } from './stats';
-import { Errors } from'./errors/errordefinitions';
 
 const bodyParser = require('body-parser');
 const compression = require('compression');

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import express from 'express';
 import _ from 'lodash';
 import 'source-map-support/register';
+import config from '../config';
 import { logger, transport } from './logger';
 
 import { Common } from './common';
@@ -10,10 +11,10 @@ import { ClientError } from './errors/clienterror';
 import { LogMiddleware } from './middleware';
 import { WalletService } from './server';
 import { Stats } from './stats';
+import { Errors } from'./errors/errordefinitions';
 
 const bodyParser = require('body-parser');
 const compression = require('compression');
-const config = require('../config');
 const RateLimit = require('express-rate-limit');
 const rp = require('request-promise-native');
 const Defaults = Common.Defaults;
@@ -600,7 +601,6 @@ export class ExpressApp {
 
     // DEPRECATED
     router.post('/v1/txproposals/', (req, res) => {
-      const Errors = require('./errors/errordefinitions');
       const err = Errors.UPGRADE_NEEDED;
       return returnError(err, res, req);
     });

--- a/packages/bitcore-wallet-service/src/lib/lock.ts
+++ b/packages/bitcore-wallet-service/src/lib/lock.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Common } from './common';
-import { Storage } from './storage';
 import { Errors } from './errors/errordefinitions';
+import { Storage } from './storage';
 
 const $ = require('preconditions').singleton();
 const Defaults = Common.Defaults;

--- a/packages/bitcore-wallet-service/src/lib/lock.ts
+++ b/packages/bitcore-wallet-service/src/lib/lock.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import { Common } from './common';
 import { Storage } from './storage';
+import { Errors } from './errors/errordefinitions';
 
 const $ = require('preconditions').singleton();
 const Defaults = Common.Defaults;
-const Errors = require('./errors/errordefinitions');
 const ACQUIRE_RETRY_STEP = 50; // ms
 
 export class Lock {

--- a/packages/bitcore-wallet-service/src/lib/model/wallet.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/wallet.ts
@@ -5,13 +5,15 @@ import logger from '../logger';
 import { Address } from './address';
 import { AddressManager } from './addressmanager';
 import { Copayer } from './copayer';
+import config from '../../config';
 
 const $ = require('preconditions').singleton();
 const Uuid = require('uuid');
-const config = require('../../config');
+
 const Constants = Common.Constants,
   Defaults = Common.Defaults,
   Utils = Common.Utils;
+
 const Bitcore = {
   btc: require('bitcore-lib'),
   bch: require('bitcore-lib-cash'),

--- a/packages/bitcore-wallet-service/src/lib/model/wallet.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/wallet.ts
@@ -1,11 +1,11 @@
 import _ from 'lodash';
+import config from '../../config';
 import { ChainService } from '../chain/index';
 import { Common } from '../common';
 import logger from '../logger';
 import { Address } from './address';
 import { AddressManager } from './addressmanager';
 import { Copayer } from './copayer';
-import config from '../../config';
 
 const $ = require('preconditions').singleton();
 const Uuid = require('uuid');

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3,7 +3,9 @@ import * as crypto from 'crypto'
 import * as _ from 'lodash';
 import Moralis from 'moralis';
 import 'source-map-support/register';
+import { Validation } from 'crypto-wallet-core';
 import logger from './logger';
+import config from '../config';
 
 import { BlockChainExplorer } from './blockchainexplorer';
 import { V8 } from './blockchainexplorers/v8';
@@ -30,16 +32,15 @@ import {
   Wallet
 } from './model';
 import { Storage } from './storage';
+import { serverMessages } from '../serverMessages';
+import { serverMessages as deprecatedServerMessage } from '../deprecated-serverMessages';
+import { BCHAddressTranslator } from './bchaddresstranslator';
+import { Errors } from './errors/errordefinitions';
 
-const config = require('../config');
 const Uuid = require('uuid');
 const $ = require('preconditions').singleton();
-const deprecatedServerMessage = require('../deprecated-serverMessages');
-const serverMessages = require('../serverMessages');
-const BCHAddressTranslator = require('./bchaddresstranslator');
 const EmailValidator = require('email-validator');
 
-import { Validation } from 'crypto-wallet-core';
 const Bitcore = require('bitcore-lib');
 const Bitcore_ = {
   btc: Bitcore,
@@ -55,8 +56,6 @@ const Utils = Common.Utils;
 const Constants = Common.Constants;
 const Defaults = Common.Defaults;
 const Services = Common.Services;
-
-const Errors = require('./errors/errordefinitions');
 
 let request = require('request');
 let initialized = false;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1,17 +1,21 @@
 import * as async from 'async';
 import * as crypto from 'crypto'
+import { Validation } from 'crypto-wallet-core';
 import * as _ from 'lodash';
 import Moralis from 'moralis';
 import 'source-map-support/register';
-import { Validation } from 'crypto-wallet-core';
-import logger from './logger';
 import config from '../config';
+import logger from './logger';
 
+import { serverMessages as deprecatedServerMessage } from '../deprecated-serverMessages';
+import { serverMessages } from '../serverMessages';
+import { BCHAddressTranslator } from './bchaddresstranslator';
 import { BlockChainExplorer } from './blockchainexplorer';
 import { V8 } from './blockchainexplorers/v8';
 import { ChainService } from './chain/index';
 import { Common } from './common';
 import { ClientError } from './errors/clienterror';
+import { Errors } from './errors/errordefinitions';
 import { FiatRateService } from './fiatrateservice';
 import { Lock } from './lock';
 import { MessageBroker } from './messagebroker';
@@ -32,10 +36,6 @@ import {
   Wallet
 } from './model';
 import { Storage } from './storage';
-import { serverMessages } from '../serverMessages';
-import { serverMessages as deprecatedServerMessage } from '../deprecated-serverMessages';
-import { BCHAddressTranslator } from './bchaddresstranslator';
-import { Errors } from './errors/errordefinitions';
 
 const Uuid = require('uuid');
 const $ = require('preconditions').singleton();

--- a/packages/bitcore-wallet-service/src/lib/stats.ts
+++ b/packages/bitcore-wallet-service/src/lib/stats.ts
@@ -3,8 +3,7 @@ import * as _ from 'lodash';
 import moment from 'moment';
 import * as mongodb from 'mongodb';
 import logger from './logger';
-
-const config = require('../config');
+import config from '../config';
 
 const INITIAL_DATE = '2015-01-01';
 

--- a/packages/bitcore-wallet-service/src/lib/stats.ts
+++ b/packages/bitcore-wallet-service/src/lib/stats.ts
@@ -2,8 +2,8 @@ import * as async from 'async';
 import * as _ from 'lodash';
 import moment from 'moment';
 import * as mongodb from 'mongodb';
-import logger from './logger';
 import config from '../config';
+import logger from './logger';
 
 const INITIAL_DATE = '2015-01-01';
 

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -2,6 +2,7 @@ import * as async from 'async';
 import _ from 'lodash';
 import { Db } from 'mongodb';
 import * as mongodb from 'mongodb';
+import { BCHAddressTranslator } from './bchaddresstranslator'; // only for migration
 import { Common } from './common';
 import logger from './logger';
 import {
@@ -12,13 +13,11 @@ import {
   Preferences,
   PushNotificationSub,
   Session,
-  TxConfirmationSub,
   TxNote,
   TxProposal,
   Wallet
 } from './model';
 
-const BCHAddressTranslator = require('./bchaddresstranslator'); // only for migration
 const $ = require('preconditions').singleton();
 
 const collections = {

--- a/packages/bitcore-wallet-service/src/pushnotificationsservice/pushnotificationsservice.ts
+++ b/packages/bitcore-wallet-service/src/pushnotificationsservice/pushnotificationsservice.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import logger from '../lib/logger';
 import { PushNotificationsService } from '../lib/pushnotificationsservice';
-
-const config = require('../config');
+import config from '../config';
 
 const pushNotificationsService = new PushNotificationsService();
 pushNotificationsService.start(config, err => {

--- a/packages/bitcore-wallet-service/src/pushnotificationsservice/pushnotificationsservice.ts
+++ b/packages/bitcore-wallet-service/src/pushnotificationsservice/pushnotificationsservice.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
+import config from '../config';
 import logger from '../lib/logger';
 import { PushNotificationsService } from '../lib/pushnotificationsservice';
-import config from '../config';
 
 const pushNotificationsService = new PushNotificationsService();
 pushNotificationsService.start(config, err => {

--- a/packages/bitcore-wallet-service/src/serverMessages.ts
+++ b/packages/bitcore-wallet-service/src/serverMessages.ts
@@ -1,4 +1,4 @@
-module.exports = (wallet, appName, appVersion) => {
+export const serverMessages = (wallet, appName, appVersion) => {
   if (!appVersion || !appName) return;
 
   const serverMessages = [];

--- a/packages/bitcore-wallet-service/test/bchaddresstranslator.js
+++ b/packages/bitcore-wallet-service/test/bchaddresstranslator.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 var chai = require('chai');
 var sinon = require('sinon');
 var should = chai.should();
-var t = require('../ts_build/lib/bchaddresstranslator');
+var t = require('../ts_build/lib/bchaddresstranslator').BCHAddressTranslator;
 
 describe('BCH Address translator', function() {
 

--- a/packages/bitcore-wallet-service/test/blockchainexplorer.js
+++ b/packages/bitcore-wallet-service/test/blockchainexplorer.js
@@ -42,12 +42,15 @@ describe('BlockChain explorer', function() {
 
     });
     it('should fail on unsupported provider', function() {
-      (function() {
+      try {
         var exp = new BlockChainExplorer({
           provider: 'dummy',
           coin: 'btc',
         });
-      }).should.throw('not supported');
+        throw new Error('Should have thrown');
+      } catch (err) {
+        err.message.should.equal('No url found for provider: dummy:btc:livenet');
+      }
     });
   });
   describe('#v8', function() {

--- a/packages/bitcore-wallet-service/test/expressapp.js
+++ b/packages/bitcore-wallet-service/test/expressapp.js
@@ -7,7 +7,7 @@ var request = require('request');
 var http = require('http');
 var should = chai.should();
 var proxyquire = require('proxyquire');
-var config = require('../ts_build/config.js');
+var config = require('../ts_build/config.js').default;
 var log = require('npmlog');
 
 var { Common } = require('../ts_build/lib/common');

--- a/packages/bitcore-wallet-service/test/integration/changelly.js
+++ b/packages/bitcore-wallet-service/test/integration/changelly.js
@@ -7,7 +7,7 @@ const { WalletService } = require('../../ts_build/lib/server');
 const TestData = require('../testdata');
 const helpers = require('./helpers');
 
-let config = require('../../ts_build/config.js');
+let config = require('../../ts_build/config.js').default;
 let server, wallet, fakeRequest, req;
 
 let { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {

--- a/packages/bitcore-wallet-service/test/integration/coinGecko.js
+++ b/packages/bitcore-wallet-service/test/integration/coinGecko.js
@@ -6,7 +6,7 @@ const { WalletService } = require('../../ts_build/lib/server');
 const TestData = require('../testdata');
 const helpers = require('./helpers');
 
-let config = require('../../ts_build/config.js');
+let config = require('../../ts_build/config.js').default;
 let server, wallet, fakeRequest, req;
 
 describe('CoinGecko integration', function() {

--- a/packages/bitcore-wallet-service/test/integration/emailnotifications.js
+++ b/packages/bitcore-wallet-service/test/integration/emailnotifications.js
@@ -9,8 +9,8 @@ var should = chai.should();
 const { logger, transport } = require('../../ts_build/lib/logger.js');
 transport.level= 'error';
 
-var WalletService = require('../../ts_build/lib/server');
-var EmailService = require('../../ts_build/lib/emailservice');
+var WalletService = require('../../ts_build/lib/server').WalletService;
+var EmailService = require('../../ts_build/lib/emailservice').EmailService;
 
 var TestData = require('../testdata');
 var helpers = require('./helpers');

--- a/packages/bitcore-wallet-service/test/integration/oneInch.js
+++ b/packages/bitcore-wallet-service/test/integration/oneInch.js
@@ -6,7 +6,7 @@ const { WalletService } = require('../../ts_build/lib/server');
 const TestData = require('../testdata');
 const helpers = require('./helpers');
 
-let config = require('../../ts_build/config.js');
+let config = require('../../ts_build/config.js').default;
 let server, wallet, fakeRequest, req;
 
 describe('OneInch integration', function() {

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -14,7 +14,7 @@ const should = chai.should();
 const { logger, transport } = require('../../ts_build/lib/logger.js');
 const { ChainService } = require('../../ts_build/lib/chain/index');
 
-var config = require('../../ts_build/config.js');
+var config = require('../../ts_build/config.js').default;
 config.moralis = config.moralis ?? {
   apiKey: 'apiKey',
   whitelist: []

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -39,7 +39,7 @@ const Defaults = Common.Defaults;
 const VanillaDefaults = _.cloneDeep(Defaults);
 
 const Model = require('../../ts_build/lib/model');
-const BCHAddressTranslator = require('../../ts_build/lib/bchaddresstranslator');
+const { BCHAddressTranslator } = require('../../ts_build/lib/bchaddresstranslator');
 
 var HugeTxs = require('./hugetx');
 var TestData = require('../testdata');


### PR DESCRIPTION
This is a cleanup PR that reduces code smell in several areas.

* Converts some local files into ES modules instead of commonJS modules, including:
  * config.ts
  * errordefinitions.ts was reworked for typing.
* Improves regtest support
  * `regtestEnabled` is now configurable by chain
  * `v8.ts` takes regtest into account
  * Address validation for regtest addresses for a testnet wallet _if_ `regtestEnabled` is true.
* In `blockchainexplorer.ts`, the `PROVIDERS` was weird in that validation was done on it even if the opts would overwrite it. This PR makes the `PROVIDERS` a true fallback to the config.
* Makes the logs in `v8.ts` consistent.