### PR TITLE
[BWS] Prevent wrapped address types for non-segwit chain wallets

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -96,6 +96,12 @@ export const Constants = {
     P2PKH: 'P2PKH',
     P2WPKH: 'P2WPKH'
   },
+
+  NATIVE_SEGWIT_CHAINS: {
+    BTC: 'btc',
+    LTC: 'ltc'
+  },
+
   DERIVATION_STRATEGIES: {
     BIP44: 'BIP44',
     BIP45: 'BIP45'

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -572,7 +572,7 @@ export class WalletService implements IWalletService {
     const derivationStrategy = Constants.DERIVATION_STRATEGIES.BIP44;
     let addressType = opts.n === 1 ? Constants.SCRIPT_TYPES.P2PKH : Constants.SCRIPT_TYPES.P2SH;
 
-    if (opts.useNativeSegwit) {
+    if (opts.useNativeSegwit && Utils.checkValueInCollection(opts.chain, Constants.NATIVE_SEGWIT_CHAINS)) {
       addressType = opts.n === 1 ? Constants.SCRIPT_TYPES.P2WPKH : Constants.SCRIPT_TYPES.P2WSH;
     }
 


### PR DESCRIPTION
There's a bug in the wallet that passes in `useNativeSegwit` even for BCH and DOGE wallets. The wallet bug is being fixed, but this will prevent older wallet versions from continuing to create wallets with segwit addresses for non-segwit chains.