### PR TITLE
Optimize find in bitcore-node config path finding

### DIFF
--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -21,7 +21,7 @@ function findConfig(): ConfigType | undefined {
   // No config specified. Search home, bitcore and cur directory
   for (let path of bitcoreConfigPaths) {
     if (foundConfig) { 
-      break;
+      return foundConfig;
     }
     try {
       const expanded = path[0] === '~' ? path.replace('~', homedir()) : path;

--- a/packages/bitcore-node/src/config.ts
+++ b/packages/bitcore-node/src/config.ts
@@ -20,14 +20,15 @@ function findConfig(): ConfigType | undefined {
   }
   // No config specified. Search home, bitcore and cur directory
   for (let path of bitcoreConfigPaths) {
-    if (!foundConfig) {
-      try {
-        const expanded = path[0] === '~' ? path.replace('~', homedir()) : path;
-        const bitcoreConfig = require(expanded) as { bitcoreNode: ConfigType };
-        foundConfig = bitcoreConfig.bitcoreNode;
-      } catch (e) {
-        foundConfig = undefined;
-      }
+    if (foundConfig) { 
+      break;
+    }
+    try {
+      const expanded = path[0] === '~' ? path.replace('~', homedir()) : path;
+      const bitcoreConfig = require(expanded) as { bitcoreNode: ConfigType };
+      foundConfig = bitcoreConfig.bitcoreNode;
+    } catch (e) {
+      foundConfig = undefined;
     }
   }
   return foundConfig;


### PR DESCRIPTION
This change changes the logic for the bitcore-node config path finding. Instead of continuing the loop after a config path is found to have a valid config type, it returns the config type as soon as it finds a config type.