### PR TITLE
[BWS] Fix walletCheck query param

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -553,7 +553,7 @@ export class ExpressApp {
         server => {
           const opts = {
             identifier: req.params['identifier'],
-            walletCheck: req.params['walletCheck']
+            walletCheck: ['1', 'true'].includes(req.query['walletCheck'])
           };
           server.getWalletFromIdentifier(opts, (err, wallet) => {
             if (err) return returnError(err, res, req);


### PR DESCRIPTION
'walletCheck' is supposed to be in the query params, not the URI params