### PR TITLE
[Multi] Regtest support

### DIFF
--- a/packages/bitcore-lib-cash/lib/address.js
+++ b/packages/bitcore-lib-cash/lib/address.js
@@ -206,7 +206,7 @@ Address._transformBuffer = function(buffer, network, type) {
     throw new TypeError('Unknown network');
   }
 
-  if (!bufferVersion.network || (networkObj && networkObj !== bufferVersion.network)) {
+  if (!bufferVersion.network || (networkObj && networkObj.xpubkey !== bufferVersion.network.xpubkey)) {
     throw new TypeError('Address has mismatched network type.');
   }
 
@@ -215,7 +215,7 @@ Address._transformBuffer = function(buffer, network, type) {
   }
 
   info.hashBuffer = buffer.slice(1);
-  info.network = bufferVersion.network;
+  info.network = networkObj || bufferVersion.network;
   info.type = bufferVersion.type;
   return info;
 };

--- a/packages/bitcore-lib-cash/lib/networks.js
+++ b/packages/bitcore-lib-cash/lib/networks.js
@@ -44,6 +44,11 @@ function get(arg, keys) {
     }
     return undefined;
   }
+  if(networkMaps[arg] && networkMaps[arg].length >= 1) {
+    return networkMaps[arg][0];
+  } else {
+    return networkMaps[arg];
+  }
 }
 
 /***
@@ -127,7 +132,10 @@ function indexNetworkBy(network, keys) {
     var key = keys[i];
     var networkValue = network[key];
     if(!_.isUndefined(networkValue) && !_.isObject(networkValue)) {
-      networkMaps[networkValue] = network;
+      if(!networkMaps[networkValue]) {
+        networkMaps[networkValue] = [];
+      }
+      networkMaps[networkValue].push(network);
     }
   }
 }

--- a/packages/bitcore-lib-cash/lib/networks.js
+++ b/packages/bitcore-lib-cash/lib/networks.js
@@ -39,12 +39,11 @@ function get(arg, keys) {
       var filteredNet = _.pick(network, keys);
       var netValues = _.values(filteredNet);
       if(~netValues.indexOf(arg)) {
-	return network;
+	      return network;
       }
     }
     return undefined;
   }
-  return networkMaps[arg];
 }
 
 /***

--- a/packages/bitcore-lib-cash/package.json
+++ b/packages/bitcore-lib-cash/package.json
@@ -35,7 +35,6 @@
     "request": "browser-request"
   },
   "dependencies": {
-    "bitcore-lib": "^10.0.23",
     "bn.js": "=4.11.8",
     "bs58": "^4.0.1",
     "buffer-compare": "=1.1.1",

--- a/packages/bitcore-lib-cash/test/hdprivatekey.js
+++ b/packages/bitcore-lib-cash/test/hdprivatekey.js
@@ -7,7 +7,6 @@ var expect = require('chai').expect;
 var bitcore = require('..');
 var errors = bitcore.errors;
 var hdErrors = errors.HDPrivateKey;
-var buffer = require('buffer');
 var Networks = bitcore.Networks;
 var BufferUtil = bitcore.util.buffer;
 var HDPrivateKey = bitcore.HDPrivateKey;

--- a/packages/bitcore-lib-doge/lib/address.js
+++ b/packages/bitcore-lib-doge/lib/address.js
@@ -195,10 +195,14 @@ Address._transformBuffer = function(buffer, network, type) {
     throw new TypeError('Address buffers must be exactly 21 bytes.');
   }
 
-  network = Networks.get(network);
+  var networkObj = Networks.get(network);
   var bufferVersion = Address._classifyFromVersion(buffer);
 
-  if (!bufferVersion.network || (network && network !== bufferVersion.network)) {
+  if (network && !networkObj) {
+    throw new TypeError('Unknown network');
+  }
+
+  if (!bufferVersion.network || (networkObj && networkObj.xpubkey !== bufferVersion.network.xpubkey)) {
     throw new TypeError('Address has mismatched network type.');
   }
 
@@ -207,7 +211,7 @@ Address._transformBuffer = function(buffer, network, type) {
   }
 
   info.hashBuffer = buffer.slice(1);
-  info.network = bufferVersion.network;
+  info.network = networkObj || bufferVersion.network;
   info.type = bufferVersion.type;
   return info;
 };

--- a/packages/bitcore-lib-doge/lib/networks.js
+++ b/packages/bitcore-lib-doge/lib/networks.js
@@ -171,7 +171,12 @@ addNetwork({
   privatekey: 0xf1,
   scripthash: 0xc4,
   xpubkey: 0x043587cf,
-  xprivkey: 0x04358394
+  xprivkey: 0x04358394,
+  networkMagic: 0xfcc1b7dc,
+  port: 44556,
+  dnsSeeds: [
+    'testseed.jrn.me.uk'
+  ]
 });
 
 /**
@@ -189,99 +194,17 @@ addNetwork({
   scripthash: 0xc4,
   xpubkey: 0x043587cf,
   xprivkey: 0x04358394,
+  networkMagic: 0xfabfb5da,
+  port: 18444,
+  dnsSeeds: []
 });
 
 var regtest = get('regtest');
 
 
-// Add configurable values for testnet/regtest
-
-var TESTNET = {
-  PORT: 44556,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xfcc1b7dc),
-  DNS_SEEDS: [
-    'testseed.jrn.me.uk'
-  ]
-};
-
-for (var key in TESTNET) {
-  if (!_.isObject(TESTNET[key])) {
-    networkMaps[TESTNET[key]] = testnet;
-  }
-}
-
-var REGTEST = {
-  PORT: 18444,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xfabfb5da),
-  DNS_SEEDS: []
-};
-
-for (var key in REGTEST) {
-  if (!_.isObject(REGTEST[key])) {
-    networkMaps[REGTEST[key]] = testnet;
-  }
-}
-
-Object.defineProperty(testnet, 'port', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.PORT;
-    } else {
-      return TESTNET.PORT;
-    }
-  }
-});
-
-Object.defineProperty(testnet, 'networkMagic', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.NETWORK_MAGIC;
-    } else {
-      return TESTNET.NETWORK_MAGIC;
-    }
-  }
-});
-
-Object.defineProperty(testnet, 'dnsSeeds', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.DNS_SEEDS;
-    } else {
-      return TESTNET.DNS_SEEDS;
-    }
-  }
-});
-
-Object.defineProperty(regtest, 'networkMagic', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    return REGTEST.NETWORK_MAGIC;
-  }
-});
-Object.defineProperty(regtest, 'dnsSeeds', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    return REGTEST.DNS_SEEDS;
-  }
-});
-Object.defineProperty(regtest, 'port', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    return REGTEST.PORT;
-  }
-});
-
 /**
  * @function
+ * @deprecated
  * @member Networks#enableRegtest
  * Will enable regtest features for testnet
  */
