### PR TITLE
[Insight] Handle expired txs; Parse output scripts

### DIFF
--- a/packages/insight/config-overrides.js
+++ b/packages/insight/config-overrides.js
@@ -1,0 +1,22 @@
+// config-overrides.js
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const webpack = require('webpack');
+
+module.exports = function override(config, env) {
+  config.resolve.fallback = {
+    ...config.resolve.fallback,
+    assert: require.resolve('assert/'),
+    buffer: require.resolve('buffer'),
+    crypto: require.resolve('crypto-browserify'),
+    stream: require.resolve('stream-browserify'),
+    url: require.resolve('url/')
+  };
+
+  config.plugins.push(
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer']
+    })
+  )
+
+  return config;
+};

--- a/packages/insight/custom.d.ts
+++ b/packages/insight/custom.d.ts
@@ -1,4 +1,29 @@
-declare module "*.svg" {
+declare module '*.svg' {
     const content: any;
     export default content;
+}
+
+declare module '*.wav' {
+    const src: string;
+    export default src;
+}
+
+declare module 'bitcore-lib' {
+    const index: any;
+    export default index;
+}
+
+declare module 'bitcore-lib-cash' {
+    const index: any;
+    export default index;
+}
+
+declare module 'bitcore-lib-doge' {
+    const index: any;
+    export default index;
+}
+
+declare module 'bitcore-lib-ltc' {
+    const index: any;
+    export default index;
 }

--- a/packages/insight/package.json
+++ b/packages/insight/package.json
@@ -15,8 +15,8 @@
     "API"
   ],
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,json\"}",
@@ -26,12 +26,20 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "1.8.1",
+    "assert": "2.1.0",
     "axios": "0.21.1",
+    "bitcore-lib": "^10.0.23",
+    "bitcore-lib-cash": "^10.0.23",
+    "bitcore-lib-doge": "^10.0.21",
+    "bitcore-lib-ltc": "^10.0.21",
+    "buffer": "6.0.3",
     "chart.js": "3.5.1",
+    "crypto-browserify": "3.12.0",
     "framer-motion": "6.3.3",
     "nprogress": "0.2.0",
     "qrcode.react": "3.0.1",
     "react": "18.1.0",
+    "react-app-rewired": "2.2.1",
     "react-chartjs-2": "3.2.0",
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "18.0.0",
@@ -43,8 +51,10 @@
     "react-scripts": "5.0.1",
     "redux": "4.2.0",
     "redux-thunk": "2.4.1",
+    "stream-browserify": "3.0.0",
     "styled-components": "5.3.5",
     "swr": "1.3.0",
