### PR TITLE
[BCN] Filter delegated calls when building effects

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/models/transaction.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/models/transaction.ts
@@ -415,7 +415,8 @@ export class EVMTransactionModel extends BaseTransaction<IEVMTransaction> {
           const effect = this._getEffectForNativeTransfer(BigInt(internalTx.action.value).toString(), internalTx.action.to, internalTx.action.from || tx.from, internalTx.traceAddress.join('_'));
           effects.push(effect);
         }
-        if (internalTx.abiType) {
+        // Ignoring delegated calls because they are redundant
+        if (internalTx.abiType && internalTx.type != 'delegatecall') {
           // Handle Abi related effects
           const effect = this._getEffectForAbiType(internalTx.abiType, internalTx.action.to, internalTx.action.from || tx.from, internalTx.traceAddress.join('_'));
           if (effect) {
@@ -430,7 +431,8 @@ export class EVMTransactionModel extends BaseTransaction<IEVMTransaction> {
           const effect = this._getEffectForNativeTransfer(BigInt(internalTx.value).toString(), internalTx.to, internalTx.from, internalTx.depth);
           effects.push(effect);
         }
-        if (internalTx.abiType) {
+        // Ignoring delegated calls because they are redundant
+        if (internalTx.abiType && internalTx.type != 'DELEGATECALL') {
           // Handle Abi related effects
           const effect = this._getEffectForAbiType(internalTx.abiType, internalTx.to, internalTx.from, internalTx.depth);
           if (effect) {

--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -15,7 +15,7 @@ interface IGethTxTraceBase {
   input: string;
   output: string;
   to: string;
-  type: 'CREATE';
+  type: 'CALL' | 'STATICCALL' | 'DELEGATECALL' | 'CREATE' | 'CREATE2';
   value: string;
   abiType?: IAbiDecodedData;
 }

--- a/packages/bitcore-node/src/providers/chain-state/evm/types.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/types.ts
@@ -86,7 +86,7 @@ export interface GethTraceCall {
   input: string;
   output: string;
   to: string;
-  type: 'CALL' | 'STATICALL' | 'DELEGATECALL' | 'CREATE' | 'CREATE2' | 'SELFDESTRUCT';
+  type: 'CALL' | 'STATICCALL' | 'DELEGATECALL' | 'CREATE' | 'CREATE2';
   value?: string;
 }
 


### PR DESCRIPTION
Delegated calls are redundant and cause ERC20 transfers appear to be made twice. By ignoring them when we build the effects array we can clean up unnecessary data.