### PR TITLE
[REF] Special handling for usdc.e and usdc on matic

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/utils.ts
@@ -522,6 +522,12 @@ export class Utils {
     const suffix = Constants.EVM_CHAINSUFFIXMAP[chain.toLowerCase()];
     const coinIsAChain = !!Constants.EVM_CHAINSUFFIXMAP[coin.toLowerCase()];
     if (suffix && (coinIsAChain || chain.toLowerCase() !== 'eth')) {
+       // Special handling for usdc.e and usdc on matic
+      if (coin.toLowerCase() === 'usdc.e') {
+        return 'USDC_m';
+      } else if (coin.toLowerCase() === 'usdc') {
+        return 'USDCn_m';
+      }
       return `${coin.toUpperCase()}_${suffix}`;
     }
     return coin.toUpperCase();


### PR DESCRIPTION
currencies specified by invoice v4:

  USDC_m: {
    code: 'USDC.e',
    name: 'USD Coin',
    network: 'Polygon',
    imgSrc: '/img/icon/currencies/USDC.svg',
    networkImgSrc: '/img/icon/currencies/MATIC.svg',
    displayNetwork: true,
  },
  USDCn_m: {
    code: 'USDC',
    name: 'USD Coin',
    network: 'Polygon',
    imgSrc: '/img/icon/currencies/USDC.svg',
    networkImgSrc: '/img/icon/currencies/MATIC.svg',
    displayNetwork: true,
  },
  
For USDC.e and USDC wallets in the app, we expect USDC.e_m and USDC_m in the paypro options.
But we have for USDC.e -> USDC_m  and for USDC -> USDCn_m 
