### PR TITLE
[BCN] Add network to wallet queries for testnet3 -> testnet4 migration

### DIFF
--- a/packages/bitcore-node/scripts/migrateTestnetWallets.js
+++ b/packages/bitcore-node/scripts/migrateTestnetWallets.js
@@ -5,11 +5,53 @@ const { WalletAddressStorage } = require('../build/src/models/walletAddress');
 const { Storage } = require('../build/src/services/storage');
 const { wait } = require('../build/src/utils');
 
-const chain = 'BTC';
-const oldNetwork = 'testnet3';
-const newNetwork = 'testnet4';
-const dryRun = true; // make sure you stop sync services before running this script
-const batchSize = 10000;
+function usage(errMsg) {
+  console.log('USAGE: ./migrateTestnetWallets.js [options]');
+  console.log('OPTIONS:');
+  console.log('  --chain <value>         REQUIRED - e.g. BTC, BCH, DOGE, LTC...');
+  console.log('  --oldNetwork <value>    REQUIRED - e.g. testnet3');
+  console.log('  --newNetwork <value>    REQUIRED - e.g. testnet4');
+  console.log('  --batchSize <value>     Number of documents to update at a time. Default: 10000');
+  console.log('  --deDup                 Delete duplicate walletAddresses (can happen if users');
+  console.log('  --doit                  Save the migration to the db. Make sure you stop sync services before running this script');
+  if (errMsg) {
+    console.log('\nERROR: ' + errMsg);
+  }
+  process.exit();
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes('--help') || args.includes('-h')) {
+  usage();
+}
+
+const chainIdx = args.indexOf('--chain');
+const oldNetworkIdx = args.indexOf('--oldNetwork');
+const newNetworkIdx = args.indexOf('--newNetwork');
+const chain = args[chainIdx + 1]?.toUpperCase();
+const oldNetwork = args[oldNetworkIdx + 1]?.toLowerCase();
+const newNetwork = args[newNetworkIdx + 1]?.toLowerCase();
+const deDup = !args.includes('--deDup');
+const dryRun = !args.includes('--doit');
+
+if (
+  chainIdx === -1 ||
+  oldNetworkIdx === -1 ||
+  newNetworkIdx === -1 ||
+  !chain ||
+  !oldNetwork ||
+  !newNetwork
+) {
+  usage('Missing required options.');
+}
+
+const batchSizeIdx = args.indexOf('--batchSize');
+const batchSize = (batchSizeIdx > -1 && parseInt(args[batchSizeIdx + 1])) || 10000;
+if (batchSize > -1 && isNaN(parseInt(args[batchSizeIdx + 1]))) {
+  usage('batchSize must be an integer');
+}
+
 
 let quit = false;
 process.on('SIGINT', () => {
@@ -19,6 +61,23 @@ process.on('SIGINT', () => {
   console.log('Caught interrupt signal');
   quit = true;
 });
+
+async function deleteOldAddress(e) {
+  let [_, c, n, w, a] = e.message.split('{')[1].split(':');
+  c = c.trim().replace(/"/g, '').replace(/,/g, '');
+  n = n.trim().replace(/"/g, '').replace(/,/g, '');
+  w = w.trim().replace('ObjectId(', '').replace(')', '').replace(/'/g, '').replace(/,/g, '');
+  a = a.replace('}', '').trim().replace(/"/g, '').replace(/,/g, '');
+  console.log('Deleting dup:', c, n, w, a);
+  const del1 = await WalletAddressStorage.collection.findOne({ chain, network: oldNetwork, wallet: new ObjectID(w), address: a });
+  const del2 = await WalletAddressStorage.collection.findOne({ chain, network: newNetwork, wallet: new ObjectID(w), address: a });
+  console.log(del1);
+  console.log(del2);
+  if (!!del1 && !!del2) {
+    const del = await WalletAddressStorage.collection.deleteOne({ chain, network: oldNetwork, wallet: new ObjectID(w), address: a });
+    console.log(del.deletedCount);
+  }
+};
 
 Storage.start()
   .then(async () => {
@@ -54,8 +113,14 @@ Storage.start()
     let walletAddresses = await WalletAddressStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray();
     let walletAddressesUpdated = 0;
     while (walletAddresses.length > 0 && !quit) {
-      const res = await WalletAddressStorage.collection.updateMany({ _id: { $in: walletAddresses.map(c => c._id) } }, { $set: { network: newNetwork } });
-      walletAddressesUpdated += res.modifiedCount;
+      try {
+        const res = await WalletAddressStorage.collection.updateMany({ _id: { $in: walletAddresses.map(c => c._id) } }, { $set: { network: newNetwork } });
+        walletAddressesUpdated += res.modifiedCount;
+      } catch (e) {
+        if (e.message.includes('E11000') && deDup) {
+          await deleteOldAddress(e);
+        } else { throw e; }
+      }
       process.stdout.write(`Updated ${walletAddressesUpdated} walletAddresses (${(walletAddressesUpdated / cnt2 * 100).toFixed(2)}%)\r`);
       await wait(250);
       walletAddresses = await WalletAddressStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray()

--- a/packages/bitcore-node/scripts/migrateTestnetWallets.js
+++ b/packages/bitcore-node/scripts/migrateTestnetWallets.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const { WalletStorage } = require('../build/src/models/wallet');
+const { WalletAddressStorage } = require('../build/src/models/walletAddress');
+const { Storage } = require('../build/src/services/storage');
+const { wait } = require('../build/src/utils');
+
+const chain = 'BTC';
+const oldNetwork = 'testnet3';
+const newNetwork = 'testnet4';
+const dryRun = true; // make sure you stop sync services before running this script
+const batchSize = 10000;
+
+let quit = false;
+process.on('SIGINT', () => {
+  if (quit) {
+    process.exit(1);
+  }
+  console.log('Caught interrupt signal');
+  quit = true;
+});
+
+Storage.start()
+  .then(async () => {
+    console.log('Connected to the database');
+
+    const cnt1 = await WalletStorage.collection.countDocuments({ chain, network: oldNetwork });
+    const cnt2 = await WalletAddressStorage.collection.countDocuments({ chain, network: oldNetwork });
+
+    console.log(`${chain} ${oldNetwork} wallets:`, cnt1);
+    console.log(`${chain} ${oldNetwork} walletAddresses:`, cnt2);
+
+    if (dryRun) {
+      return;
+    }
+    console.log('----------------------------------------');
+
+    console.log(`Updating ${chain} ${oldNetwork} => ${newNetwork} wallets in 10 seconds...`);
+    !quit && await wait(10000);
+    console.log(`Updating ${chain} ${oldNetwork} wallets...`);
+    let wallets = await WalletStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray();
+    let walletsUpdated = 0;
+    while (wallets.length > 0 && !quit) {
+      const res = await WalletStorage.collection.updateMany({ _id: { $in: wallets.map(c => c._id) } }, { $set: { network: newNetwork } });
+      walletsUpdated += res.modifiedCount;
+      process.stdout.write(`Updated ${walletsUpdated} wallets (${(walletsUpdated / cnt1 * 100).toFixed(2)}%)\r`);
+      await wait(250);
+      wallets = await WalletStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray()
+    }
+
+    console.log(`Updating ${chain} ${oldNetwork} => ${newNetwork} walletAddresses in 10 seconds...`);
+    !quit && await wait(10000);
+    console.log(`Updating ${chain} ${oldNetwork} walletAddresses...`);
+    let walletAddresses = await WalletAddressStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray();
+    let walletAddressesUpdated = 0;
+    while (walletAddresses.length > 0 && !quit) {
+      const res = await WalletAddressStorage.collection.updateMany({ _id: { $in: walletAddresses.map(c => c._id) } }, { $set: { network: newNetwork } });
+      walletAddressesUpdated += res.modifiedCount;
+      process.stdout.write(`Updated ${walletAddressesUpdated} walletAddresses (${(walletAddressesUpdated / cnt2 * 100).toFixed(2)}%)\r`);
+      await wait(250);
+      walletAddresses = await WalletAddressStorage.collection.find({ chain, network: oldNetwork }).project({ _id: 1 }).limit(batchSize).toArray()
+    }
+  })
+  .catch(console.error)
+  .finally(() => {
+    console.log('Closing the database connection');
+    Storage.stop();
+  });

--- a/packages/bitcore-node/scripts/migrateTestnetWallets.js
+++ b/packages/bitcore-node/scripts/migrateTestnetWallets.js
@@ -12,7 +12,7 @@ function usage(errMsg) {
   console.log('  --oldNetwork <value>    REQUIRED - e.g. testnet3');
   console.log('  --newNetwork <value>    REQUIRED - e.g. testnet4');
   console.log('  --batchSize <value>     Number of documents to update at a time. Default: 10000');
-  console.log('  --deDup                 Delete duplicate walletAddresses (can happen if users');
+  console.log('  --deDup                 Delete duplicate walletAddresses (dups can happen if an updated wallet is queried before addresses are updated)');
   console.log('  --doit                  Save the migration to the db. Make sure you stop sync services before running this script');
   if (errMsg) {
     console.log('\nERROR: ' + errMsg);
@@ -32,7 +32,7 @@ const newNetworkIdx = args.indexOf('--newNetwork');
 const chain = args[chainIdx + 1]?.toUpperCase();
 const oldNetwork = args[oldNetworkIdx + 1]?.toLowerCase();
 const newNetwork = args[newNetworkIdx + 1]?.toLowerCase();
-const deDup = !args.includes('--deDup');
+const deDup = args.includes('--deDup');
 const dryRun = !args.includes('--doit');
 
 if (

--- a/packages/bitcore-node/scripts/migrateToNamedTestnets.js
+++ b/packages/bitcore-node/scripts/migrateToNamedTestnets.js
@@ -6,7 +6,7 @@ const { TransactionStorage } = require('../build/src/models/transaction');
 const { WalletStorage } = require('../build/src/models/wallet');
 const { WalletAddressStorage } = require('../build/src/models/walletAddress');
 const { Storage } = require('../build/src/services/storage');
-const { wait } = require('../build/src/utils/wait');
+const { wait } = require('../build/src/utils');
 
 const chain = 'LTC';
 const oldNetwork = 'testnet';

--- a/packages/bitcore-node/scripts/purgeNetworkData.js
+++ b/packages/bitcore-node/scripts/purgeNetworkData.js
@@ -14,7 +14,7 @@ function usage(errMsg) {
   console.log('  --network <value>    REQUIRED - e.g. mainnet, testnet3, regtest...');
   console.log('  --limit <value>      Number of documents to delete at a time. Default: 250');
   console.log('  --sleep <value>      Sleep time in milliseconds between deletions. Default: 50');
-  console.log('  --every <value>      Sleep for --sleep milliseconds every --every loop iteration. Default: 1');
+  console.log('  --every <value>      Sleep for --sleep milliseconds every --every loop iteration. Default: 10');
   if (errMsg) {
     console.log('\nERROR: ' + errMsg);
   }
@@ -42,7 +42,7 @@ const limit = (limitIdx > -1 && parseInt(args[limitIdx + 1])) || 250;
 const sleepIdx = args.indexOf('--sleep');
 const sleepMs = (sleepIdx > -1 && parseInt(args[sleepIdx + 1])) || 50;
 const everyIdx = args.indexOf('--every');
-const nSleep = (everyIdx > -1 && parseInt(args[everyIdx + 1])) || 1;
+const nSleep = (everyIdx > -1 && parseInt(args[everyIdx + 1])) || 10;
 
 console.log('Connecting to database...');
 

--- a/packages/bitcore-node/scripts/purgeNetworkData.js
+++ b/packages/bitcore-node/scripts/purgeNetworkData.js
@@ -80,7 +80,7 @@ Storage.start()
       progressCnt = 0;
       let blkIds = await BlockStorage.collection.find({ chain, network }).project({ _id: 1 }).limit(limit).toArray();
       while (blkIds.length && !quit) {
-        process.stdout.write(`Blocks: ${(progressCnt / blkCount).toFixed(2)}% (${progressCnt} / ${blkCount})\r`);
+        process.stdout.write(`Blocks: ${(progressCnt / blkCount * 100).toFixed(2)}% (${progressCnt} / ${blkCount})\r`);
         const res = await BlockStorage.collection.deleteMany({ _id: { $in: blkIds.map(a => a._id) } });
         progressCnt += blkIds.length;
         if (progressCnt % nSleep === 0) {
@@ -95,7 +95,7 @@ Storage.start()
       progressCnt = 0;
       let txIds = await TransactionStorage.collection.find({ chain, network }).project({ _id: 1 }).limit(limit).toArray();
       while (txIds.length && !quit) {
-        process.stdout.write(`Transactions: ${(progressCnt / txCount).toFixed(2)}% (${progressCnt} / ${txCount})\r`);
+        process.stdout.write(`Transactions: ${(progressCnt / txCount * 100).toFixed(2)}% (${progressCnt} / ${txCount})\r`);
         const res = await TransactionStorage.collection.deleteMany({ _id: { $in: txIds.map(a => a._id) } });
         progressCnt += txIds.length;
         if (progressCnt % nSleep === 0) {
@@ -110,7 +110,7 @@ Storage.start()
       progressCnt = 0;
       let coinIds = await CoinStorage.collection.find({ chain, network }).project({ _id: 1 }).limit(limit).toArray();
       while (coinIds.length && !quit) {
-        process.stdout.write(`Coins: ${(progressCnt / coinCount).toFixed(2)}% (${progressCnt} / ${coinCount})\r`);
+        process.stdout.write(`Coins: ${(progressCnt / coinCount * 100).toFixed(2)}% (${progressCnt} / ${coinCount})\r`);
         const res = await CoinStorage.collection.deleteMany({ _id: { $in: coinIds.map(a => a._id) } });
         progressCnt += coinIds.length;
         if (progressCnt % nSleep === 0) {

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -601,7 +601,7 @@ export class InternalStateProvider implements IChainStateService {
   /**
    * Get a series of hashes that come before a given height, or the 30 most recent hashes
    *
-   * @returns Array<string>
+   * @returns {Promise<Array<string>>}
    */
   async getLocatorHashes(params): Promise<Array<string>> {
     const { chain, network, startHeight, endHeight } = params;

--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -383,6 +383,9 @@ export class InternalStateProvider implements IChainStateService {
       wallets: wallet._id,
       'wallets.0': { $exists: true }
     };
+    if (wallet.chain === 'BTC' && ['testnet3', 'testnet4'].includes(wallet.network)) {
+      query['network'] = wallet.network;
+    }
 
     if (args) {
       if (args.startBlock || args.endBlock) {
@@ -430,12 +433,18 @@ export class InternalStateProvider implements IChainStateService {
       spentHeight: { $lt: SpentHeightIndicators.minimum },
       mintHeight: { $gt: SpentHeightIndicators.conflicting }
     };
+    if (params.wallet.chain === 'BTC' && ['testnet3', 'testnet4'].includes(params.wallet.network)) {
+      query['network'] = params.wallet.network;
+    }
     return CoinStorage.getBalance({ query });
   }
 
   async getWalletBalanceAtTime(params: GetWalletBalanceAtTimeParams) {
     const { chain, network, time } = params;
     let query = { wallets: params.wallet._id, 'wallets.0': { $exists: true } };
+    if (params.wallet.chain === 'BTC' && ['testnet3', 'testnet4'].includes(params.wallet.network)) {
+      query['network'] = params.wallet.network;
+    }
     return CoinStorage.getBalanceAtTime({ query, time, chain, network });
   }
 
@@ -446,6 +455,9 @@ export class InternalStateProvider implements IChainStateService {
       'wallets.0': { $exists: true },
       mintHeight: { $gt: SpentHeightIndicators.conflicting }
     };
+    if (wallet.chain === 'BTC' && ['testnet3', 'testnet4'].includes(wallet.network)) {
+      query['network'] = wallet.network;
+    }
     if (args.includeSpent !== 'true') {
       if (args.includePending === 'true') {
         query.spentHeight = { $lte: SpentHeightIndicators.pending };
@@ -591,7 +603,7 @@ export class InternalStateProvider implements IChainStateService {
    *
    * @returns Array<string>
    */
-  async getLocatorHashes(params) {
+  async getLocatorHashes(params): Promise<Array<string>> {
     const { chain, network, startHeight, endHeight } = params;
     const query =
       startHeight && endHeight
@@ -607,7 +619,7 @@ export class InternalStateProvider implements IChainStateService {
             network
           };
     const locatorBlocks = await BitcoinBlockStorage.collection
-      .find(query, { sort: { height: -1 }, limit: 30 })
+      .find(query).sort({ height: -1 }).limit(30)
       .addCursorFlag('noCursorTimeout', true)
       .toArray();
     if (locatorBlocks.length < 2) {

--- a/packages/bitcore-node/src/providers/fee/bitgo.ts
+++ b/packages/bitcore-node/src/providers/fee/bitgo.ts
@@ -7,12 +7,13 @@ import { IFeeProvider } from '../../types/FeeProvider';
 export class BitgoClass implements IFeeProvider {
   private feeUrls = {
     mainnet: 'https://www.bitgo.com/api/v2/btc/tx/fee',
-    testnet: 'https://www.bitgo-test.com/api/v2/tbtc/tx/fee'
+    testnet3: 'https://www.bitgo-test.com/api/v2/tbtc/tx/fee',
+    testnet4: 'https://www.bitgo-test.com/api/v2/tbtc4/tx/fee'
   };
 
   public async getFee(network: NetworkType, nblocks: number): Promise<number> {
     try {
-      network = network === 'regtest' ? 'testnet' : network;
+      network = network === 'regtest' ? 'testnet4' : network;
       nblocks = Math.min(Math.max(nblocks, 2), 1000); // min 2, max 1000
 
       const res = await util.promisify(request.get).call(request, {

--- a/packages/bitcore-node/src/providers/fee/blockcypher.ts
+++ b/packages/bitcore-node/src/providers/fee/blockcypher.ts
@@ -7,18 +7,18 @@ import { FeeCacheType, IFeeProvider } from '../../types/FeeProvider';
 export class BlockCypherClass implements IFeeProvider {
   private feeUrls = {
     mainnet: 'https://api.blockcypher.com/v1/btc/main',
-    testnet: 'https://api.blockcypher.com/v1/btc/test3'
+    testnet3: 'https://api.blockcypher.com/v1/btc/test3'
   };
 
   private cache: {
     mainnet: FeeCacheType;
-    testnet: FeeCacheType
+    testnet3: FeeCacheType;
   } = {
     mainnet: {
       timestamp: 0,
       response: null
     },
-    testnet: {
+    testnet3: {
       timestamp: 0,
       response: null
     }
@@ -26,7 +26,7 @@ export class BlockCypherClass implements IFeeProvider {
 
   public async getFee(network: NetworkType, nblocks: number): Promise<number> {
     try {
-      network = network === 'regtest' ? 'testnet' : network;
+      network = network === 'regtest' ? 'testnet3' : network;
 
       // blockcypher rate limits to 3 req/s or 100 req/hr, so cache for 1.5 minutes
       if (this.cache[network] && this.cache[network].timestamp > Date.now() - 1000 * 90) {

--- a/packages/bitcore-node/src/providers/fee/mempoolspace.ts
+++ b/packages/bitcore-node/src/providers/fee/mempoolspace.ts
@@ -9,18 +9,24 @@ export class MempoolSpaceClass implements IFeeProvider {
   // TODO run our own mempool.space server
   private feeUrls = {
     mainnet: 'https://mempool.space/api/v1/fees/recommended',
-    testnet: 'https://mempool.space/testnet/api/v1/fees/recommended'
+    testnet3: 'https://mempool.space/testnet/api/v1/fees/recommended',
+    testnet4: 'https://mempool.space/testnet4/api/v1/fees/recommended'
   };
 
   private cache: {
     mainnet: FeeCacheType;
-    testnet: FeeCacheType
+    testnet3: FeeCacheType;
+    testnet4: FeeCacheType;
   } = {
     mainnet: {
       timestamp: 0,
       response: null
     },
-    testnet: {
+    testnet3: {
+      timestamp: 0,
+      response: null
+    },
+    testnet4: {
       timestamp: 0,
       response: null
     }
@@ -29,7 +35,7 @@ export class MempoolSpaceClass implements IFeeProvider {
   private cacheTime = 1000 * 90; // 90 seconds
 
   public async getFee(network: NetworkType, nblocks: number): Promise<number> {
-    network = network === 'regtest' ? 'testnet' : network;
+    network = network === 'regtest' ? 'testnet4' : network;
     
     if (this.cache[network] && this.cache[network].timestamp > Date.now() - this.cacheTime) {
       return this._getFeeLevel(this.cache[network].response, nblocks);

--- a/packages/bitcore-node/src/types/ChainNetwork.ts
+++ b/packages/bitcore-node/src/types/ChainNetwork.ts
@@ -1,4 +1,6 @@
-export type NetworkType = 'mainnet' | 'testnet' | 'regtest';
+export type BtcNetworks = 'mainnet' | 'testnet3' | 'testnet4' | 'regtest';
+
+export type NetworkType = 'mainnet' | 'testnet' | 'regtest' | BtcNetworks;
 
 export interface Chain {
   chain: string;

--- a/packages/bitcore-wallet-service/src/lib/common/constants.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/constants.ts
@@ -112,11 +112,11 @@ export const Constants = {
   NETWORK_ALIASES: {
     btc: {
       mainnet: 'livenet',
-      testnet: 'testnet3'
+      testnet: 'testnet4'
     },
     bch: {
       mainnet: 'livenet',
-      testnet: 'testnet3'
+      testnet: 'testnet4'
     },
     ltc: {
       mainnet: 'livenet',

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -2131,7 +2131,7 @@ describe('Wallet service', function() {
       beforeEach(function(done) {
         helpers.createAndJoinWallet(1, 1, {
           coin: 'bch',
-          network: 'testnet3',
+          network: 'testnet4',
         }, function(s, w) {
           server = s;
           wallet = w;


### PR DESCRIPTION
This is meant to be a temp change so that wallets won't grab testnet3 data during the data purge