+    "url": "0.11.3",
     "web-vitals": "2.1.4"
   },
   "devDependencies": {

--- a/packages/insight/src/assets/styles/transaction.ts
+++ b/packages/insight/src/assets/styles/transaction.ts
@@ -172,6 +172,8 @@ export const ArrowDiv = styled.div<ArrowDivProps>`
 
 export const ScriptText = styled.p`
   margin: 0.2rem 0;
+  white-space: normal;
+  word-wrap: break-word;
 `;
 
 export const SpanLink = styled.span`

--- a/packages/insight/src/components/coin.tsx
+++ b/packages/insight/src/components/coin.tsx
@@ -64,6 +64,8 @@ const Coin: FC<CoinProps> = ({transaction, currency, network, order}) => {
               <TransactionTileFlex justifyContent='flex-end'>
                 {height === -3 && <TransactionChip error>Invalid</TransactionChip>}
 
+                {height === -5 && <TransactionChip error>Expired</TransactionChip>}
+
                 {confirmations === -1 && <TransactionChip warning>Unconfirmed</TransactionChip>}
 
                 {confirmations === 1 && <TransactionChip primary>1 Confirmation</TransactionChip>}
@@ -114,6 +116,8 @@ const Coin: FC<CoinProps> = ({transaction, currency, network, order}) => {
                 {height === -3 && <TransactionChip error>Invalid</TransactionChip>}
 
                 {height === -4 && <TransactionChip error>Error</TransactionChip>}
+
+                {height === -5 && <TransactionChip error>Expired</TransactionChip>}
 
                 {confirmations === -1 && <TransactionChip warning>Unconfirmed</TransactionChip>}
 

--- a/packages/insight/src/components/transaction-details-eth.tsx
+++ b/packages/insight/src/components/transaction-details-eth.tsx
@@ -85,6 +85,8 @@ const TransactionDetailsEth: FC<TransactionDetailsEthProps> = ({
         </div>
 
         <TransactionTileFlex>
+          {confirmations === -5 && <TransactionChip error>Expired</TransactionChip>}
+
           {confirmations === -3 && <TransactionChip error>Invalid</TransactionChip>}
 
           {confirmations === -1 && <TransactionChip warning>Unconfirmed</TransactionChip>}

--- a/packages/insight/src/pages/transaction.tsx
+++ b/packages/insight/src/pages/transaction.tsx
@@ -38,7 +38,7 @@ const TransactionHash: React.FC = () => {
   const [error, setError] = useState('');
   const [refTxid, setRefTxid] = useState<string | undefined>();
   const [refVout, setRefVout] = useState<number | undefined>();
-  let confInterval: number;
+  let confInterval: NodeJS.Timer | null = null;
 
   useEffect(() => {
     if (reftxidParam != null && reftxidParam !== '') {
@@ -97,8 +97,8 @@ const TransactionHash: React.FC = () => {
 
     // clear interval on nav to new tx or unmount
     return () => {
-      clearInterval(confInterval);
-      confInterval = 0;
+      clearInterval(confInterval as NodeJS.Timer);
+      confInterval = null;
     };  
   }, [network, currency, tx]);
 
@@ -124,7 +124,8 @@ const TransactionHash: React.FC = () => {
           const {height} = _newTip;
           const confirmations = blockHeight > 0 ? height - blockHeight + 1 : blockHeight;
           if (confirmations !== -1) { // conf status has changed from unconfirmed
-            clearInterval(confInterval);
+            clearInterval(confInterval as NodeJS.Timer);
+            confInterval = null;
             transaction.confirmations = confirmations;
             if (confirmations > -1) { // if confirmed
               transaction.blockHash = _txRefresh.blockHash;
@@ -190,7 +191,15 @@ const TransactionHash: React.FC = () => {
                     }.`}
                     type={'error'}
                   />
-                ))}
+                ))
+              }
+
+              {transaction.confirmations === -5 &&
+                <Info
+                  message={'This transaction was dropped from the mempool'}
+                  type={'error'}
+                />
+              }
 
               <TransactionTileBody>
                 <TransactionBodyCol

--- a/packages/insight/src/react-app-env.d.ts
+++ b/packages/insight/src/react-app-env.d.ts
@@ -1,5 +1,1 @@
 // / <reference types="react-scripts" />
-declare module '*.wav' {
-  const src: string;
-  export default src;
-}

--- a/packages/insight/src/utilities/helper-methods.ts
+++ b/packages/insight/src/utilities/helper-methods.ts
@@ -7,6 +7,10 @@ import {
   UTXO_DEFAULT_REFRESH_INTERVAL,
 } from './constants';
 import {BlockTransactionDetails} from './models';
+import BitcoreLib from 'bitcore-lib';
+import BitcoreLibCash from 'bitcore-lib-cash';
+import BitcoreLibDoge from 'bitcore-lib-doge';
+import BitcoreLibLtc from 'bitcore-lib-ltc';
 
 export const buildTime = (time: string): string => {
   const diffMs = Math.abs(Date.now() - Date.parse(time));
@@ -163,4 +167,18 @@ export const normalizeParams = (
   network: string,
 ): {currency: string; network: string} => {
   return {currency: currency.toUpperCase(), network: network.toLowerCase()};
+};
+
+export const getLib = (currency: string) => {
+  switch (currency.toUpperCase()) {
+    case 'BTC':
+    default:
+      return BitcoreLib;
+    case 'BCH':
+      return BitcoreLibCash;
+    case 'DOGE':
+      return BitcoreLibDoge;
+    case 'LTC':
+      return BitcoreLibLtc;
+  }
 };

--- a/packages/insight/tsconfig.json
+++ b/packages/insight/tsconfig.json
@@ -20,7 +20,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": ".", // To import directly from the root of the project
-    "types": ["cypress", "cypress-axe"]
+    "types": ["cypress", "cypress-axe", "node"]
   },
   "include": ["**/*.ts", "**/*.tsx", "."],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR does 3 things:
1. Handles expired txs. Example tx: BTC testnet bcf7993cce13f4cd0319e0acd90e520b0c77ee87a3d01738c5c202d313ad0c98 (see screenshot)
2. Parses scripts for the outputs, including `OP_RETURN`s (examples of OP_RETURNs: ed2419565502556b5bcdf367a9e6db40eb6cdf1ae1402368acfbe433bc4b86c4, 09e0f34d56855f3318703a80bd6f4011afc0ef3b16904c08b20827aaed28b021)
3. Shows the outputs as spent when spent by unconfirmed txs


![image](https://github.com/bitpay/bitcore/assets/32603939/2dc1ce53-efd7-4190-a20f-e040dcf7fe4d)
