### PR TITLE
[BCN] Fix pruning service finally bug

### DIFF
--- a/packages/bitcore-node/src/services/pruning.ts
+++ b/packages/bitcore-node/src/services/pruning.ts
@@ -201,11 +201,11 @@ export class PruningService {
       });
       logger.info(`Removed all pending ${chain}:${network} txs older than ${days} days: ${rmCount}`);
       this.lastRunTimeOld = Date.now();
+      logger.info('========== OLD FINISHED ===========');
     } catch (err: any) {
       logger.error(`Error processing old mempool txs: ${err.stack || err.message || err}`);
     } finally {
       this.runningOld = false;
-      logger.info('========== OLD FINISHED ===========');
     }
   }
 
@@ -263,11 +263,11 @@ export class PruningService {
       }
       logger.info(`Invalidated ${invalidCount} (processed ${realCount}) pending TXOs for ${chain}:${network}`);
       this.lastRunTimeInvalid = Date.now();
+      logger.info('========== INVALID FINISHED ===========');
     } catch (err: any) {
       logger.error(`Error processing invalid txs: ${err.stack || err.message || err}`);
     } finally {
       this.runningInvalid = false;
-      logger.info('========== INVALID FINISHED ===========');
     }
   }
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -7399,7 +7399,7 @@ export class WalletService implements IWalletService {
                 );
 
                 data.body = {
-                  allowance: spenderData?.value ?? "0"
+                  allowance: spenderData?.value ?? '0'
                 };
               }
             }


### PR DESCRIPTION
The pruning service has a bug where the interval will evaluate if `this.runningOld` or `this.runningInvalid` are true and if so then return. The problem is the evaluation was inside the try block, so returning would hit the finally block and set `this.runningOld` or `this.runningInvalid` to false again.


This PR:
* Moves the running consideration outside the try blocks
* Adds consideration for txs marked "expired" by the "--OLD" handler
* Adds start and finish logs