### PR TITLE
[Libs] Fix PrivateKey instantiation with trimmed hex

### DIFF
--- a/packages/bitcore-lib-cash/lib/privatekey.js
+++ b/packages/bitcore-lib-cash/lib/privatekey.js
@@ -103,7 +103,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
-      info.bn = new BN(Buffer.from(data, 'hex'));
+      info.bn = new BN(data, 'hex');
     } else {
       info = PrivateKey._transformWIF(data, network);
     }

--- a/packages/bitcore-lib-cash/test/privatekey.js
+++ b/packages/bitcore-lib-cash/test/privatekey.js
@@ -424,7 +424,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -432,7 +432,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 

--- a/packages/bitcore-lib-cash/test/privatekey.js
+++ b/packages/bitcore-lib-cash/test/privatekey.js
@@ -25,18 +25,26 @@ describe('PrivateKey', function() {
   var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
 
   it('should create a new random private key', function() {
-    var a = new PrivateKey();
+    const a = new PrivateKey();
     should.exist(a);
     should.exist(a.bn);
-    var b = PrivateKey();
+    const b = PrivateKey();
     should.exist(b);
     should.exist(b.bn);
+    a.bn.toString().should.not.equal(b.bn.toString());
   });
 
   it('should create a privatekey from hexa string', function() {
-    var a = new PrivateKey(hex2);
+    const a = new PrivateKey(hex2);
     should.exist(a);
     should.exist(a.bn);
+    a.toString().should.equal(hex2);
+  });
+
+  it('should create a privatekey from a non-standard hex string', function() {
+    const hex = '9aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'; // length 63...no leading 0
+    const a = new PrivateKey(hex);
+    a.toString().should.equal('09aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'); // has leading 0
   });
 
   it('should create a new random testnet private key with only one argument', function() {

--- a/packages/bitcore-lib-cash/test/publickey.js
+++ b/packages/bitcore-lib-cash/test/publickey.js
@@ -49,7 +49,7 @@ describe('PublicKey', function() {
     it('from a private key', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pk = new PublicKey(privkey);
       pk.toString().should.equal(pubhex);
     });

--- a/packages/bitcore-lib-doge/lib/privatekey.js
+++ b/packages/bitcore-lib-doge/lib/privatekey.js
@@ -103,7 +103,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
-      info.bn = new BN(Buffer.from(data, 'hex'));
+      info.bn = new BN(data, 'hex');
     } else {
       info = PrivateKey._transformWIF(data, network);
     }

--- a/packages/bitcore-lib-doge/test/privatekey.js
+++ b/packages/bitcore-lib-doge/test/privatekey.js
@@ -25,18 +25,26 @@ describe('PrivateKey', function() {
   var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
 
   it('should create a new random private key', function() {
-    var a = new PrivateKey();
+    const a = new PrivateKey();
     should.exist(a);
     should.exist(a.bn);
-    var b = PrivateKey();
+    const b = PrivateKey();
     should.exist(b);
     should.exist(b.bn);
+    a.bn.toString().should.not.equal(b.bn.toString());
   });
 
   it('should create a privatekey from hexa string', function() {
-    var a = new PrivateKey(hex2);
+    const a = new PrivateKey(hex2);
     should.exist(a);
     should.exist(a.bn);
+    a.toString().should.equal(hex2);
+  });
+
+  it('should create a privatekey from a non-standard hex string', function() {
+    const hex = '9aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'; // length 63...no leading 0
+    const a = new PrivateKey(hex);
+    a.toString().should.equal('09aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'); // has leading 0
   });
 
   it('should create a new random testnet private key with only one argument', function() {

--- a/packages/bitcore-lib-doge/test/privatekey.js
+++ b/packages/bitcore-lib-doge/test/privatekey.js
@@ -407,7 +407,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -415,7 +415,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 

--- a/packages/bitcore-lib-doge/test/privatekey.js
+++ b/packages/bitcore-lib-doge/test/privatekey.js
@@ -17,7 +17,7 @@ var invalidbase58 = require('./data/bitcoind/base58_keys_invalid.json');
 describe('PrivateKey', function() {
   var hex = '96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a';
   var hex2 = '8080808080808080808080808080808080808080808080808080808080808080';
-  var buf = new Buffer(hex, 'hex');
+  var buf = Buffer.from(hex, 'hex');
   var wifTestnet = 'ckrhHfB5k7NzVEqEsksYGvh2xSjZiT71oVGGSysP97bGMCkm3EgK';
   var wifTestnetUncompressed = '95cdHztwpWKgA4dgw8chw9hjR4yjxNFZrPr9otqgPL5mH9PGesJ';
   var wifLivenet = 'QTfg5tZJYhr9Hw1GVYuK74im5VsSN1dB6Xfuz3xYUWEBWWqNZfPx';
@@ -135,7 +135,7 @@ describe('PrivateKey', function() {
     it('should not be able to instantiate private key WIF is too long', function() {
       expect(function() {
         var buf = Base58Check.decode('QPn542uVdzBgCfV6nEViShboFTpDd1at8mQpQugEQHgpuLbsgcZe');
-        var buf2 = Buffer.concat([buf, new Buffer(0x01)]);
+        var buf2 = Buffer.concat([buf, Buffer.from(0x01)]);
         return new PrivateKey(buf2);
       }).to.throw('Length of buffer must be 33 (uncompressed) or 34 (compressed');
     });
@@ -143,7 +143,7 @@ describe('PrivateKey', function() {
     it('should not be able to instantiate private key WIF because of unknown network byte', function() {
       expect(function() {
         var buf = Base58Check.decode('QPn542uVdzBgCfV6nEViShboFTpDd1at8mQpQugEQHgpuLbsgcZe');
-        var buf2 = Buffer.concat([new Buffer('ff', 'hex'), buf.slice(1, 33)]);
+        var buf2 = Buffer.concat([Buffer.from('ff', 'hex'), buf.subarray(1, 33)]);
         return new PrivateKey(buf2);
       }).to.throw('Invalid network');
     });
@@ -339,9 +339,9 @@ describe('PrivateKey', function() {
     });
 
     it('should return buffer with length equal 32', function() {
-      var bn = BN.fromBuffer(buf.slice(0, 31));
+      var bn = BN.fromBuffer(buf.subarray(0, 31));
       var privkey = new PrivateKey(bn, 'livenet');
-      var expected = Buffer.concat([ new Buffer([0]), buf.slice(0, 31) ]);
+      var expected = Buffer.concat([Buffer.from([0]), buf.subarray(0, 31) ]);
       privkey.toBuffer().toString('hex').should.equal(expected.toString('hex'));
     });
   });
@@ -407,7 +407,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(new Buffer(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -415,7 +415,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(new Buffer(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 

--- a/packages/bitcore-lib-doge/test/privatekey.js
+++ b/packages/bitcore-lib-doge/test/privatekey.js
@@ -135,7 +135,7 @@ describe('PrivateKey', function() {
     it('should not be able to instantiate private key WIF is too long', function() {
       expect(function() {
         var buf = Base58Check.decode('QPn542uVdzBgCfV6nEViShboFTpDd1at8mQpQugEQHgpuLbsgcZe');
-        var buf2 = Buffer.concat([buf, Buffer.from(0x01)]);
+        var buf2 = Buffer.concat([buf, Buffer.from([0x01])]);
         return new PrivateKey(buf2);
       }).to.throw('Length of buffer must be 33 (uncompressed) or 34 (compressed');
     });

--- a/packages/bitcore-lib-doge/test/transaction/transaction.js
+++ b/packages/bitcore-lib-doge/test/transaction/transaction.js
@@ -251,8 +251,8 @@ describe('Transaction', function() {
   var changeAddress = 'DAPkqFzgrXVsUU7WkSf1GYMmFzEGvuK4SK';
   var changeAddressP2SH = 'A7HRQk3GFCW2QasvdZxXuYj8kkQK5QrYLs';
   var privateKey = 'dd7bdefb163b31eb706ec43589c24cd27fc7878216836468bf216845c7c4aa1c';
-  var private1 = 'ba9bb7f48969e94301025313c298916b2913fb7eecefe98b9128ef4d87e40ea40';
-  var private2 = '6403e70451390134f2bddbe5ecb33c5b264af292fcbf2cdd97deaac7e1e8f7ba0';
+  var private1 = '74a605e8593ace50e1a5d20a57ae7bf3a172d6b4d5d9280ee5519946ec1a039b';
+  var private2 = '62314e4414b9deb3ce85e4d512c2fbce52a48804e7412a8dec6201f0f996cc82';
   var public1 = new PrivateKey(private1).publicKey;
   var public2 = new PrivateKey(private2).publicKey;
 

--- a/packages/bitcore-lib-ltc/lib/privatekey.js
+++ b/packages/bitcore-lib-ltc/lib/privatekey.js
@@ -103,7 +103,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
-      info.bn = new BN(Buffer.from(data, 'hex'));
+      info.bn = new BN(data, 'hex');
     } else {
       info = PrivateKey._transformWIF(data, network);
     }

--- a/packages/bitcore-lib-ltc/test/privatekey.js
+++ b/packages/bitcore-lib-ltc/test/privatekey.js
@@ -408,7 +408,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -416,7 +416,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 

--- a/packages/bitcore-lib-ltc/test/privatekey.js
+++ b/packages/bitcore-lib-ltc/test/privatekey.js
@@ -25,18 +25,26 @@ describe('PrivateKey', function() {
   var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
 
   it('should create a new random private key', function() {
-    var a = new PrivateKey();
+    const a = new PrivateKey();
     should.exist(a);
     should.exist(a.bn);
-    var b = PrivateKey();
+    const b = PrivateKey();
     should.exist(b);
     should.exist(b.bn);
+    a.bn.toString().should.not.equal(b.bn.toString());
   });
 
   it('should create a privatekey from hexa string', function() {
-    var a = new PrivateKey(hex2);
+    const a = new PrivateKey(hex2);
     should.exist(a);
     should.exist(a.bn);
+    a.toString().should.equal(hex2);
+  });
+
+  it('should create a privatekey from a non-standard hex string', function() {
+    const hex = '9aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'; // length 63...no leading 0
+    const a = new PrivateKey(hex);
+    a.toString().should.equal('09aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'); // has leading 0
   });
 
   it('should create a new random testnet private key with only one argument', function() {

--- a/packages/bitcore-lib-ltc/test/publickey.js
+++ b/packages/bitcore-lib-ltc/test/publickey.js
@@ -49,7 +49,7 @@ describe('PublicKey', function() {
     it('from a private key', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pk = new PublicKey(privkey);
       pk.toString().should.equal(pubhex);
     });

--- a/packages/bitcore-lib/lib/privatekey.js
+++ b/packages/bitcore-lib/lib/privatekey.js
@@ -104,7 +104,7 @@ PrivateKey.prototype._classifyArguments = function(data, network) {
     info.network = Networks.get(data);
   } else if (typeof(data) === 'string'){
     if (JSUtil.isHexa(data)) {
-      info.bn = new BN(Buffer.from(data, 'hex'));
+      info.bn = new BN(data, 'hex');
     } else {
       info = PrivateKey._transformWIF(data, network);
     }

--- a/packages/bitcore-lib/test/privatekey.js
+++ b/packages/bitcore-lib/test/privatekey.js
@@ -26,18 +26,26 @@ describe('PrivateKey', function() {
   var wifNamecoin = '74pxNKNpByQ2kMow4d9kF6Z77BYeKztQNLq3dSyU4ES1K5KLNiz';
 
   it('should create a new random private key', function() {
-    var a = new PrivateKey();
+    const a = new PrivateKey();
     should.exist(a);
     should.exist(a.bn);
-    var b = PrivateKey();
+    const b = PrivateKey();
     should.exist(b);
     should.exist(b.bn);
+    a.bn.toString().should.not.equal(b.bn.toString());
   });
 
   it('should create a privatekey from hexa string', function() {
-    var a = new PrivateKey(hex2);
+    const a = new PrivateKey(hex2);
     should.exist(a);
     should.exist(a.bn);
+    a.toString().should.equal(hex2);
+  });
+
+  it('should create a privatekey from a non-standard hex string', function() {
+    const hex = '9aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'; // length 63...no leading 0
+    const a = new PrivateKey(hex);
+    a.toString().should.equal('09aea0e90d2dae1b52f6e5fcfd9f7a6a984db2cdcff0704c2d732ac862770ed8'); // has leading 0
   });
 
   it('should create a new random testnet private key with only one argument', function() {

--- a/packages/bitcore-lib/test/privatekey.js
+++ b/packages/bitcore-lib/test/privatekey.js
@@ -461,7 +461,7 @@ describe('PrivateKey', function() {
     it('should convert this known PrivateKey to known PublicKey', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       var pubkey = privkey.toPublicKey();
       pubkey.toString().should.equal(pubhex);
     });
@@ -469,7 +469,7 @@ describe('PrivateKey', function() {
     it('should have a "publicKey" property', function() {
       var privhex = '906977a061af29276e40bf377042ffbde414e496ae2260bbf1fa9d085637bfff';
       var pubhex = '02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc';
-      var privkey = new PrivateKey(new BN(Buffer.from(privhex, 'hex')));
+      var privkey = new PrivateKey(new BN(privhex, 'hex'));
       privkey.publicKey.toString().should.equal(pubhex);
     });
 


### PR DESCRIPTION
This PR:

* Fixes PrivateKey instantiation with hex strings that are missing leading zeros. See newly added test for an example.
* Adds tests
* Cleans up `new Buffer` (deprecated) and `new BN(Buffer.from` (misleading)