@@ -291,6 +214,7 @@ function enableRegtest() {
 
 /**
  * @function
+ * @deprecated
  * @member Networks#disableRegtest
  * Will disable regtest features for testnet
  */

--- a/packages/bitcore-lib-doge/test/networks.js
+++ b/packages/bitcore-lib-doge/test/networks.js
@@ -15,25 +15,12 @@ describe('Networks', function() {
     should.exist(networks.defaultNetwork);
   });
 
-  it('#DEPRECATED will enable/disable regtest Network', function() {
+  it('should not replace testnet network with regtest', function() {
     const beforeEnable = networks.testnet;
     networks.enableRegtest();
-    /*
-    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
-    networks.testnet.port.should.equal(18444);
-    networks.testnet.dnsSeeds.should.deep.equal([]);
-    networks.testnet.regtestEnabled.should.equal(true);
-    */
     networks.testnet.should.deep.equal(beforeEnable);
 
     networks.disableRegtest();
-    /*
-    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fcc1b7dc', 'hex'));
-    networks.testnet.port.should.equal(44556);
-    networks.testnet.dnsSeeds.should.deep.equal([
-      'testseed.jrn.me.uk',
-    ]);
-    */
     networks.testnet.should.deep.equal(beforeEnable);
   });
 

--- a/packages/bitcore-lib-doge/test/networks.js
+++ b/packages/bitcore-lib-doge/test/networks.js
@@ -15,19 +15,26 @@ describe('Networks', function() {
     should.exist(networks.defaultNetwork);
   });
 
-  it('will enable/disable regtest Network', function() {
+  it('#DEPRECATED will enable/disable regtest Network', function() {
+    const beforeEnable = networks.testnet;
     networks.enableRegtest();
-    networks.testnet.networkMagic.should.deep.equal(new Buffer('fabfb5da', 'hex'));
+    /*
+    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
     networks.testnet.port.should.equal(18444);
     networks.testnet.dnsSeeds.should.deep.equal([]);
     networks.testnet.regtestEnabled.should.equal(true);
+    */
+    networks.testnet.should.deep.equal(beforeEnable);
 
     networks.disableRegtest();
-    networks.testnet.networkMagic.should.deep.equal(new Buffer('fcc1b7dc', 'hex'));
+    /*
+    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fcc1b7dc', 'hex'));
     networks.testnet.port.should.equal(44556);
     networks.testnet.dnsSeeds.should.deep.equal([
       'testseed.jrn.me.uk',
     ]);
+    */
+    networks.testnet.should.deep.equal(beforeEnable);
   });
 
   it('will get network based on string "regtest" value', function() {

--- a/packages/bitcore-lib-ltc/lib/address.js
+++ b/packages/bitcore-lib-ltc/lib/address.js
@@ -250,7 +250,7 @@ Address._transformBuffer = function(buffer, network, type) {
   } else {
     info.hashBuffer = buffer.slice(1);
   }
-  info.network = bufferVersion.network;
+  info.network = networkObj || bufferVersion.network;
   info.type = bufferVersion.type;
   return info;
 };

--- a/packages/bitcore-lib-ltc/lib/networks.js
+++ b/packages/bitcore-lib-ltc/lib/networks.js
@@ -44,7 +44,11 @@ function get(arg, keys) {
     }
     return undefined;
   }
-  return networkMaps[arg];
+  if(networkMaps[arg] && networkMaps[arg].length >= 1) {
+    return networkMaps[arg][0];
+  } else {
+    return networkMaps[arg];
+  }
 }
 
 /**
@@ -108,7 +112,10 @@ function addNetwork(data) {
 
   _.each(network, function(value) {
     if (!_.isUndefined(value) && !_.isObject(value)) {
-      networkMaps[value] = network;
+      if(!networkMaps[value]) {
+        networkMaps[value] = [];
+      }
+      networkMaps[value].push(network);
     }
   });
 
@@ -177,7 +184,7 @@ var livenet = get('livenet');
 
 addNetwork({
   name: 'testnet',
-  alias: 'regtest',
+  alias: 'test',
   pubkeyhash: 0x6f, // 111
   privatekey: 0xef, // 239
   scripthash: 0x3a, // 58

--- a/packages/bitcore-lib-ltc/lib/networks.js
+++ b/packages/bitcore-lib-ltc/lib/networks.js
@@ -76,6 +76,7 @@ function addNetwork(data) {
     privatekey: data.privatekey,
     scripthash: data.scripthash,
     scripthash2: data.scripthash2,
+    bech32prefix: data.bech32prefix,
     xpubkey: data.xpubkey,
     xprivkey: data.xprivkey
   });
@@ -181,8 +182,15 @@ addNetwork({
   privatekey: 0xef, // 239
   scripthash: 0x3a, // 58
   scripthash2: 0xc4, // 196
+  bech32prefix: 'tltc',
   xpubkey: 0x043587cf,
-  xprivkey: 0x04358394
+  xprivkey: 0x04358394,
+  networkMagic: 0xfdd2c8f1,
+  port: 19335,
+  dnsSeeds: [
+    'testnet-seed.litecointools.com',
+    'seed-b.litecoin.loshan.co.uk'
+  ]
 });
 
 /**
@@ -191,89 +199,30 @@ addNetwork({
  */
 var testnet = get('testnet');
 
-// Add configurable values for testnet/regtest
-
-var TESTNET = {
-  PORT: 19335,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xfdd2c8f1),
-  DNS_SEEDS: [
-    'testnet-seed.litecointools.com',
-    'seed-b.litecoin.loshan.co.uk'
-  ],
-  BECH32_PREFIX: 'tltc'
-};
-
-for (var key in TESTNET) {
-  if (!_.isObject(TESTNET[key])) {
-    networkMaps[TESTNET[key]] = testnet;
-  }
-}
-networkMaps[TESTNET.NETWORK_MAGIC.toString('hex')] = testnet;
-
-var REGTEST = {
-  PORT: 19444,
-  NETWORK_MAGIC: BufferUtil.integerAsBuffer(0xfabfb5da),
-  DNS_SEEDS: [],
-  BECH32_PREFIX: 'rltc'
-};
-
-for (var key in REGTEST) {
-  if (!_.isObject(REGTEST[key])) {
-    networkMaps[REGTEST[key]] = testnet;
-  }
-}
-networkMaps[REGTEST.NETWORK_MAGIC.toString('hex')] = testnet;
-
-Object.defineProperty(testnet, 'port', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.PORT;
-    } else {
-      return TESTNET.PORT;
-    }
-  }
+addNetwork({
+  name: 'regtest',
+  alias: 'dev',
+  pubkeyhash: 0x6f, // 111
+  privatekey: 0xef, // 239
+  scripthash: 0x3a, // 58
+  scripthash2: 0xc4, // 196
+  bech32prefix: 'rltc',
+  xpubkey: 0x043587cf,
+  xprivkey: 0x04358394,
+  networkMagic: 0xfabfb5da,
+  port: 19444,
+  dnsSeeds: []
 });
 
-Object.defineProperty(testnet, 'networkMagic', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.NETWORK_MAGIC;
-    } else {
-      return TESTNET.NETWORK_MAGIC;
-    }
-  }
-});
-
-Object.defineProperty(testnet, 'dnsSeeds', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.DNS_SEEDS;
-    } else {
-      return TESTNET.DNS_SEEDS;
-    }
-  }
-});
-
-Object.defineProperty(testnet, 'bech32prefix', {
-  enumerable: true,
-  configurable: false,
-  get: function() {
-    if (this.regtestEnabled) {
-      return REGTEST.BECH32_PREFIX
-    } else {
-      return TESTNET.BECH32_PREFIX
-    }
-  }
-})
+/**
+ * @instance
+ * @member Networks#testnet
+ */
+var regtest = get('regtest');
 
 /**
  * @function
+ * @deprecated
  * @member Networks#enableRegtest
  * Will enable regtest features for testnet
  */
