### PR TITLE
[BWC] Better handling when res.body is {}

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/errors/spec.ts
+++ b/packages/bitcore-wallet-client/src/lib/errors/spec.ts
@@ -181,6 +181,10 @@ var errorSpec = [
   {
     name: 'INVALID_REQUEST',
     message: 'The PayPro request was invalid. Please try again later.'
+  },
+  {
+    name: 'PAYLOAD_TOO_LARGE',
+    message: 'The request payload is too large.'
   }
 ];
 module.exports = errorSpec;

--- a/packages/bitcore-wallet-client/src/lib/request.ts
+++ b/packages/bitcore-wallet-client/src/lib/request.ts
@@ -117,12 +117,12 @@ export class Request {
       if (res.status !== 200) {
         if (res.status === 503) return cb(new Errors.MAINTENANCE_ERROR());
         if (res.status === 404) return cb(new Errors.NOT_FOUND());
-
         if (!res.status) return cb(new Errors.CONNECTION_ERROR());
 
         log.error('HTTP Error:' + res.status);
 
-        if (!res.body) return cb(new Error(res.status));
+        if (!res.body || !Object.keys(res.body).length)
+          return cb(new Error(res.status + `${err?.message ? ': ' + err.message : ''}`));
         return cb(Request._parseError(res.body));
       }
 

--- a/packages/bitcore-wallet-client/src/lib/request.ts
+++ b/packages/bitcore-wallet-client/src/lib/request.ts
@@ -117,6 +117,7 @@ export class Request {
       if (res.status !== 200) {
         if (res.status === 503) return cb(new Errors.MAINTENANCE_ERROR());
         if (res.status === 404) return cb(new Errors.NOT_FOUND());
+        if (res.status === 413) return cb(new Errors.PAYLOAD_TOO_LARGE());
         if (!res.status) return cb(new Errors.CONNECTION_ERROR());
 
         log.error('HTTP Error:' + res.status);


### PR DESCRIPTION
This PR improves handling when `res.body` is `{}` which happens when there's an HTTP error that's not specifically handled. To test, you can comment out one of the common handlers (e.g. NOT_FOUND). I also added a handler for 413 which you can replicate by passing in too many input UTXOs. Below is a script for testing:

```
const BWC = require('/path/to/bitcore/packages/bitcore-wallet-client').default;
const walletData = '<exported private keyless wallet>';

const wallet = new BWC({ baseUrl: 'http://localhost:3232/bws/api' });

const decrypted = BWC.sjcl.decrypt('password123', walletData);
wallet.fromObj(JSON.parse(decrypted).credentials);
wallet.openWallet({}, (err) => {
  if (err) {
    console.error(err);
    return;
  }
  wallet.getUtxos({}, (err, utxos) => {
    if (err) {
      console.error(err);
      return;
    }
    
    // step into the below call until you get to the doRequest call
    wallet.createTxProposal({
      inputs: [...utxos, ...new Array(10000).fill(utxos[1])], // send some absurd amount of utxos (they can be duplicates)
      outputs: [{ toAddress: 'bcrt1pq80g2j2lxw9h9d3y5y5hws4xr3wyk8u3ngqx8sk09kpe3xtss4xsmhlfn5', amount: 1926137390000 }], // amount (in sats) of the majority of the utxos
      dryRun: true,
      feePerKb: 1000 * 4,
    },(err, txp) => {
      if (err) {
        console.error(err);
        return;
      }
      console.log(txp.id);
    });
  });
});

```