### PR TITLE
[BCC] Handle single output tx fee bumping

### DIFF
--- a/packages/bitcore-client/bin/wallet-bump-tx
+++ b/packages/bitcore-client/bin/wallet-bump-tx
@@ -19,12 +19,13 @@ program
   .option('-P, --feePriority <rate>', 'optional - Priority fee for EVM type 2 txs in Gwei')
   .option('-q, --quiet', 'optional - Do not prompt for confirmation or show raw tx data')
   .option('--noRbf', 'optional - Disable replace-by-fee')
+  .option('--isSweep', 'optional - Force treat the transaction as a sweep. Useful for when the --change is not an address controlled by the wallet')
   .option('--storageType <storageType>', 'optional - Name of the database to use (default Level)')
   .option('--path <path>', 'optional - Custom wallet storage path')
   .parse(process.argv);
 
 const main = async () => {
-  const { name, path, storageType = 'Level', raw: rawTx, change, feeRate, feeTarget = 2, feePriority, quiet, noRbf } = program.opts();
+  const { name, path, storageType = 'Level', raw: rawTx, change, feeRate, feeTarget = 2, feePriority, quiet, noRbf, isSweep } = program.opts();
   let { txid } = program.opts();
   let wallet;
   
@@ -61,6 +62,7 @@ const main = async () => {
       params.recipients = outputs.filter(o => o.mintIndex != change).map(o => ({ address: o.address, amount: o.value }));
       params.lockUntilBlock = locktime > 0 ? locktime : undefined;
       params.replaceByFee = !noRbf;
+      params.isSweep = isSweep ?? outputs.length === 1;
       if (feeRate) {
         params.feeRate = feeRate;
       } else {

--- a/packages/bitcore-client/bin/wallet-bump-tx
+++ b/packages/bitcore-client/bin/wallet-bump-tx
@@ -5,7 +5,6 @@
 const program = require('commander');
 const { Wallet } = require('../ts_build/src/wallet');
 const promptly = require('promptly');
-const { Web3 } = require('crypto-wallet-core');
 
 program
   .version(require('../package.json').version)

--- a/packages/bitcore-client/bin/wallet-bump-tx
+++ b/packages/bitcore-client/bin/wallet-bump-tx
@@ -19,7 +19,7 @@ program
   .option('-P, --feePriority <rate>', 'optional - Priority fee for EVM type 2 txs in Gwei')
   .option('-q, --quiet', 'optional - Do not prompt for confirmation or show raw tx data')
   .option('--noRbf', 'optional - Disable replace-by-fee')
-  .option('--isSweep', 'optional - Force treat the transaction as a sweep. Useful for when the --change is not an address controlled by the wallet')
+  .option('--isSweep', 'optional - Treat the transaction as a sweep/max send which ensures all UTXOs are used (defaults to true if there is only one output)')
   .option('--storageType <storageType>', 'optional - Name of the database to use (default Level)')
   .option('--path <path>', 'optional - Custom wallet storage path')
   .parse(process.argv);
@@ -29,89 +29,18 @@ const main = async () => {
   let { txid } = program.opts();
   let wallet;
   
+  if (!txid && !rawTx) {
+    return console.log('Must provide either --raw or --txid');
+  }
+
   try {
     wallet = await Wallet.loadWallet({ name, path, storageType });
 
     if (change == null && wallet.isUtxoChain()) {
-      throw new Error('Must provide --change for UTXO chains');
+      return console.log('Must provide --change for UTXO chains');
     }
 
-    const lib = wallet.getLib();
-    let existingTx;
-    if (rawTx) {
-      if (lib.ethers) {
-        existingTx = lib.ethers.utils.parseTransaction(rawTx);
-      } else {
-        const tx = new lib.Transaction(rawTx);
-        txid = tx.id;
-      }
-    }
-    if (txid) {
-      existingTx = await wallet.getTransactionByTxid({ txid, populated: wallet.isUtxoChain() });
-    } else if (!existingTx) {
-      throw new Error('Must provide either --raw or --txid.');
-    }
-
-    const params = {};
-
-    if (wallet.isUtxoChain()) {
-      const { coins: { inputs, outputs }, locktime } = existingTx;
-
-      params.utxos = inputs;
-      params.change = outputs.find(o => o.mintIndex == change).address;
-      params.recipients = outputs.filter(o => o.mintIndex != change).map(o => ({ address: o.address, amount: o.value }));
-      params.lockUntilBlock = locktime > 0 ? locktime : undefined;
-      params.replaceByFee = !noRbf;
-      params.isSweep = isSweep ?? outputs.length === 1;
-      if (feeRate) {
-        params.feeRate = feeRate;
-      } else {
-        params.feeRate = (await wallet.getNetworkFee({ target: feeTarget })).feerate;
-        console.log(`Bumping fee rate to ${params.feeRate} sats/byte`);
-      }
-
-    // EVM chains
-    } else {
-      const { nonce, gasLimit, gasPrice, to, data, value, chainId, type } = existingTx;
-      // converting gasLimit and value with toString avoids a bigNumber warning
-      params.nonce = nonce
-      params.gasLimit = gasLimit?.toString();
-      params.gasPrice = gasPrice;
-      params.data = data;
-      params.chainId = chainId;
-      params.type = type;
-      params.recipients = [{ address: to, amount: value.toString() }];
-      
-      // TODO fix type2 support
-      if (false && existingTx.type === 2) {
-        if (feeRate) {
-          params.maxGasFee = Web3.utils.toWei(feeRate.toString(), 'gwei');
-        } else {
-          // TODO placeholder until for type2 support is merged in another PR
-          // params.maxGasFee = (await wallet.getNetworkFee({ target: feeTarget })).feerate;
-          // console.log(`Bumping max gas price to ${Web3.utils.fromWei(params.maxGasFee.toString(), 'gwei')} gwei`);
-        }
-        if (feePriority) {    
-          params.maxPriorityFee = Web3.utils.toWei(feePriority.toString(), 'gwei');
-        } else {
-          // TODO placeholder until for type2 support is merged in another PR
-          // params.maxPriorityFee = existingTx.maxPriorityFeePerGas;
-          // console.log(`Bumping max priority fee to ${Web3.utils.fromWei(params.maxPriorityFee.toString(), 'gwei')} gwei`);
-        }
-
-      // type 0
-      } else {
-        if (feeRate) {
-          params.gasPrice = Web3.utils.toWei(feeRate.toString(), 'gwei');
-        } else {
-          params.gasPrice = (await wallet.getNetworkFee({ target: feeTarget })).feerate;
-          console.log(`Bumping gas price to ${Web3.utils.fromWei(params.gasPrice.toString(), 'gwei')} gwei`);
-        }
-      }
-      
-    }
-
-    const tx = await wallet.newTx(params);
+    const { tx, params } = await wallet.bumpTxFee({ txid, rawTx, changeIdx: change, feeRate, feeTarget, feePriority, noRbf, isSweep });
     !quiet && console.log('UnsignedRawTx: ', tx);
     const passphrase = await promptly.password('Wallet Password:');
     wallet = await wallet.unlock(passphrase);

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -398,6 +398,7 @@ export class Wallet {
     replaceByFee?: boolean;
     lockUntilBlock?: number;
     lockUntilDate?: Date;
+    isSweep?: boolean;
   }) {
     const chain = params.token ? this.chain + 'ERC20' : this.chain;
     let tokenContractAddress;
@@ -433,7 +434,8 @@ export class Wallet {
       contractAddress: params.contractAddress,
       replaceByFee: params.replaceByFee,
       lockUntilBlock: params.lockUntilBlock,
-      lockUntilDate: params.lockUntilDate
+      lockUntilDate: params.lockUntilDate,
+      isSweep: params.isSweep
     };
     return Transactions.create(payload);
   }

--- a/packages/crypto-wallet-core/src/transactions/bch/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/bch/index.ts
@@ -2,8 +2,8 @@ import { BTCTxProvider } from '../btc';
 
 export class BCHTxProvider extends BTCTxProvider {
   lib = require('bitcore-lib-cash');
-  create({ recipients, utxos = [], change, fee = 20000 }) {
-    const filteredUtxos = this.selectCoins(recipients, utxos, fee);
+  create({ recipients, utxos = [], change, fee = 20000, isSweep }) {
+    const filteredUtxos = isSweep ? utxos : this.selectCoins(recipients, utxos, fee);
     const btcUtxos = filteredUtxos.map(utxo => {
       const btcUtxo = Object.assign({}, utxo, {
         amount: utxo.value / 1e8,

--- a/packages/crypto-wallet-core/src/transactions/btc/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/btc/index.ts
@@ -31,8 +31,8 @@ export class BTCTxProvider {
     return filteredUtxos;
   }
 
-  create({ recipients, utxos = [], change, feeRate, fee, replaceByFee, lockUntilDate, lockUntilBlock }) {
-    const filteredUtxos = this.selectCoins(recipients, utxos, fee);
+  create({ recipients, utxos = [], change, feeRate, fee, isSweep, replaceByFee, lockUntilDate, lockUntilBlock }) {
+    const filteredUtxos = isSweep ? utxos : this.selectCoins(recipients, utxos, fee);
     const btcUtxos = filteredUtxos.map(utxo => {
       const btcUtxo = Object.assign({}, utxo, {
         amount: utxo.value / 1e8,


### PR DESCRIPTION
This handles the case when the tx is a sweep/max send and all given utxos should be used.

Also moved the fee bump logic into the Wallet class for integrations.