### PR TITLE
[BCN] Fix param.value.substring is not a function

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts
@@ -102,6 +102,7 @@ export class GethRPC implements IRpc {
     trace.abiType = trace.input ? EVMTransactionStorage.abiDecode(trace.input) : undefined;
     if (trace.abiType) {
       for (let param of trace.abiType.params) {
+        param.value = typeof param.value === 'string' ? param.value : JSON.stringify(param.value);
         if (param.value && param.value.length > 100) {
           // Need to truncate this so it doesn't blow up the index.
           param.value = param.value.substring(0, 100) + '...';


### PR DESCRIPTION
```
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]: info :: 2023-12-15T19:45:29.653Z :: 2023-12-15 19:45:29.653 UTC | Syncing... | Chain: ETH | Network: mainnet |   58.48 blocks/min | Height: 18793589
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]: error :: 2023-12-15T19:45:29.815Z :: Error syncing ETH mainnet -- TypeError: param.value.substring is not a function
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:107:37)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:56
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at Array.flatMap (<anonymous>)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:28)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:56
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at Array.flatMap (<anonymous>)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:28)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:90:65
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at Array.flatMap (<anonymous>)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at GethRPC.reconcileTraces (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:90:37)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at EthP2pWorker.<anonymous> (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/p2p.ts:357:15)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at step (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:82:23)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at Object.next (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:63:53)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at fulfilled (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:54:58)
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     at processTicksAndRejections (node:internal/process/task_queues:95:5) {
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:   [stack]: 'TypeError: param.value.substring is not a function\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:107:37)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:56\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at Array.flatMap (<anonymous>)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:28)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:56\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at Array.flatMap (<anonymous>)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at GethRPC.flattenTraceCalls (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:115:28)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at /home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:90:65\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at Array.flatMap (<anonymous>)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at GethRPC.reconcileTraces (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/rpcs/gethRpc.ts:90:37)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at EthP2pWorker.<anonymous> (/home/bitcore/bitcore/packages/bitcore-node/src/providers/chain-state/evm/p2p/p2p.ts:357:15)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at step (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:82:23)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at Object.next (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:63:53)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at fulfilled (/home/bitcore/bitcore/packages/bitcore-node/build/src/providers/chain-state/evm/p2p/p2p.js:54:58)\n' +
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:     '    at processTicksAndRejections (node:internal/process/task_queues:95:5)',
Dec 15 19:45:29 ip-172-31-80-253 node[2661372]:   [message]: 'param.value.substring is not a function'
```