@@ -283,6 +232,7 @@ function enableRegtest() {
 
 /**
  * @function
+ * @deprecated
  * @member Networks#disableRegtest
  * Will disable regtest features for testnet
  */
@@ -300,6 +250,7 @@ module.exports = {
   livenet: livenet,
   mainnet: livenet,
   testnet: testnet,
+  regtest: regtest,
   get: get,
   enableRegtest: enableRegtest,
   disableRegtest: disableRegtest

--- a/packages/bitcore-lib-ltc/test/networks.js
+++ b/packages/bitcore-lib-ltc/test/networks.js
@@ -40,7 +40,7 @@ describe('Networks', function() {
 
   it('will get network based on string "regtest" value', function() {
     var network = networks.get('regtest');
-    network.should.equal(networks.testnet);
+    network.should.equal(networks.regtest);
   });
 
   it('should be able to define a custom Network', function() {

--- a/packages/bitcore-lib-ltc/test/networks.js
+++ b/packages/bitcore-lib-ltc/test/networks.js
@@ -15,26 +15,12 @@ describe('Networks', function() {
     should.exist(networks.defaultNetwork);
   });
 
-  it('#DEPRECATED will enable/disable regtest Network', function() {
+  it('should not replace testnet network with regtest', function() {
     const beforeEnable = networks.testnet;
     networks.enableRegtest();
-    /*
-    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
-    networks.testnet.port.should.equal(19444);
-    networks.testnet.dnsSeeds.should.deep.equal([]);
-    networks.testnet.regtestEnabled.should.equal(true);
-    */
     networks.testnet.should.deep.equal(beforeEnable);
 
     networks.disableRegtest();
-    /*
-    networks.testnet.networkMagic.should.deep.equal(Buffer.from('fdd2c8f1', 'hex'));
-    networks.testnet.port.should.equal(19335);
-    networks.testnet.dnsSeeds.should.deep.equal([
-      'testnet-seed.litecointools.com',
-      'seed-b.litecoin.loshan.co.uk'
-    ]);
-    */
     networks.testnet.should.deep.equal(beforeEnable);
   });
 

--- a/packages/bitcore-lib-ltc/test/networks.js
+++ b/packages/bitcore-lib-ltc/test/networks.js
@@ -15,20 +15,27 @@ describe('Networks', function() {
     should.exist(networks.defaultNetwork);
   });
 
-  it('will enable/disable regtest Network', function() {
+  it('#DEPRECATED will enable/disable regtest Network', function() {
+    const beforeEnable = networks.testnet;
     networks.enableRegtest();
+    /*
     networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
     networks.testnet.port.should.equal(19444);
     networks.testnet.dnsSeeds.should.deep.equal([]);
     networks.testnet.regtestEnabled.should.equal(true);
+    */
+    networks.testnet.should.deep.equal(beforeEnable);
 
     networks.disableRegtest();
+    /*
     networks.testnet.networkMagic.should.deep.equal(Buffer.from('fdd2c8f1', 'hex'));
     networks.testnet.port.should.equal(19335);
     networks.testnet.dnsSeeds.should.deep.equal([
       'testnet-seed.litecointools.com',
       'seed-b.litecoin.loshan.co.uk'
     ]);
+    */
+    networks.testnet.should.deep.equal(beforeEnable);
   });
 
   it('will get network based on string "regtest" value', function() {

--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -263,7 +263,7 @@ Address._transformBuffer = function(buffer, network, type) {
   } else {
     info.hashBuffer = buffer.slice(1);
   }
-  info.network = bufferVersion.network;
+  info.network = networkObj || bufferVersion.network;
   info.type = bufferVersion.type;
   return info;
 };

--- a/packages/bitcore-lib/lib/networks.js
+++ b/packages/bitcore-lib/lib/networks.js
@@ -113,7 +113,6 @@ function addNetwork(data) {
   networks.push(network);
 
   return network;
-
 }
 
 /**

--- a/packages/bitcore-lib/test/networks.js
+++ b/packages/bitcore-lib/test/networks.js
@@ -19,7 +19,7 @@ describe('Networks', function() {
     const beforeEnable = networks.testnet;
     networks.enableRegtest();
     /*
-     *networks.testnet.networkMagic.should.deep.equal(new Buffer('fabfb5da', 'hex'));
+     *networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
      *networks.testnet.port.should.equal(18444);
      *networks.testnet.dnsSeeds.should.deep.equal([]);
      *networks.testnet.regtestEnabled.should.equal(true);

--- a/packages/bitcore-lib/test/networks.js
+++ b/packages/bitcore-lib/test/networks.js
@@ -15,15 +15,9 @@ describe('Networks', function() {
     should.exist(networks.defaultNetwork);
   });
 
-  it('#DEPRECATED will enable/disable regtest Network', function() {
+  it('should not replace testnet network with regtest', function() {
     const beforeEnable = networks.testnet;
     networks.enableRegtest();
-    /*
-     *networks.testnet.networkMagic.should.deep.equal(Buffer.from('fabfb5da', 'hex'));
-     *networks.testnet.port.should.equal(18444);
-     *networks.testnet.dnsSeeds.should.deep.equal([]);
-     *networks.testnet.regtestEnabled.should.equal(true);
-     */
     networks.testnet.should.deep.equal(beforeEnable);
 
     networks.disableRegtest();

--- a/packages/bitcore-node/test/integration/matic/p2p.spec.ts
+++ b/packages/bitcore-node/test/integration/matic/p2p.spec.ts
@@ -1,6 +1,6 @@
 import * as BitcoreClient from 'bitcore-client';
 import { expect } from 'chai';
-import { Web3 } from 'crypto-wallet-core';
+import { Web3, Transactions } from 'crypto-wallet-core';
 import sinon from 'sinon';
 import config from '../../../src/config';
 import { CacheStorage } from '../../../src/models/cache';
@@ -65,16 +65,19 @@ async function sendTransaction(from, to, amount, web3, wallet, nonce = 0) {
 describe('Polygon', function() {
   const suite = this;
   this.timeout(50000);
+  const sandbox = sinon.createSandbox();
 
   before(async () => {
     await intBeforeHelper();
     await resetDatabase();
     await Api.start();
+    sandbox.stub(Transactions.get({ chain }), 'getChainId').returns(1337);
   });
 
   after(async () => {
     await Api.stop();
     await intAfterHelper(suite);
+    sandbox.restore();
   });
 
   it('should be able to create a wallet with an address', async () => {

--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -913,8 +913,8 @@ export class API extends EventEmitter {
       return cb(new Error('Invalid coin'));
 
     var network = opts.network || 'livenet';
-    if (!_.includes(['testnet', 'livenet'], network))
-      return cb(new Error('Invalid network'));
+    if (!_.includes(['testnet', 'livenet', 'regtest'], network))
+      return cb(new Error('Invalid network: ' + network));
 
     if (!this.credentials) {
       return cb(new Error('Import credentials first with setCredentials()'));

--- a/packages/bitcore-wallet-client/src/lib/key.ts
+++ b/packages/bitcore-wallet-client/src/lib/key.ts
@@ -365,8 +365,8 @@ export class Key {
   };
 
   _checkNetwork = function (network) {
-    if (!_.includes(['livenet', 'testnet'], network))
-      throw new Error('Invalid network');
+    if (!_.includes(['livenet', 'testnet', 'regtest'], network))
+      throw new Error('Invalid network ' + network);
   };
 
   /*
@@ -384,7 +384,7 @@ export class Key {
 
     // checking in chains for simplicity
     if (
-      opts.network == 'testnet' &&
+      ['testnet', 'regtest]'].includes(opts.network) &&
       Constants.UTXO_CHAINS.includes(opts.coin)
     ) {
       coinCode = '1';
@@ -439,11 +439,11 @@ export class Key {
       Constants.PATHS.REQUEST_KEY
     ).privateKey.toString();
 
-    if (opts.network == 'testnet') {
+    if (['testnet', 'regtest'].includes(opts.network)) {
       // Hacky: BTC/BCH xPriv depends on network: This code is to
-      // convert a livenet xPriv to a testnet xPriv
+      // convert a livenet xPriv to a testnet/regtest xPriv
       let x = xPrivKey.toObject();
-      x.network = 'testnet';
+      x.network = opts.network;
       delete x.xprivkey;
       delete x.checksum;
       x.privateKey = _.padStart(x.privateKey, 64, '0');

--- a/packages/bitcore-wallet-service/bws.example.config.js
+++ b/packages/bitcore-wallet-service/bws.example.config.js
@@ -2,6 +2,7 @@ module.exports = {
   basePath: '/bws/api',
   disableLogs: false,
   port: 3232,
+  allowRegtest: false,
 
   // Uncomment to make BWS a forking server
   // cluster: true,

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -950,10 +950,9 @@ export class BtcChain implements IChain {
   protected _isCorrectNetwork(wallet, addr) {
     const addrNetwork = addr.network.toString();
     const walNetwork = wallet.network;
-    const walChain = wallet.chain || wallet.coin; // wallet.coin is for backward compatibility
 
-    if (addrNetwork === 'regtest' && walNetwork === 'testnet') {
-      return config.blockchainExplorerOpts?.[walChain]?.testnet?.regtestEnabled;
+    if (addrNetwork === 'testnet' && walNetwork === 'regtest') {
+      return !!config.allowRegtest;
     }
     return addrNetwork === walNetwork;
   }

--- a/packages/bitcore-wallet-service/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/utils.ts
@@ -1,5 +1,6 @@
 import * as CWC from 'crypto-wallet-core';
 import _ from 'lodash';
+import Config from '../../config';
 import { logger } from '../logger';
 
 const $ = require('preconditions').singleton();
@@ -272,5 +273,14 @@ export class Utils {
 
     const result = Bitcore_[coin].Address.fromObject(origObj);
     return coin == 'bch' ? result.toLegacyAddress() : result.toString();
+  }
+
+  static compareNetworks(network1, network2) {
+    network1 = network1?.toLowerCase();
+    network2 = network2?.toLowerCase();
+
+    if (network1 == network2) return true;
+    if (Config.allowRegtest && ['testnet', 'regtest'].includes(network1) && ['testnet', 'regtest'].includes(network2)) return true;
+    return false;
   }
 }

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -439,6 +439,7 @@ export class WalletService implements IWalletService {
     if (typeof message === 'string' && args.length > 0 && !message.endsWith('%o')) {
       for (let i = 0; i < args.length; i++) {
         message += ' %o';
+        args[i] = args[i]?.stack || args[i]?.message || args[i];
       }
     }
 
@@ -568,6 +569,10 @@ export class WalletService implements IWalletService {
     opts.network = opts.network || 'livenet';
     if (!Utils.checkValueInCollection(opts.network, Constants.NETWORKS)) {
       return cb(new ClientError('Invalid network'));
+    }
+
+    if (opts.network === 'regtest' && !config.allowRegtest) {
+      return cb(new ClientError('Regtest is not allowed for this environment'));
     }
 
     const derivationStrategy = Constants.DERIVATION_STRATEGIES.BIP44;
@@ -1159,7 +1164,7 @@ export class WalletService implements IWalletService {
           return cb(new ClientError('The wallet you are trying to join was created for a different chain'));
         }
 
-        if (wallet.network != xPubKey.network.name) {
+        if (!Utils.compareNetworks(wallet.network, xPubKey.network.name)) {
           return cb(new ClientError('The wallet you are trying to join was created for a different network'));
         }
 

--- a/packages/crypto-wallet-core/src/transactions/matic/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/matic/index.ts
@@ -1,8 +1,5 @@
-import { ethers } from 'ethers';
-import Web3 from 'web3';
 import { ETHTxProvider } from '../eth';
-const utils = require('web3-utils');
-const { toBN } = Web3.utils;
+
 export class MATICTxProvider extends ETHTxProvider {
   getChainId(network: string) {
     let chainId = 137;
@@ -12,7 +9,7 @@ export class MATICTxProvider extends ETHTxProvider {
         chainId = 80001;
         break;
       case 'regtest':
-        chainId = 1337;
+        chainId = 13375;
         break;
       default:
         chainId = 137;

--- a/packages/crypto-wallet-core/test/transactions.ts
+++ b/packages/crypto-wallet-core/test/transactions.ts
@@ -1098,6 +1098,6 @@ describe('MATIC Transaction getChainId', () => {
     expect(testId).to.equal(80001);
 
     const regtestId = Transactions.get({ chain: 'MATIC' }).getChainId('regtest');
-    expect(regtestId).to.equal(1337);
+    expect(regtestId).to.equal(13375);
   });
 });


### PR DESCRIPTION
This adds natural regtest support in a way that doesn't require you to clobber testnet. This is necessary because several currencies have address formats that are different between regtest and testnet.

This relates to https://github.com/bitpay/bitpay-app/pull/1054 which may be useful for testing this

NOTE: when using the above PR, you'll have to update your bitpay-app `package.json` bitcore dependencies to point to local bitcore dirs. You'll also need to update any bitcore sub dependencies to point to local dirs as well, since running `yarn` in the bitpay-app won't respect lerna linking when pulling sub-dependencies.