### PR TITLE
[BCC] Add bin to bitcore-client

### DIFF
--- a/packages/bitcore-client/package.json
+++ b/packages/bitcore-client/package.json
@@ -8,6 +8,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "bin": "bin/wallet",
   "scripts": {
     "build": "npm run compile",
     "clean": "rm -rf ./ts_build",


### PR DESCRIPTION
This allows bitcore-client to be run using `npx`