### PR TITLE
Fixed Script.fromASM support PUSHDATA

### DIFF
--- a/packages/bitcore-lib/lib/script/script.js
+++ b/packages/bitcore-lib/lib/script/script.js
@@ -963,6 +963,7 @@ Script.buildWitnessV1Out = function(to, scriptTree) {
       to = Address.fromString(to);
     }
   }
+  
 
   function buildTree(tree) {
     if (Array.isArray(tree)) {
@@ -991,11 +992,11 @@ Script.buildWitnessV1Out = function(to, scriptTree) {
   }
 
   let taggedHash = null;
-  if (scriptTree) {
+  if (scriptTree) { 
     const [_, h] = buildTree(scriptTree);
     taggedHash = h;
   }
-
+  
   let tweakedPubKey;
   if (to instanceof PublicKey) {
     tweakedPubKey = to.createTapTweak(taggedHash).tweakedPubKey;

--- a/packages/bitcore-lib/lib/script/script.js
+++ b/packages/bitcore-lib/lib/script/script.js
@@ -167,8 +167,6 @@ Script.fromASM = function(str) {
         opcodenum=Opcode.OP_PUSHDATA2
       }else if(buf.length <= 0x100000000){
         opcodenum=Opcode.OP_PUSHDATA4
-      }else{
-        throw new Error('Pushdata data is too long');
       }
       script.chunks.push({
         buf: buf,

--- a/packages/bitcore-lib/test/script/script.js
+++ b/packages/bitcore-lib/test/script/script.js
@@ -203,24 +203,27 @@ describe('Script', function() {
       script.chunks[3].opcodenum.should.equal(Opcode.OP_EQUALVERIFY);
       script.chunks[4].opcodenum.should.equal(Opcode.OP_CHECKSIG);
     });
-  });
 
-  describe('#fromASM PUSHDATA', function() {
-    it('should parse this known script in ASM', function() {
+    it('should parse OP_PUSHDATA in ASM', function() {
       const data0 = '01'.repeat(0x4b)
-      const data1 = '01'.repeat(0x100)
-      const data2 = '01'.repeat(0x10000)
-      const data3 = '01'.repeat(0x10000+1)
-      var asm = `${data0} ${data1} ${data2} ${data3}`;
+      const data1 = '01'.repeat(0x4c)
+      const data2 = '01'.repeat(0x100)
+      const data3 = '01'.repeat(0x100+1)
+      const data4 = '01'.repeat(0x10000)
+      const data5 = '01'.repeat(0x10000+1)
+      var asm = `${data0} ${data1} ${data2} ${data3} ${data4} ${data5}`;
       var script = Script.fromASM(asm);
-      console.log("🚀 ~ it ~ script:", script)
       script.chunks[0].opcodenum.should.equal(0x4b);
       script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA1);
-      script.chunks[1].len.should.equal(0x100);
-      script.chunks[2].opcodenum.should.equal(Opcode.OP_PUSHDATA2);
-      script.chunks[2].len.should.equal(0x10000);
-      script.chunks[3].opcodenum.should.equal(Opcode.OP_PUSHDATA4);
-      script.chunks[3].len.should.equal(0x10000+1);
+      script.chunks[1].len.should.equal(0x4c);
+      script.chunks[2].opcodenum.should.equal(Opcode.OP_PUSHDATA1);
+      script.chunks[2].len.should.equal(0x100);
+      script.chunks[3].opcodenum.should.equal(Opcode.OP_PUSHDATA2);
+      script.chunks[3].len.should.equal(0x100+1);
+      script.chunks[4].opcodenum.should.equal(Opcode.OP_PUSHDATA2);
+      script.chunks[4].len.should.equal(0x10000);
+      script.chunks[5].opcodenum.should.equal(Opcode.OP_PUSHDATA4);
+      script.chunks[5].len.should.equal(0x10000+1);
     });
   });
 

--- a/packages/bitcore-lib/test/script/script.js
+++ b/packages/bitcore-lib/test/script/script.js
@@ -205,6 +205,25 @@ describe('Script', function() {
     });
   });
 
+  describe('#fromASM PUSHDATA', function() {
+    it('should parse this known script in ASM', function() {
+      const data0 = '01'.repeat(0x4b)
+      const data1 = '01'.repeat(0x100)
+      const data2 = '01'.repeat(0x10000)
+      const data3 = '01'.repeat(0x10000+1)
+      var asm = `${data0} ${data1} ${data2} ${data3}`;
+      var script = Script.fromASM(asm);
+      console.log("🚀 ~ it ~ script:", script)
+      script.chunks[0].opcodenum.should.equal(0x4b);
+      script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA1);
+      script.chunks[1].len.should.equal(0x100);
+      script.chunks[2].opcodenum.should.equal(Opcode.OP_PUSHDATA2);
+      script.chunks[2].len.should.equal(0x10000);
+      script.chunks[3].opcodenum.should.equal(Opcode.OP_PUSHDATA4);
+      script.chunks[3].len.should.equal(0x10000+1);
+    });
+  });
+
   describe('#fromString', function() {
 
     it('should parse these known scripts', function() {

--- a/packages/bitcore-lib/test/script/script.js
+++ b/packages/bitcore-lib/test/script/script.js
@@ -211,7 +211,8 @@ describe('Script', function() {
       const data3 = '01'.repeat(0x100+1)
       const data4 = '01'.repeat(0x10000)
       const data5 = '01'.repeat(0x10000+1)
-      var asm = `${data0} ${data1} ${data2} ${data3} ${data4} ${data5}`;
+      const data6 = '01'.repeat(1)
+      var asm = `${data0} ${data1} ${data2} ${data3} ${data4} ${data5} ${data6}`;
       var script = Script.fromASM(asm);
       script.chunks[0].opcodenum.should.equal(0x4b);
       script.chunks[1].opcodenum.should.equal(Opcode.OP_PUSHDATA1);
@@ -224,6 +225,8 @@ describe('Script', function() {
       script.chunks[4].len.should.equal(0x10000);
       script.chunks[5].opcodenum.should.equal(Opcode.OP_PUSHDATA4);
       script.chunks[5].len.should.equal(0x10000+1);
+      script.chunks[6].opcodenum.should.equal(1);
+      script.chunks[6].len.should.equal(1);
     });
   });
 


### PR DESCRIPTION
Script.fromASM should support PUSHDATA, otherwise it will lead to incorrect chunks settings, which in turn makes the result of toBuffer incorrect.

The bitcore-lib-cash code was previously fixed. LTC and DOGE are also incorrect, if corrections are needed, submit a patch separately.