### PR TITLE
[BCN] Move descendant invalidation to pruning service

### DIFF
--- a/packages/bitcore-node/scripts/fixReplacedTree.js
+++ b/packages/bitcore-node/scripts/fixReplacedTree.js
@@ -42,6 +42,8 @@ if (!['BTC', 'BCH', 'DOGE', 'LTC'].includes(chain) || !['mainnet', 'testnet', 'r
 const real = !!args.find(a => a === '--real');
 const force = !!args.find(a => a === '--force');
 
+real && console.log('~~~~ DRY RUN ~~~~');
+console.log('Connecting to storage...');
 Storage.start()
   .then(async () => {
     const tx = await TransactionStorage.collection.findOne({ chain, network, txid });

--- a/packages/bitcore-node/scripts/fixReplacedTree.js
+++ b/packages/bitcore-node/scripts/fixReplacedTree.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const CWC = require('crypto-wallet-core');
+const { Storage } = require('../build/src/services/storage');
+const { TransactionStorage } = require('../build/src/models/transaction');
+
+function usage(errMsg) {
+  console.log('USAGE: ./fixreplacedTree.js <txid> <replacementTxid> [options]');
+  console.log('OPTIONS:');
+  console.log('  --chain <value>      BTC, BCH, DOGE, or LTC');
+  console.log('  --network <value>    mainnet, testnet, or regtest');
+  console.log('  --real               Write the change to the db. If not given, will only do a dry run');
+  console.log('  --force              Force the overwrite of an existing replacedByTxid field');
+  if (errMsg) {
+    console.log('\nERROR: ' + errMsg);
+  }
+  process.exit();
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  usage();
+}
+
+if (!args[0] || !/^[a-f0-9]{64}$/i.test(args[0])) {
+  usage('Missing or invalid txid param.');
+}
+
+if (!args[1] || !/^[a-f0-9]{64}$/i.test(args[1])) {
+  usage('Missing replacementTxid param.');
+}
+
+const [txid, replacementTxid] = args;
+const chain = args[args.indexOf('--chain') + 1];
+const network = args[args.indexOf('--network') + 1];
+
+if (!['BTC', 'BCH', 'DOGE', 'LTC'].includes(chain) || !['mainnet', 'testnet', 'regtest'].includes(network)) {
+  usage('Invalid chain and/or network param(s).');
+}
+
+const real = !!args.find(a => a === '--real');
+const force = !!args.find(a => a === '--force');
+
+Storage.start()
+  .then(async () => {
+    const tx = await TransactionStorage.collection.findOne({ chain, network, txid });
+
+    if (!tx) {
+      console.log('No tx found for txid.');
+      return;
+    }
+    
+    if (tx.replacedByTxid) {
+      console.log('Tx already has replacement txid: ' + tx.replacedByTxid);
+      if (!force) {
+        return;
+      }
+    }
+    
+    if (real) {
+      await TransactionStorage._invalidateTx({ chain, network, invalidTxid: txid, replacedByTxid: replacementTxid });
+
+      const tx = await TransactionStorage.collection.findOne({ chain, network, txid });
+      console.log('Tx replaced', tx.replacedByTxid);
+    } else {
+      console.log('Dry run complete.');
+    }
+  })
+  .catch(console.error)
+  .finally(Storage.stop.bind(Storage))

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -660,7 +660,7 @@ export class TransactionModel extends BaseTransaction<IBtcTransaction> {
         if (seenInvalidTxids.has(input.spentTxid)) {
           continue;
         }
-        await this._invalidateTx({ chain, network, invalidTxid: input.spentTxid, replacedByTxid: minedTxid });
+        await this._invalidateTx({ chain, network, invalidTxid: input.spentTxid, replacedByTxid: minedTxid, simple: true });
         seenInvalidTxids.add(input.spentTxid);
       }
 
@@ -673,29 +673,33 @@ export class TransactionModel extends BaseTransaction<IBtcTransaction> {
   async _invalidateTx(params: {
     chain: string;
     network: string;
-    invalidTxid: string,
-    replacedByTxid?: string // only provided at the beginning of the ancestral tree. Txs that spend unconfirmed outputs aren't "replaced"
-    invalidParentTxids?: string[] // empty at the beginning of the ancestral tree. 
+    invalidTxid: string;
+    replacedByTxid?: string; // only provided at the beginning of the ancestral tree. Txs that spend unconfirmed outputs aren't "replaced"
+    invalidParentTxids?: string[]; // empty at the beginning of the ancestral tree.
+    simple?: boolean; // if true, don't invalidate descendants
   }) {
-    const { chain, network, invalidTxid, replacedByTxid, invalidParentTxids = [] } = params;
-    const spentOutputsQuery = {
-      chain,
-      network,
-      spentHeight: SpentHeightIndicators.pending,
-      mintTxid: invalidTxid
-    };
+    const { chain, network, invalidTxid, replacedByTxid, invalidParentTxids = [], simple } = params;
+    
+    if (!simple) {
+      const spentOutputsQuery = {
+        chain,
+        network,
+        spentHeight: SpentHeightIndicators.pending,
+        mintTxid: invalidTxid
+      };
 
-    // spent outputs of invalid tx
-    const spentOutputsStream = await CoinStorage.collection.find(spentOutputsQuery);
-    const seenTxids = new Set();
-    let output: ICoin | null;
+      // spent outputs of invalid tx
+      const spentOutputsStream = await CoinStorage.collection.find(spentOutputsQuery);
+      const seenTxids = new Set();
+      let output: ICoin | null;
 
-    while ((output = await spentOutputsStream.next())) {
-      if (!output.spentTxid || seenTxids.has(output.spentTxid)) {
-        continue;
+      while ((output = await spentOutputsStream.next())) {
+        if (!output.spentTxid || seenTxids.has(output.spentTxid)) {
+          continue;
+        }
+        // invalidate descendent tx (tx spending unconfirmed UTXO)
+        await this._invalidateTx({ chain, network, invalidTxid: output.spentTxid, invalidParentTxids: [...invalidParentTxids, invalidTxid], simple });
       }
-      // invalidate descendent tx (tx spending unconfirmed UTXO)
-      await this._invalidateTx({ chain, network, invalidTxid: output.spentTxid, invalidParentTxids: [...invalidParentTxids, invalidTxid] });
     }
 
     const setTx: { blockHeight: number; replacedByTxid?: string } = { blockHeight: SpentHeightIndicators.conflicting };

--- a/packages/bitcore-node/src/models/transaction.ts
+++ b/packages/bitcore-node/src/models/transaction.ts
@@ -652,7 +652,7 @@ export class TransactionModel extends BaseTransaction<IBtcTransaction> {
         spentTxid: { $ne: minedTxid }
       };
 
-      const conflictingInputsStream = await CoinStorage.collection.find(conflictingInputsQuery);
+      const conflictingInputsStream = CoinStorage.collection.find(conflictingInputsQuery);
       const seenInvalidTxids = new Set();
       let input: ICoin | null;
 
@@ -689,7 +689,7 @@ export class TransactionModel extends BaseTransaction<IBtcTransaction> {
       };
 
       // spent outputs of invalid tx
-      const spentOutputsStream = await CoinStorage.collection.find(spentOutputsQuery);
+      const spentOutputsStream = CoinStorage.collection.find(spentOutputsQuery);
       const seenTxids = new Set();
       let output: ICoin | null;
 

--- a/packages/bitcore-node/src/rpc.ts
+++ b/packages/bitcore-node/src/rpc.ts
@@ -73,17 +73,17 @@ export class RPC {
     return this.asyncCall('getblockcount', []);
   }
 
-  getBlock(hash: string, verbose: boolean) {
-    return this.asyncCall<RPCBlock<RPCTransaction>>('getblock', [hash, verbose]);
+  getBlock(hash: string, verbosity: number) {
+    return this.asyncCall<RPCBlock<RPCTransaction>>('getblock', [hash, verbosity]);
   }
 
   getBlockHash(height: number) {
     return this.asyncCall<string>('getblockhash', [height]);
   }
 
-  async getBlockByHeight(height: number) {
+  async getBlockByHeight(height: number, verbosity: number) {
     const hash = await this.getBlockHash(height);
-    return this.getBlock(hash, false);
+    return this.getBlock(hash, verbosity);
   }
 
   getTransaction(txid: string) {

--- a/packages/bitcore-node/src/services/pruning.ts
+++ b/packages/bitcore-node/src/services/pruning.ts
@@ -224,7 +224,7 @@ export class PruningService {
       let realCount = 0;
       let invalidCount = 0;
       const seen = new Set<string>();
-      const voutStream = this.coinModel.collection.find({ chain, network, mintHeight: SpentHeightIndicators.pending }).batchSize(1);
+      const voutStream = this.coinModel.collection.find({ chain, network, mintHeight: SpentHeightIndicators.pending });
       for await (const vout of voutStream) {
         if (this.stopping) {
           break;

--- a/packages/bitcore-node/src/services/pruning.ts
+++ b/packages/bitcore-node/src/services/pruning.ts
@@ -284,6 +284,8 @@ export class PruningService {
       } catch (err: any) {
         logger.error(`Error invalidating tx ${tx.txid}: ${err.stack || err.message || err}`);
       }
+    } else {
+      logger.info(`Skipping invalidation of ${tx.txid} with immature replacement => ${tx.replacedByTxid}`);
     }
     return false;
   }

--- a/packages/bitcore-node/test/integration/models/coin.spec.ts
+++ b/packages/bitcore-node/test/integration/models/coin.spec.ts
@@ -119,7 +119,10 @@ describe('Coin Model', function() {
 
     const badTxs = await TransactionStorage.collection.find({ chain, network, txid: { $in: txids } }).toArray();
     expect(badTxs.length).to.eq(chainLength);
-    expect(badTxs.map(tx => tx.blockHeight)).to.deep.eq(new Array(chainLength).fill(SpentHeightIndicators.conflicting));
+    // the replaced tx is marked as conflicting, all the rest still pending to be cleaned up by pruning service
+    expect(badTxs[0].blockHeight).to.eq(SpentHeightIndicators.conflicting);
+    expect(badTxs[0].replacedByTxid).to.exist;
+    expect(badTxs.slice(1).every(tx => tx.blockHeight === SpentHeightIndicators.pending)).to.equal(true);
 
     const goodTxs = await TransactionStorage.collection.find({ chain, network, txid: blockTx.txid }).toArray();
     expect(goodTxs.length).to.eq(1);


### PR DESCRIPTION
This PR:

* Moves descendant invalidation to the pruning service by recycling the processAllInvalidTxs() function to invalidate descendants. The sync process will mark immediate replacements as replaced/invalid and then this process cleans up descendant trees asynchronously.
* Adds a script to manually fix specific replacement tree.