### PR TITLE
fix: ecdsa sign would return r as a BN.js instance

### DIFF
--- a/packages/bitcore-lib/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib/lib/crypto/ecdsa.js
@@ -211,7 +211,7 @@ ECDSA.prototype._findSignature = function(d, e) {
     badrs++;
     k = this.k;
     Q = G.mul(k);
-    r = Q.x.umod(N);
+    r = Q.getX().umod(N);
     s = k.invm(N).mul(e.add(d.mul(r))).umod(N);
   } while (r.cmp(BN.Zero) <= 0 || s.cmp(BN.Zero) <= 0);
 


### PR DESCRIPTION
### Description

The `Q.x` would return a BN without bitcore-lib's methods, this is avoided by calling `getX` instead which converts to the appropriate instance.