### PR TITLE
[BCC] Fix XRP issues with bitcore-client

### DIFF
--- a/packages/bitcore-client/bin/wallet-bump-tx
+++ b/packages/bitcore-client/bin/wallet-bump-tx
@@ -57,8 +57,7 @@ const main = async () => {
     // converting gasLimit and value with toString avoids a bigNumber warning
     const params = { nonce, gasLimit: gasLimit.toString(), gasPrice, data, chainId, recipients: [{ address: to, amount: value.toString() }] };
 
-    const noChange = ['ETH', 'MATIC'].includes(wallet.chain); 
-    params.change = noChange ? null : wallet.deriveAddress(wallet.addressIndex, true);
+    params.change = !wallet.isUtxoChain() ? null : wallet.deriveAddress(wallet.addressIndex, true);
     const changeIdx = params.change ? wallet.addressIndex : null;
     const tx = await wallet.newTx(params);
     console.log('UnsignedRawTx: ', tx);

--- a/packages/bitcore-client/bin/wallet-paypro
+++ b/packages/bitcore-client/bin/wallet-paypro
@@ -101,8 +101,7 @@ const main = async () => {
     const utxos = await wallet.getUtxosArray();
     const params = { recipients, feeRate, from, invoiceID, data, value, utxos };
     params.nonce = Number(nonce);
-    const noChange = ['ETH', 'MATIC'].includes(wallet.chain); 
-    params.change = noChange ? null : wallet.deriveAddress(wallet.addressIndex, true);
+    params.change = !wallet.isUtxoChain() ? null : wallet.deriveAddress(wallet.addressIndex, true);
     const changeIdx = params.change ? wallet.addressIndex : null;
     const unsignedTx = await wallet.newTx(params);
     console.log(`unsignedRawTx: ${unsignedTx}`);

--- a/packages/bitcore-client/bin/wallet-send
+++ b/packages/bitcore-client/bin/wallet-send
@@ -57,9 +57,8 @@ const main = async () => {
       recipients,
       from: lastAddress,
       token
-    };
-    const noChange = ['ETH', 'MATIC'].includes(wallet.chain); 
-    params.change = noChange ? null : wallet.deriveAddress(wallet.addressIndex, true);
+    }; 
+    params.change = !wallet.isUtxoChain() ? null : wallet.deriveAddress(wallet.addressIndex, true);
     const changeIdx = params.change ? wallet.addressIndex : null;
     const tx = await wallet.newTx(params);
     console.log('unsignedRawTx: ', tx);

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -235,6 +235,14 @@ export class Wallet {
     }
   }
 
+  /**
+   * Certain chains don't 
+   * @returns {Boolean}
+   */
+  isUtxoChain() {
+    return ['BTC', 'BCH', 'DOGE', 'LTC'].includes(this.chain)
+  }
+
   lock() {
     this.unlocked = undefined;
     return this;
@@ -490,7 +498,7 @@ export class Wallet {
       let decryptedParams = Encryption.bitcoinCoreDecrypt(addresses, passphrase);
       decryptedKeys = [...decryptedParams.jsonlDecrypted];
     }
-    if (!['ETH', 'MATIC'].includes(this.chain)) {
+    if (this.isUtxoChain()) {
       // If changeAddressIdx == null, then save the change key at the current addressIndex (just in case)
       const changeKey = await this.derivePrivateKey(true, changeAddressIdx == null ? this.addressIndex : changeAddressIdx);
       await this.importKeys({ keys: [changeKey] });
@@ -596,7 +604,7 @@ export class Wallet {
   }
 
   private async _getChangeAddress() {
-    if (['ETH', 'MATIC'].includes(this.chain)) {
+    if (!this.isUtxoChain()) {
       return;
     }
     const key = await this.derivePrivateKey(true, this.addressIndex);

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -236,11 +236,12 @@ export class Wallet {
   }
 
   /**
-   * Certain chains don't 
+   * Does this wallet use UTXOs?
    * @returns {Boolean}
    */
   isUtxoChain() {
-    return ['BTC', 'BCH', 'DOGE', 'LTC'].includes(this.chain)
+    // the toUpperCase() should not be necessary, but it's here just in case.
+    return ['BTC', 'BCH', 'DOGE', 'LTC'].includes(this.chain?.toUpperCase() || 'BTC');
   }
 
   lock() {

--- a/packages/bitcore-node/package-lock.json
+++ b/packages/bitcore-node/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "bitcore-node",
-			"version": "10.0.12",
+			"version": "10.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"abi-decoder": "2.4.0",

--- a/packages/bitcore-p2p-cash/package-lock.json
+++ b/packages/bitcore-p2p-cash/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "bitcore-p2p-cash",
-			"version": "10.0.11",
+			"version": "10.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"bloom-filter": "^0.2.0",

--- a/packages/bitcore-p2p-doge/package-lock.json
+++ b/packages/bitcore-p2p-doge/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "bitcore-p2p-doge",
-			"version": "10.0.11",
+			"version": "10.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"bloom-filter": "^0.2.0",

--- a/packages/bitcore-p2p/package-lock.json
+++ b/packages/bitcore-p2p/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "bitcore-p2p",
-			"version": "10.0.11",
+			"version": "10.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"bloom-filter": "^0.2.0",

--- a/packages/crypto-wallet-core/package-lock.json
+++ b/packages/crypto-wallet-core/package-lock.json
@@ -6,14 +6,14 @@
 	"packages": {
 		"": {
 			"name": "crypto-wallet-core",
-			"version": "10.0.11",
+			"version": "10.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"ethers": "^5.0.12",
 				"info": "0.0.6-beta.0",
 				"ripple-binary-codec": "0.2.6",
 				"ripple-keypairs": "git+https://git@github.com/bitpay/ripple-keypairs.git#8d3a4643a8ddfce8222786e1e5a3e85a89a5b7f5",
-				"ripple-lib": "^1.8.0",
+				"ripple-lib": "1.8.0",
 				"web3": "1.4.0"
 			},
 			"devDependencies": {

--- a/packages/crypto-wallet-core/package.json
+++ b/packages/crypto-wallet-core/package.json
@@ -31,7 +31,7 @@
     "info": "0.0.6-beta.0",
     "ripple-binary-codec": "0.2.6",
     "ripple-keypairs": "git+https://git@github.com/bitpay/ripple-keypairs.git#8d3a4643a8ddfce8222786e1e5a3e85a89a5b7f5",
-    "ripple-lib": "^1.8.0",
+    "ripple-lib": "1.8.0",
     "web3": "1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This [removes the semvar](https://github.com/bitpay/bitcore/pull/3647/files#diff-e37da4f64183a7da37dc38b44dd7e35033afeaa4780fbfd4f1b0ef7c2b698f85R34) from the `ripple-lib` dep in CWC. `ripple-lib` v1.10.1 was being installed in other environments which caused the following error when signing an XRP tx
```TypeError: Cannot read properties of undefined (reading 'encodeForSigning')```

Additionally, I've cleaned up the check for needing change addresses and effectively excluded XRP wallets from creating change addresses as well.