### PR TITLE
Fix: Simplex getQuote with sepa payment method (old app)

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -5875,6 +5875,11 @@ export class WalletService implements IWalletService {
         Authorization: 'ApiKey ' + API_KEY
       };
 
+      if (req.body && req.body.payment_methods && Array.isArray(req.body.payment_methods)) {
+        // Workaround to fix older versions of the app
+        req.body.payment_methods = req.body.payment_methods.map(item => item === 'simplex_account' ? 'sepa_open_banking' : item);
+      }
+
       this.request.post(
         API + '/wallet/merchant/v2/quote',
         {


### PR DESCRIPTION
The Simplex team changed the attribute months ago to indicate that a quote with the Sepa Bank Transfer payment method is required. However, older versions of the app continue to send requests with this attribute. With this fix, they are replaced by the correct and expected key.