### PR TITLE
[BWS/BCN] Thorough scanning, cleanup some BWS lodash

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -371,8 +371,8 @@ export class InternalStateProvider implements IChainStateService {
   }
 
   async updateWallet(params: UpdateWalletParams) {
-    const { wallet, addresses } = params;
-    await WalletAddressStorage.updateCoins({ wallet, addresses });
+    const { wallet, addresses, reprocess = false } = params;
+    await WalletAddressStorage.updateCoins({ wallet, addresses, opts: { reprocess } });
   }
 
   async streamWalletTransactions(params: StreamWalletTransactionsParams) {

--- a/packages/bitcore-node/src/routes/api/wallet.ts
+++ b/packages/bitcore-node/src/routes/api/wallet.ts
@@ -4,6 +4,7 @@ import logger from '../../logger';
 import { ChainStateProvider } from '../../providers/chain-state';
 import { StreamWalletAddressesParams } from '../../types/namespaces/ChainStateProvider';
 import { Auth, AuthenticatedRequest } from '../../utils/auth';
+import config from '../../config';
 const router = Router({ mergeParams: true });
 
 function isTooLong(field, maxLength = 255) {
@@ -97,14 +98,26 @@ router.get('/:pubKey/check', Auth.authenticateMiddleware, async (req: Authentica
 router.post('/:pubKey', Auth.authenticateMiddleware, async (req: AuthenticatedRequest, res: Response) => {
   let keepAlive;
   try {
-    let { chain, network } = req.params;
-    let addressLines: { address: string }[] = req.body.filter(line => !!line.address);
+    const { chain, network, pubKey } = req.params;
+    const addressLines: { address: string }[] = req.body.filter(line => !!line.address);
 
-    let addresses = addressLines.map(({ address }) => address);
+    const addresses = addressLines.map(({ address }) => address);
     for (const address of addresses) {
       if (isTooLong(address) || !Validation.validateAddress(chain, network, address)) {
         return res.status(413).send('Invalid address');
       }
+    }
+    let reprocess = false;
+    if (req.headers['x-reprocess']) {
+      const reprocessOk = Auth.verifyRequestSignature({
+        message: ['reprocess', '/addAddresses' + pubKey, JSON.stringify(req.body)].join('|'),
+        pubKey: config.services.socket.bwsKeys[0],
+        signature: req.headers['x-reprocess']
+      });
+      if (!reprocessOk) {
+        return res.status(401).send('Authentication failed');
+      }
+      reprocess = true;
     }
     res.status(200);
     keepAlive = setInterval(() => {
@@ -114,7 +127,8 @@ router.post('/:pubKey', Auth.authenticateMiddleware, async (req: AuthenticatedRe
       chain,
       network,
       wallet: req.wallet!,
-      addresses
+      addresses,
+      reprocess
     });
     clearInterval(keepAlive);
     return res.end();

--- a/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
+++ b/packages/bitcore-node/src/types/namespaces/ChainStateProvider.ts
@@ -84,6 +84,7 @@ export type GetWalletParams = ChainNetwork & PubKey;
 export type UpdateWalletParams = ChainNetwork & {
   wallet: MongoBound<IWallet>;
   addresses: string[];
+  reprocess?: boolean;
 };
 
 export type GetWalletBalanceParams = ChainNetwork & {

--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -2328,22 +2328,24 @@ export class API extends EventEmitter {
     });
   }
 
-  // /**
-  // * Start an address scanning process.
-  // * When finished, the scanning process will send a notification 'ScanFinished' to all copayers.
-  // *
-  // * @param {Object} opts
-  // * @param {Boolean} opts.includeCopayerBranches (defaults to false)
-  // * @param {Callback} cb
-  // */
+  /**
+   * Start an address scanning process.
+   * When finished, the scanning process will send a notification 'ScanFinished' to all copayers.
+   *
+   * @param {Object} opts
+   * @param {Boolean} opts.includeCopayerBranches (defaults to false)
+   * @param {Number} opts.startIdx (optional) address derivation path start index (support agents only)
+   * @param {Callback} cb
+   */
   startScan(opts, cb) {
     $.checkState(
       this.credentials && this.credentials.isComplete(),
       'Failed state: this.credentials at <startScan()>'
     );
 
-    var args = {
-      includeCopayerBranches: opts.includeCopayerBranches
+    const args = {
+      includeCopayerBranches: opts.includeCopayerBranches,
+      startIdx: opts.startIdx
     };
 
     this.request.post('/v1/addresses/scan', args, err => {
@@ -2460,7 +2462,7 @@ export class API extends EventEmitter {
 
     opts = opts || {};
     var args = [];
-    if (_.isNumber(opts.minTs)) {
+    if (opts.minTs != null && !isNaN(opts.minTs)) {
       args.push('minTs=' + opts.minTs);
     }
     var qs = '';

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorer.ts
@@ -48,7 +48,7 @@ const PROVIDERS = {
   }
 };
 
-export function BlockChainExplorer(opts) {
+export function BlockChainExplorer(opts): V8 {
   $.checkArgument(opts, 'Failed state: opts undefined at <BlockChainExplorer()>');
 
   const provider = opts.provider || 'v8';

--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8/client.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8/client.ts
@@ -160,6 +160,9 @@ export class Client {
     logger.debug('addAddresses: %o %o', url, payload);
     const signature = this.sign({ method: 'POST', url, payload });
     const h = { 'x-signature': signature };
+    if (params.reprocess) {
+      h['x-reprocess'] = params.reprocess;
+    }
     return request.post(url, {
       headers: h,
       body: payload,

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -38,7 +38,7 @@ export class BtcChain implements IChain {
     return 0;
   }
 
-  getWalletBalance(server, wallet, opts, cb) {
+  getWalletBalance(server: WalletService, wallet, opts, cb) {
     server.getUtxosForCurrentWallet(
       {
         coin: opts.coin,
@@ -74,7 +74,7 @@ export class BtcChain implements IChain {
   }
 
   // opts.payProUrl => only to use different safety margin or not
-  getWalletSendMaxInfo(server, wallet, opts, cb) {
+  getWalletSendMaxInfo(server: WalletService, wallet, opts, cb) {
     server.getUtxosForCurrentWallet({}, (err, utxos) => {
       if (err) return cb(err);
 
@@ -167,7 +167,7 @@ export class BtcChain implements IChain {
     return null;
   }
 
-  getChangeAddress(server, wallet, opts) {
+  getChangeAddress(server: WalletService, wallet, opts) {
     return new Promise((resolve, reject) => {
       const getChangeAddress = (wallet, cb) => {
         if (wallet.singleAddress) {
@@ -339,7 +339,7 @@ export class BtcChain implements IChain {
     return parseInt(fee.toFixed(0));
   }
 
-  getFee(server, wallet, opts) {
+  getFee(server: WalletService, wallet, opts) {
     return new Promise(resolve => {
       server._getFeePerKb(wallet, opts, (err, feePerKb) => {
         return resolve({ feePerKb });
@@ -514,7 +514,7 @@ export class BtcChain implements IChain {
     return bitcoreError;
   }
 
-  checkTxUTXOs(server, txp, opts, cb) {
+  checkTxUTXOs(server: WalletService, txp, opts, cb) {
     logger.debug('Rechecking UTXOs availability for publishTx');
 
     if (txp.replaceTxByFee) {
@@ -561,7 +561,7 @@ export class BtcChain implements IChain {
     return balance;
   }
 
-  selectTxInputs(server, txp, wallet, opts, cb) {
+  selectTxInputs(server: WalletService, txp, wallet, opts, cb) {
     const MAX_TX_SIZE_IN_KB = Defaults.MAX_TX_SIZE_IN_KB_BTC;
 
     // todo: check inputs are ours and have enough value

--- a/packages/bitcore-wallet-service/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/utils.ts
@@ -22,12 +22,18 @@ export const Utils = {
     return obj && typeof obj === 'object' && !Array.isArray(obj);
   },
 
-  getMissingFields(obj, args) {
+  isNumber(val) {
+    return val != null && !isNaN(val);
+  },
+
+  isNumberish(val) {
+    return Utils.isNumber(val) || typeof val === 'bigint';
+  },
+
+  getMissingFields(obj: object, args?: Array<string>): Array<string> {
     args = args || [];
     if (!Utils.isObject(obj)) return args;
-    const missing = args.filter(arg => {
-      return !obj.hasOwnProperty(arg);
-    });
+    const missing = args.filter(arg => !obj.hasOwnProperty(arg));
     return missing;
   },
 

--- a/packages/bitcore-wallet-service/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/utils.ts
@@ -16,15 +16,20 @@ const Bitcore_ = {
   ltc: require('bitcore-lib-ltc')
 };
 
-export class Utils {
-  static getMissingFields(obj, args) {
-    args = [].concat(args);
-    if (!_.isObject(obj)) return args;
-    const missing = _.filter(args, arg => {
+export const Utils = {
+
+  isObject(obj) {
+    return obj && typeof obj === 'object' && !Array.isArray(obj);
+  },
+
+  getMissingFields(obj, args) {
+    args = args || [];
+    if (!Utils.isObject(obj)) return args;
+    const missing = args.filter(arg => {
       return !obj.hasOwnProperty(arg);
     });
     return missing;
-  }
+  },
 
   /**
    *
@@ -32,13 +37,13 @@ export class Utils {
    * @param number
    * @return {number}
    */
-  static strip(number) {
+  strip(number) {
     return parseFloat(number.toPrecision(12));
-  }
+  },
 
   /* TODO: It would be nice to be compatible with bitcoind signmessage. How
    * the hash is calculated there? */
-  static hashMessage(text, noReverse) {
+  hashMessage(text, noReverse) {
     $.checkArgument(text);
     const buf = Buffer.from(text);
     let ret = crypto.Hash.sha256sha256(buf);
@@ -46,28 +51,28 @@ export class Utils {
       ret = new bitcore.encoding.BufferReader(ret).readReverse();
     }
     return ret;
-  }
+  },
 
-  static verifyMessage(message, signature, publicKey) {
+  verifyMessage(message, signature, publicKey) {
     $.checkArgument(message);
 
-    const flattenedMessage = _.isArray(message) ? _.join(message) : message;
+    const flattenedMessage = Array.isArray(message) ? message.join('') : message;
     const hash = Utils.hashMessage(flattenedMessage, true);
 
-    const sig = this._tryImportSignature(signature);
+    const sig = Utils._tryImportSignature(signature);
     if (!sig) {
       return false;
     }
 
-    const publicKeyBuffer = this._tryImportPublicKey(publicKey);
+    const publicKeyBuffer = Utils._tryImportPublicKey(publicKey);
     if (!publicKeyBuffer) {
       return false;
     }
 
-    return this._tryVerifyMessage(hash, sig, publicKeyBuffer);
-  }
+    return Utils._tryVerifyMessage(hash, sig, publicKeyBuffer);
+  },
 
-  static _tryImportPublicKey(publicKey) {
+  _tryImportPublicKey(publicKey) {
     let publicKeyBuffer = publicKey;
     try {
       if (!Buffer.isBuffer(publicKey)) {
@@ -78,9 +83,9 @@ export class Utils {
       logger.error('_tryImportPublicKey encountered an error: %o', e);
       return false;
     }
-  }
+  },
 
-  static _tryImportSignature(signature) {
+  _tryImportSignature(signature) {
     try {
       let signatureBuffer = signature;
       if (!Buffer.isBuffer(signature)) {
@@ -92,9 +97,9 @@ export class Utils {
       logger.error('_tryImportSignature encountered an error: %o', e);
       return false;
     }
-  }
+  },
 
-  static _tryVerifyMessage(hash, sig, publicKeyBuffer) {
+  _tryVerifyMessage(hash, sig, publicKeyBuffer) {
     try {
       // uses the native module (c++) for performance vs bitcore lib (javascript)
       return secp256k1.ecdsaVerify(sig, hash, publicKeyBuffer);
@@ -102,9 +107,9 @@ export class Utils {
       logger.error('_tryVerifyMessage encountered an error: %o', e);
       return false;
     }
-  }
+  },
 
-  static formatAmount(satoshis, unit, opts) {
+  formatAmount(satoshis, unit, opts) {
     const UNITS = Object.entries(CWC.Constants.UNITS).reduce((units, [currency, currencyConfig]) => {
       units[currency] = {
         toSatoshis: currencyConfig.toSatoshis,
@@ -137,41 +142,41 @@ export class Utils {
       return Number(satoshis).toLocaleString();
     }
 
-    const u = _.assign(UNITS[unit], opts);
+    const u = Object.assign({}, UNITS[unit], opts);
     var decimals = opts.decimals ? opts.decimals : u;
     var toSatoshis = opts.toSatoshis ? opts.toSatoshis : u.toSatoshis;
 
     const amount = (satoshis / toSatoshis).toFixed(decimals.maxDecimals);
     return addSeparators(amount, opts.thousandsSeparator || ',', opts.decimalSeparator || '.', decimals.minDecimals);
-  }
+  },
 
-  static formatAmountInBtc(amount) {
+  formatAmountInBtc(amount) {
     return (
       Utils.formatAmount(amount, 'btc', {
         minDecimals: 8,
         maxDecimals: 8
       }) + 'btc'
     );
-  }
+  },
 
-  static formatUtxos(utxos) {
-    if (_.isEmpty(utxos)) return 'none';
-    return _.map([].concat(utxos), i => {
+  formatUtxos(utxos) {
+    if (!utxos?.length) return 'none';
+    return utxos.map(i => {
       const amount = Utils.formatAmountInBtc(i.satoshis);
       const confirmations = i.confirmations ? i.confirmations + 'c' : 'u';
       return amount + '/' + confirmations;
     }).join(', ');
-  }
+  },
 
-  static formatRatio(ratio) {
+  formatRatio(ratio) {
     return (ratio * 100).toFixed(4) + '%';
-  }
+  },
 
-  static formatSize(size) {
+  formatSize(size) {
     return (size / 1000).toFixed(4) + 'kB';
-  }
+  },
 
-  static parseVersion(version) {
+  parseVersion(version) {
     const v: {
       agent?: string;
       major?: number;
@@ -186,16 +191,16 @@ export class Utils {
       v.agent = version;
       return v;
     }
-    v.agent = _.includes(['bwc', 'bws'], x[0]) ? 'bwc' : x[0];
+    v.agent = ['bwc', 'bws'].includes(x[0]) ? 'bwc' : x[0];
     x = x[1].split('.');
     v.major = x[0] ? parseInt(x[0]) : null;
     v.minor = x[1] ? parseInt(x[1]) : null;
     v.patch = x[2] ? parseInt(x[2]) : null;
 
     return v;
-  }
+  },
 
-  static parseAppVersion(agent) {
+  parseAppVersion(agent) {
     const v: {
       app?: string;
       major?: number;
@@ -226,9 +231,9 @@ export class Utils {
     v.patch = x[2] ? parseInt(x[2]) : null;
 
     return v;
-  }
+  },
 
-  static getIpFromReq(req): string {
+  getIpFromReq(req): string {
     if (req.headers) {
       if (req.headers['x-forwarded-for']) return req.headers['x-forwarded-for'].split(',')[0];
       if (req.headers['x-real-ip']) return req.headers['x-real-ip'].split(',')[0];
@@ -236,14 +241,14 @@ export class Utils {
     if (req.ip) return req.ip;
     if (req.connection && req.connection.remoteAddress) return req.connection.remoteAddress;
     return '';
-  }
+  },
 
-  static checkValueInCollection(value, collection) {
-    if (!value || !_.isString(value)) return false;
-    return _.includes(_.values(collection), value);
-  }
+  checkValueInCollection(value, collection) {
+    if (typeof value !== 'string') return false;
+    return Object.values(collection).includes(value);
+  },
 
-  static getAddressCoin(address) {
+  getAddressCoin(address) {
     try {
       new Bitcore_['btc'].Address(address);
       return 'btc';
@@ -265,44 +270,44 @@ export class Utils {
         }
       }
     }
-  }
+  },
 
-  static translateAddress(address, coin) {
+  translateAddress(address, coin) {
     const origCoin = Utils.getAddressCoin(address);
     const origAddress = new Bitcore_[origCoin].Address(address);
     const origObj = origAddress.toObject();
 
     const result = Bitcore_[coin].Address.fromObject(origObj);
     return coin == 'bch' ? result.toLegacyAddress() : result.toString();
-  }
+  },
 
-  static compareNetworks(network1, network2, chain) {
-    network1 = network1 ? this.getNetworkName(chain, network1.toLowerCase()) : null;
-    network2 = network2 ? this.getNetworkName(chain, network2.toLowerCase()) : null;
+  compareNetworks(network1, network2, chain) {
+    network1 = network1 ? Utils.getNetworkName(chain, network1.toLowerCase()) : null;
+    network2 = network2 ? Utils.getNetworkName(chain, network2.toLowerCase()) : null;
 
     if (network1 == network2) return true;
-    if (Config.allowRegtest && ['testnet', 'regtest'].includes(this.getNetworkType(network1)) && ['testnet', 'regtest'].includes(this.getNetworkType(network2))) return true;
+    if (Config.allowRegtest && ['testnet', 'regtest'].includes(Utils.getNetworkType(network1)) && ['testnet', 'regtest'].includes(Utils.getNetworkType(network2))) return true;
     return false;
-  }
+  },
 
   // Good for going from generic 'testnet' to specific 'testnet3', 'sepolia', etc
-  static getNetworkName(chain, network) {
+  getNetworkName(chain, network) {
     const aliases = Constants.NETWORK_ALIASES[chain];
     if (aliases && aliases[network]) {
       return aliases[network];
     }
     return network;
-  }
+  },
 
   // Good for going from specific 'testnet3', 'sepolia', etc to generic 'testnet'
-  static getGenericName(network) {
+  getGenericName(network) {
     if (network === 'mainnet') return 'livenet';
     const isTestnet = !!Object.keys(Constants.NETWORK_ALIASES).find(key => Constants.NETWORK_ALIASES[key].testnet === network);
     if (isTestnet) return 'testnet';
     return network;
-  }
+  },
 
-  static getNetworkType(network) {
+  getNetworkType(network) {
     if (['mainnet', 'livenet'].includes(network)) {
       return 'mainnet';
     }
@@ -310,5 +315,23 @@ export class Utils {
        return 'regtest';
     }
     return 'testnet';
+  },
+
+  castToBool(input: any) {
+    input = input?.toString();
+    if (input?.toLowerCase() === 'true' || input == '1') {
+      return true;
+    }
+    return false;
+  },
+
+  sortAsc(arr, ...keys) {
+    if (!keys.length) return arr.sort((a, b) => a - b);
+    if (keys.length === 1) return arr.sort((a, b) => a[keys[0]] - b[keys[0]]);
+    return arr.sort((a, b) => keys.reduce((val, k) => val[k], a) - keys.reduce((val, k) => val[k], b));
+  },
+
+  sortDesc(arr, ...keys) {
+    return Utils.sortAsc(arr, ...keys).reverse();
   }
 }

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -844,8 +844,9 @@ export class ExpressApp {
 
     router.get('/v1/addresses/', (req, res) => {
       getServerWithAuth(req, res, server => {
-        const opts: { limit?: number; reverse?: boolean } = {};
+        const opts: { limit?: number; reverse?: boolean; skip?: number } = {};
         if (req.query.limit) opts.limit = +req.query.limit;
+        if (req.query.skip) opts.skip = +req.query.skip;
         opts.reverse = req.query.reverse == '1';
 
         server.getMainAddresses(opts, (err, addresses) => {
@@ -1200,6 +1201,8 @@ export class ExpressApp {
 
     router.post('/v1/addresses/scan/', (req, res) => {
       getServerWithAuth(req, res, server => {
+        req.body = req.body || {};
+        req.body.startIdx = server.copayerIsSupportStaff ? Number(req.body.startIdx) : null;
         server.startScan(req.body, (err, started) => {
           if (err) return returnError(err, res, req);
           res.json(started);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -561,7 +561,7 @@ export class WalletService implements IWalletService {
       return;
     }
 
-    if (_.isEmpty(opts.name)) {
+    if (!opts.name) {
       return cb(new ClientError('Invalid wallet name'));
     }
 
@@ -792,13 +792,13 @@ export class WalletService implements IWalletService {
             const walletExtendedKeys = ['publicKeyRing', 'pubKey', 'addressManager'];
             const copayerExtendedKeys = ['xPubKey', 'requestPubKey', 'signature', 'addressManager', 'customData'];
 
-            wallet.copayers = _.map(wallet.copayers, copayer => {
+            wallet.copayers = (wallet.copayers || []).map(copayer => {
               if (copayer.id == this.copayerId) return copayer;
               return _.omit(copayer, 'customData');
             });
             if (!opts.includeExtendedInfo) {
               wallet = _.omit(wallet, walletExtendedKeys);
-              wallet.copayers = _.map(wallet.copayers, copayer => {
+              wallet.copayers = (wallet.copayers || []).map(copayer => {
                 return _.omit(copayer, copayerExtendedKeys);
               });
             }
@@ -880,7 +880,7 @@ export class WalletService implements IWalletService {
    * @param pubKeys
    */
   _getSigningKey(text, signature, pubKeys) {
-    return _.find(pubKeys, item => {
+    return pubKeys.find(item => {
       return this._verifySignature(text, signature, item.key);
     });
   }
@@ -894,7 +894,7 @@ export class WalletService implements IWalletService {
    * @param {Boolean} opts.isGlobal - If true, the notification is not issued on behalf of any particular copayer (defaults to false)
    */
   _notify(type, data, opts, cb?: (err?: any, data?: any) => void) {
-    if (_.isFunction(opts)) {
+    if (typeof opts === 'function') {
       cb = opts;
       opts = {};
     }
@@ -924,12 +924,12 @@ export class WalletService implements IWalletService {
   }
 
   _notifyTxProposalAction(type, txp, extraArgs, cb?: (err?: any, data?: any) => void) {
-    if (_.isFunction(extraArgs)) {
+    if (typeof extraArgs === 'function') {
       cb = extraArgs;
       extraArgs = {};
     }
 
-    const data = _.assign(
+    const data = Object.assign(
       {
         txProposalId: txp.id,
         creatorId: txp.creatorId,
@@ -1076,7 +1076,7 @@ export class WalletService implements IWalletService {
   }
 
   _parseClientVersion() {
-    if (_.isUndefined(this.parsedClientVersion)) {
+    if (this.parsedClientVersion == null) {
       this.parsedClientVersion = Utils.parseVersion(this.clientVersion);
     }
     return this.parsedClientVersion;
@@ -1110,7 +1110,7 @@ export class WalletService implements IWalletService {
    */
   joinWallet(opts, cb) {
     if (!checkRequired(opts, ['walletId', 'name', 'requestPubKey', 'copayerSignature'], cb)) return;
-    if (_.isEmpty(opts.name)) return cb(new ClientError('Invalid copayer name'));
+    if (!opts.name) return cb(new ClientError('Invalid copayer name'));
 
     opts.coin = opts.coin || Defaults.COIN;
     if (!opts.chain) {
@@ -1126,7 +1126,7 @@ export class WalletService implements IWalletService {
       } catch (ex) {
         return cb(new ClientError('Invalid extended public key'));
       }
-      if (_.isUndefined(xPubKey.network)) {
+      if (xPubKey.network == null) {
         return cb(new ClientError('Invalid extended public key'));
       }
     }
@@ -1198,11 +1198,7 @@ export class WalletService implements IWalletService {
           return cb(new ClientError());
         }
 
-        if (
-          _.find(wallet.copayers, {
-            xPubKey: opts.xPubKey
-          })
-        )
+        if (wallet.copayers?.find(c => c.xPubKey === opts.xPubKey))
           return cb(Errors.COPAYER_IN_WALLET);
 
         if (wallet.copayers.length == wallet.n) return cb(Errors.WALLET_FULL);
@@ -1240,26 +1236,26 @@ export class WalletService implements IWalletService {
       {
         name: 'language',
         isValid(value) {
-          return _.isString(value) && value.length == 2;
+          return typeof value === 'string' && value.length == 2;
         }
       },
       {
         name: 'unit',
         isValid(value) {
-          return _.isString(value) && _.includes(['btc', 'bit'], value.toLowerCase());
+          return typeof value === 'string' && ['btc', 'bit'].includes(value.toLowerCase());
         }
       },
       {
         name: 'tokenAddresses',
         isValid(value) {
-          return _.isArray(value) && value.every(x => Validation.validateAddress('eth', 'mainnet', x));
+          return Array.isArray(value) && value.every(x => Validation.validateAddress('eth', 'mainnet', x));
         }
       },
       {
         name: 'multisigEthInfo',
         isValid(value) {
           return (
-            _.isArray(value) &&
+            Array.isArray(value) &&
             value.every(x => Validation.validateAddress('eth', 'mainnet', x.multisigContractAddress))
           );
         }
@@ -1267,14 +1263,14 @@ export class WalletService implements IWalletService {
       {
         name: 'maticTokenAddresses',
         isValid(value) {
-          return _.isArray(value) && value.every(x => Validation.validateAddress('matic', 'mainnet', x));
+          return Array.isArray(value) && value.every(x => Validation.validateAddress('matic', 'mainnet', x));
         }
       },
       {
         name: 'multisigMaticInfo',
         isValid(value) {
           return (
-            _.isArray(value) &&
+            Array.isArray(value) &&
             value.every(x => Validation.validateAddress('matic', 'mainnet', x.multisigContractAddress))
           );
         }
@@ -1282,32 +1278,32 @@ export class WalletService implements IWalletService {
       {
         name: 'opTokenAddresses',
         isValid(value) {
-          return _.isArray(value) && value.every(x => Validation.validateAddress('op', 'mainnet', x));
+          return Array.isArray(value) && value.every(x => Validation.validateAddress('op', 'mainnet', x));
         }
       },
       {
         name: 'baseTokenAddresses',
         isValid(value) {
-          return _.isArray(value) && value.every(x => Validation.validateAddress('base', 'mainnet', x));
+          return Array.isArray(value) && value.every(x => Validation.validateAddress('base', 'mainnet', x));
         }
       },
       {
         name: 'arbTokenAddresses',
         isValid(value) {
-          return _.isArray(value) && value.every(x => Validation.validateAddress('arb', 'mainnet', x));
+          return Array.isArray(value) && value.every(x => Validation.validateAddress('arb', 'mainnet', x));
         }
       },
     ];
 
-    opts = _.pick(opts, _.map(preferences, 'name'));
+    opts = _.pick(opts, preferences.map(p => p.name));
     try {
-      _.each(preferences, preference => {
+      for (const preference of preferences) {
         const value = opts[preference.name];
-        if (!value) return;
+        if (!value) continue;
         if (!preference.isValid(value)) {
           throw new Error('Invalid ' + preference.name);
         }
-      });
+      }
     } catch (ex) {
       return cb(new ClientError(ex));
     }
@@ -1441,9 +1437,7 @@ export class WalletService implements IWalletService {
       const latestAddresses = addresses.filter(x => !x.isChange).slice(-Defaults.MAX_MAIN_ADDRESS_GAP) as IAddress[];
       if (
         latestAddresses.length < Defaults.MAX_MAIN_ADDRESS_GAP ||
-        _.some(latestAddresses, {
-          hasActivity: true
-        })
+        latestAddresses.some(a => a.hasActivity)
       )
         return cb(null, true);
 
@@ -1543,8 +1537,8 @@ export class WalletService implements IWalletService {
     const getFirstAddress = (wallet, cb) => {
       this.storage.fetchAddresses(this.walletId, (err, addresses) => {
         if (err) return cb(err);
-        if (!_.isEmpty(addresses)) {
-          let x = _.head(addresses);
+        if (addresses?.length) {
+          const x = addresses[0];
           ChainService.addressFromStorageTransform(wallet.chain, wallet.network, x);
           return cb(null, x);
         }
@@ -1599,17 +1593,15 @@ export class WalletService implements IWalletService {
     opts = opts || {};
     this.storage.fetchAddresses(this.walletId, (err, addresses) => {
       if (err) return cb(err);
-      let onlyMain = _.reject(addresses, {
-        isChange: true
-      });
+      let onlyMain = addresses.filter(a => !a.isChange);
       if (opts.reverse) onlyMain.reverse();
-      if (opts.skip > 0) onlyMain = _.drop(onlyMain, opts.skip);
-      if (opts.limit > 0) onlyMain = _.take(onlyMain, opts.limit);
+      if (opts.skip > 0) onlyMain = onlyMain.slice(opts.skip);
+      if (opts.limit > 0) onlyMain = onlyMain.slice(0, opts.limit);
 
       this.getWallet({}, (err, wallet) => {
-        _.each(onlyMain, x => {
+        for (const x of onlyMain) {
           ChainService.addressFromStorageTransform(wallet.chain, wallet.network, x);
-        });
+        }
         return cb(null, onlyMain);
       });
     });
@@ -1673,11 +1665,15 @@ export class WalletService implements IWalletService {
   getUtxosForCurrentWallet(opts, cb) {
     opts = opts || {};
 
-    const utxoKey = utxo => {
-      return utxo.txid + '|' + utxo.vout;
-    };
+    const utxoKey = utxo => utxo.txid + '|' + utxo.vout;
 
-    let coin, allAddresses, allUtxos, utxoIndex, addressStrs, bc: V8, wallet, blockchainHeight;
+    let allAddresses,
+        allUtxos,
+        utxoIndex,
+        addressStrs: string[],
+        bc: V8,
+        wallet: Wallet,
+        blockchainHeight: number;
     async.series(
       [
         next => {
@@ -1694,16 +1690,16 @@ export class WalletService implements IWalletService {
           });
         },
         next => {
-          if (_.isArray(opts.addresses)) {
+          if (Array.isArray(opts.addresses)) {
             allAddresses = opts.addresses;
             return next();
           }
 
           // even with Grouping we need address for pubkeys and path (see last step)
           this.storage.fetchAddresses(this.walletId, (err, addresses) => {
-            _.each(addresses, x => {
+            for (const x of addresses) {
               ChainService.addressFromStorageTransform(wallet.chain, wallet.network, x);
-            });
+            }
             allAddresses = addresses;
             if (allAddresses.length == 0) return cb(null, []);
 
@@ -1711,7 +1707,7 @@ export class WalletService implements IWalletService {
           });
         },
         next => {
-          addressStrs = _.map(allAddresses, 'address');
+          addressStrs = allAddresses.map(a => a.address);
           return next();
         },
         next => {
@@ -1791,12 +1787,12 @@ export class WalletService implements IWalletService {
           this.getPendingTxs({}, (err, txps) => {
             if (err) return next(err);
 
-            const lockedInputs = _.map(_.flatten(_.map(txps, 'inputs')), utxoKey);
-            _.each(lockedInputs, input => {
+            const lockedInputs = txps.flatMap(t => t.inputs).map(utxoKey);
+            for (const input of lockedInputs) {
               if (utxoIndex[input]) {
                 utxoIndex[input].locked = true;
               }
-            });
+            }
             logger.debug(`Got  ${lockedInputs.length} locked utxos`);
             return next();
           });
@@ -1815,19 +1811,19 @@ export class WalletService implements IWalletService {
             },
             (err, txs) => {
               if (err) return next(err);
-              const spentInputs = _.map(_.flatten(_.map(txs, 'inputs')), utxoKey);
-              const txIdArray = _.map(opts.inputs, 'txid');
+              const spentInputs = txs.flatMap(t => t.inputs).map(utxoKey);
+              const txIdArray = opts.inputs?.map(i => i.txid) || [];
 
-              _.each(spentInputs, input => {
+              for (const input of spentInputs) {
                 if (utxoIndex[input]) {
                   utxoIndex[input].spent = true;
                 }
-              });
+              }
               // except spent inputs of the RBF transaction if it's a replacement
-              allUtxos = _.reject(allUtxos, utxo => {
-                return (
+              allUtxos = allUtxos.filter(utxo => {
+                return !(
                   (!opts.replaceTxByFee && utxo.spent) ||
-                  (utxo.spent && opts.replaceTxByFee && !_.includes(txIdArray, utxo.txid))
+                  (utxo.spent && opts.replaceTxByFee && !txIdArray.includes(utxo.txid))
                 );
               });
               logger.debug(`Got ${allUtxos.length} usable UTXOs`);
@@ -1838,14 +1834,14 @@ export class WalletService implements IWalletService {
         next => {
           // Needed for the clients to sign UTXOs
           const addressToPath = _.keyBy(allAddresses, 'address');
-          _.each(allUtxos, utxo => {
+          for (const utxo of allUtxos) {
             if (!addressToPath[utxo.address]) {
               if (!opts.addresses) this.logw('Ignored UTXO!: ' + utxo.address);
-              return;
+              continue;
             }
             utxo.path = addressToPath[utxo.address].path;
             utxo.publicKeys = addressToPath[utxo.address].publicKeys;
-          });
+          }
           return next();
         }
       ],
@@ -2006,15 +2002,11 @@ export class WalletService implements IWalletService {
 
       const feeLevels = Defaults.FEE_LEVELS[wallet.chain];
       if (opts.feeLevel) {
-        if (
-          !_.some(feeLevels, {
-            name: opts.feeLevel
-          })
-        )
-          return cb(new ClientError('Invalid fee level. Valid values are ' + _.map(feeLevels, 'name').join(', ')));
+        if (!feeLevels.some(lvl => lvl.name === opts.feeLevel))
+          return cb(new ClientError('Invalid fee level. Valid values are ' + feeLevels.map(lvl => lvl.name).join(', ')));
       }
 
-      if (_.isNumber(opts.feePerKb)) {
+      if (Utils.isNumber(opts.feePerKb)) {
         if (opts.feePerKb < Defaults.MIN_FEE_PER_KB || opts.feePerKb > Defaults.MAX_FEE_PER_KB[wallet.chain])
           return cb(new ClientError('Invalid fee per KB'));
       }
@@ -2034,8 +2026,8 @@ export class WalletService implements IWalletService {
 
       const failed = [];
       const levels = _.fromPairs(
-        _.map(points, p => {
-          const feePerKb = _.isObject(result) && result[p] && _.isNumber(result[p]) ? +result[p] : -1;
+        points.map(p => {
+          const feePerKb = Utils.isObject(result) && result[p] && Utils.isNumber(result[p]) ? +result[p] : -1;
           if (feePerKb < 0) failed.push(p);
 
           // NOTE: ONLY BTC/BCH/DOGE/LTC expect feePerKb to be Bitcoin amounts
@@ -2126,10 +2118,10 @@ export class WalletService implements IWalletService {
       */
 
       const samplePoints = () => {
-        const definedPoints = _.uniq(_.map(feeLevels, 'nbBlocks'));
+        const definedPoints = _.uniq(feeLevels.map(lvl => lvl.nbBlocks));
         return _.uniq(
           _.flatten(
-            _.map(definedPoints, p => {
+            definedPoints.map((p: number) => {
               return _.range(p, p + Defaults.FEE_LEVELS_FALLBACK + 1);
             })
           )
@@ -2165,7 +2157,7 @@ export class WalletService implements IWalletService {
           }
         }
 
-        const values = _.map(feeLevels, level => {
+        const values = feeLevels.map(level => {
           const result: {
             feePerKb?: number;
             nbBlocks?: number;
@@ -2268,7 +2260,7 @@ export class WalletService implements IWalletService {
       [
         next => {
           const feeArgs =
-            boolToNum(!!opts.feeLevel) + boolToNum(_.isNumber(opts.feePerKb)) + boolToNum(_.isNumber(opts.fee));
+            boolToNum(!!opts.feeLevel) + boolToNum(Utils.isNumber(opts.feePerKb)) + boolToNum(Utils.isNumber(opts.fee));
           if (feeArgs > 1) return next(new ClientError('Only one of feeLevel/feePerKb/fee can be specified'));
 
           if (feeArgs == 0) {
@@ -2277,13 +2269,9 @@ export class WalletService implements IWalletService {
 
           const feeLevels = Defaults.FEE_LEVELS[wallet.chain];
           if (opts.feeLevel) {
-            if (
-              !_.some(feeLevels, {
-                name: opts.feeLevel
-              })
-            )
+            if (!feeLevels.some(lvl => lvl.name === opts.feeLevel))
               return next(
-                new ClientError('Invalid fee level. Valid values are ' + _.map(feeLevels, 'name').join(', '))
+                new ClientError('Invalid fee level. Valid values are ' + feeLevels.map(lvl => lvl.name).join(', '))
               );
           }
 
@@ -2301,12 +2289,12 @@ export class WalletService implements IWalletService {
 
         next => {
           if (!opts.sendMax) return next();
-          if (!_.isArray(opts.outputs) || opts.outputs.length > 1) {
+          if (!Array.isArray(opts.outputs) || opts.outputs.length > 1) {
             return next(new ClientError('Only one output allowed when sendMax is specified'));
           }
-          if (_.isNumber(opts.outputs[0].amount))
+          if (Utils.isNumber(opts.outputs[0].amount))
             return next(new ClientError('Amount is not allowed when sendMax is specified'));
-          if (_.isNumber(opts.fee))
+          if (Utils.isNumber(opts.fee))
             return next(
               new ClientError('Fee is not allowed when sendMax is specified (use feeLevel/feePerKb instead)')
             );
@@ -2338,7 +2326,7 @@ export class WalletService implements IWalletService {
           if (!opts.noCashAddr) return next();
 
           // TODO remove one cashaddr is used internally (noCashAddr flag)?
-          opts.origAddrOutputs = _.map(opts.outputs, x => {
+          opts.origAddrOutputs = opts.outputs.map(x => {
             const ret: {
               toAddress?: string;
               amount?: number;
@@ -2354,8 +2342,8 @@ export class WalletService implements IWalletService {
             return ret;
           });
           opts.returnOrigAddrOutputs = false;
-          _.each(opts.outputs, x => {
-            if (!x.toAddress) return;
+          for (const x of opts.outputs) {
+            if (!x.toAddress) continue;
 
             let newAddr;
             try {
@@ -2367,7 +2355,7 @@ export class WalletService implements IWalletService {
               x.toAddress = newAddr;
               opts.returnOrigAddrOutputs = true;
             }
-          });
+          }
           next();
         }
       ],
@@ -2376,7 +2364,7 @@ export class WalletService implements IWalletService {
   }
 
   _getFeePerKb(wallet, opts, cb) {
-    if (_.isNumber(opts.feePerKb)) return cb(null, opts.feePerKb);
+    if (Utils.isNumber(opts.feePerKb)) return cb(null, opts.feePerKb);
     this.getFeeLevels(
       {
         chain: wallet.chain,
@@ -3064,9 +3052,7 @@ export class WalletService implements IWalletService {
             );
           }
 
-          const action = _.find(txp.actions, {
-            copayerId: this.copayerId
-          });
+          const action = txp.actions.find(a => a.copayerId === this.copayerId);
           if (action) return cb(Errors.COPAYER_VOTED);
           if (!txp.isPending()) return cb(Errors.TX_NOT_PENDING);
 
@@ -3252,9 +3238,7 @@ export class WalletService implements IWalletService {
       (err, txp) => {
         if (err) return cb(err);
 
-        const action = _.find(txp.actions, {
-          copayerId: this.copayerId
-        });
+        const action = txp.actions.find(a => a.copayerId === this.copayerId);
 
         if (action) return cb(Errors.COPAYER_VOTED);
         if (txp.status != 'pending') return cb(Errors.TX_NOT_PENDING);
@@ -3278,12 +3262,7 @@ export class WalletService implements IWalletService {
               },
               next => {
                 if (txp.status == 'rejected') {
-                  const rejectedBy = _.map(
-                    _.filter(txp.actions, {
-                      type: 'reject'
-                    }),
-                    'copayerId'
-                  );
+                  const rejectedBy = txp.actions.filter(a => a.type === 'reject').map(a => a.copayerId);
 
                   this._notifyTxProposalAction(
                     'TxProposalFinallyRejected',
@@ -3331,9 +3310,9 @@ export class WalletService implements IWalletService {
         if (opts.tokenAddress) {
           txps = txps.filter(txp => opts.tokenAddress?.toLowerCase() === txp.tokenAddress?.toLowerCase());
         }
-        _.each(txps, txp => {
+        for (const txp of txps) {
           txp.deleteLockTime = this.getRemainingDeleteLockTime(txp);
-        });
+        };
         async.each(
           txps,
           (txp: ITxProposal, next) => {
@@ -3355,16 +3334,16 @@ export class WalletService implements IWalletService {
 
             if (txps[0] && txps[0].chain == 'bch') {
               const format = opts.noCashAddr ? 'copay' : 'cashaddr';
-              _.each(txps, x => {
-                if (x.changeAddress) {
-                  x.changeAddress.address = BCHAddressTranslator.translate(x.changeAddress.address, format);
+              for (const t of txps) {
+                if (t.changeAddress) {
+                  t.changeAddress.address = BCHAddressTranslator.translate(t.changeAddress.address, format);
                 }
-                _.each(x.outputs, x => {
-                  if (x.toAddress) {
-                    x.toAddress = BCHAddressTranslator.translate(x.toAddress, format);
+                for (const o of t.outputs) {
+                  if (o.toAddress) {
+                    o.toAddress = BCHAddressTranslator.translate(o.toAddress, format);
                   }
-                });
-              });
+                }
+              }
             }
             return cb(err, txps);
           }
@@ -3420,13 +3399,10 @@ export class WalletService implements IWalletService {
         (err, res) => {
           if (err) return cb(err);
 
-          const notifications = _.sortBy(
-            _.map(_.flatten(res), (n: INotification) => {
-              n.walletId = this.walletId;
-              return n;
-            }),
-            'id'
-          );
+          const notifications = res.flatMap((n: INotification) => {
+            n.walletId = this.walletId;
+            return n;
+          }).sort((a, b) => a.id - b.id);
 
           return cb(null, notifications);
         }
@@ -3435,20 +3411,20 @@ export class WalletService implements IWalletService {
   }
 
   _normalizeTxHistory(walletId, txs: any[], dustThreshold, bcHeight, cb) {
-    if (_.isEmpty(txs)) return cb(null, txs);
+    if (!txs?.length) return cb(null, txs);
 
     // console.log('[server.js.2915:txs:] IN NORMALIZE',txs); //TODO
     const now = Math.floor(Date.now() / 1000);
 
     // One fee per TXID
-    const indexedFee: any = _.keyBy(_.filter(txs, { category: 'fee' } as any), 'txid');
-    const indexedSend = _.keyBy(_.filter(txs, { category: 'send' } as any), 'txid');
+    const indexedFee: any = _.keyBy(txs.filter(tx => tx.category === 'fee'), 'txid');
+    const indexedSend = _.keyBy(txs.filter(tx => tx.category === 'send'), 'txid');
     const seenSend = {};
     const seenReceive = {};
 
     const moves: { [txid: string]: ITxProposal } = {};
     // remove 'fees' and 'moves' (probably change addresses)
-    txs = _.filter(txs, tx => {
+    txs = txs.filter(tx => {
       // double spend or error
       // This should be shown on the client, so we dont remove it here
       //    if (tx.height && tx.height <= -3)
@@ -3506,27 +3482,25 @@ export class WalletService implements IWalletService {
     // Filter out moves:
     // This are moves from the wallet to itself. There are 2+ outputs. one if the change
     // the other a main address for the wallet.
-    _.each(moves, (v, k) => {
-      if (v.outputs.length <= 1) {
-        delete moves[k];
+    for (const txid in moves) {
+      if (moves[txid].outputs.length <= 1) {
+        delete moves[txid];
       }
-    });
+    }
 
     const fixMoves = cb2 => {
-      if (_.isEmpty(moves)) return cb2();
+      if (!Object.keys(moves).length) return cb2();
 
       // each detected duplicate output move
-      const moves3 = _.flatten(_.map(_.values(moves), 'outputs'));
+      const moves3 = Object.values(moves).flatMap(m => m.outputs);
       // check output address for change address
-      this.storage.fetchAddressesByWalletId(walletId, _.map(moves3, 'address'), (err, addrs) => {
+      this.storage.fetchAddressesByWalletId(walletId, moves3.map(m => m.address), (err, addrs) => {
         if (err) return cb(err);
 
-        const isChangeAddress = _.countBy(_.filter(addrs, { isChange: true }), 'address');
-        _.each(moves, x => {
-          _.remove(x.outputs, i => {
-            return isChangeAddress[i.address];
-          });
-        });
+        const isChangeAddress = _.countBy(addrs.filter(a => a.isChange === true), 'address');
+        for (const x of Object.values(moves)) {
+          x.outputs = x.outputs.filter(o => !isChangeAddress[o.address]);
+        }
         return cb2();
       });
     };
@@ -3534,86 +3508,81 @@ export class WalletService implements IWalletService {
     fixMoves(err => {
       if (err) return cb(err);
 
-      const ret = _.filter(
-        _.map([].concat(txs), tx => {
-          const t = new Date(tx.blockTime).getTime() / 1000;
-          const c = tx.height >= 0 && bcHeight >= tx.height ? bcHeight - tx.height + 1 : 0;
+      const ret = (txs || []).map(tx => {
+        const t = new Date(tx.blockTime).getTime() / 1000;
+        const c = tx.height >= 0 && bcHeight >= tx.height ? bcHeight - tx.height + 1 : 0;
 
-          // This adapter rebuilds the abiType property from data contained in the effects so that it returns what wallet is used to
-          // If we remove the slight reliance in the wallet on abiType then we can remove this adapter
-          function recreateAbiType(effects) {
-            // Check if any top level effects are ERC20 transfers
-            if (effects && effects.length) {
-              const erc20Transfer = effects.find(e => e.type == 'ERC20:transfer' && e.callStack == '');
-              if (erc20Transfer) {
-                // This is the only data used in old wallet and bitpay-app
-                return { name: 'transfer' };
-              }
+        // This adapter rebuilds the abiType property from data contained in the effects so that it returns what wallet is used to
+        // If we remove the slight reliance in the wallet on abiType then we can remove this adapter
+        function recreateAbiType(effects) {
+          // Check if any top level effects are ERC20 transfers
+          if (effects && effects.length) {
+            const erc20Transfer = effects.find(e => e.type == 'ERC20:transfer' && e.callStack == '');
+            if (erc20Transfer) {
+              // This is the only data used in old wallet and bitpay-app
+              return { name: 'transfer' };
             }
-            return undefined;
           }
-
-          const ret = {
-            id: tx.id,
-            txid: tx.txid,
-            confirmations: c,
-            blockheight: tx.height > 0 ? tx.height : null,
-            fees: tx.fee ?? (indexedFee[tx.txid] ? Math.abs(indexedFee[tx.txid].satoshis) : null),
-            time: t,
-            size: tx.size,
-            amount: 0,
-            action: undefined,
-            addressTo: undefined,
-            outputs: undefined,
-            dust: false,
-            error: tx.error,
-            internal: tx.internal,
-            network: tx.network,
-            chain: tx.chain,
-            data: tx.data,
-            abiType: tx.abiType || recreateAbiType(tx.effects),
-            gasPrice: tx.gasPrice,
-            maxGasFee: tx.maxGasFee,
-            priorityGasFee: tx.priorityGasFee,
-            txType: tx.txType,
-            gasLimit: tx.gasLimit,
-            receipt: tx.receipt,
-            nonce: tx.nonce,
-            effects: tx.effects
-          };
-          switch (tx.category) {
-            case 'send':
-              ret.action = 'sent';
-              ret.amount = Math.abs(_.sumBy(tx.outputs, 'amount')) || Math.abs(tx.satoshis);
-              ret.addressTo = tx.outputs ? tx.outputs[0].address : null;
-              ret.outputs = tx.outputs;
-              break;
-            case 'receive':
-              ret.action = 'received';
-              ret.outputs = tx.outputs;
-              ret.amount = Math.abs(_.sumBy(tx.outputs, 'amount')) || Math.abs(tx.satoshis);
-              ret.dust = ret.amount < dustThreshold;
-              break;
-            case 'move':
-              ret.action = 'moved';
-              ret.amount = Math.abs(tx.satoshis);
-              ret.addressTo = tx.outputs && tx.outputs.length ? tx.outputs[0].address : null;
-              ret.outputs = tx.outputs;
-              break;
-            default:
-              ret.action = 'invalid';
-          }
-
-          // not available
-          // inputs: inputs,
-          return ret;
-
-          // filter out dust
-        }),
-        x => {
-          return !x.dust;
+          return undefined;
         }
-      );
+
+        const ret = {
+          id: tx.id,
+          txid: tx.txid,
+          confirmations: c,
+          blockheight: tx.height > 0 ? tx.height : null,
+          fees: tx.fee ?? (indexedFee[tx.txid] ? Math.abs(indexedFee[tx.txid].satoshis) : null),
+          time: t,
+          size: tx.size,
+          amount: 0,
+          action: undefined,
+          addressTo: undefined,
+          outputs: undefined,
+          dust: false,
+          error: tx.error,
+          internal: tx.internal,
+          network: tx.network,
+          chain: tx.chain,
+          data: tx.data,
+          abiType: tx.abiType || recreateAbiType(tx.effects),
+          gasPrice: tx.gasPrice,
+          maxGasFee: tx.maxGasFee,
+          priorityGasFee: tx.priorityGasFee,
+          txType: tx.txType,
+          gasLimit: tx.gasLimit,
+          receipt: tx.receipt,
+          nonce: tx.nonce,
+          effects: tx.effects
+        };
+        switch (tx.category) {
+          case 'send':
+            ret.action = 'sent';
+            ret.amount = Math.abs(tx.outputs.reduce((sum, o) => sum += o.amount, 0)) || Math.abs(tx.satoshis);
+            ret.addressTo = tx.outputs ? tx.outputs[0].address : null;
+            ret.outputs = tx.outputs;
+            break;
+          case 'receive':
+            ret.action = 'received';
+            ret.outputs = tx.outputs;
+            ret.amount = Math.abs(tx.outputs.reduce((sum, o) => sum += o.amount, 0)) || Math.abs(tx.satoshis);
+            ret.dust = ret.amount < dustThreshold;
+            break;
+          case 'move':
+            ret.action = 'moved';
+            ret.amount = Math.abs(tx.satoshis);
+            ret.addressTo = tx.outputs && tx.outputs.length ? tx.outputs[0].address : null;
+            ret.outputs = tx.outputs;
+            break;
+          default:
+            ret.action = 'invalid';
+        }
+
+        // not available
+        // inputs: inputs,
+        return ret;
+
+        // filter out dust
+      }).filter(x => !x.dust);
 
       // console.log('[server.js.2965:ret:] END',ret); //TODO
       return cb(null, ret);
@@ -3842,13 +3811,6 @@ export class WalletService implements IWalletService {
       amount = 0;
     }
 
-    const formatOutput = o => {
-      return {
-        amount: o.amount,
-        address: o.address
-      };
-    };
-
     const newTx = {
       txid: tx.txid,
       action,
@@ -3863,27 +3825,26 @@ export class WalletService implements IWalletService {
       inputs: undefined
     };
 
-    if (_.isNumber(tx.size) && tx.size > 0) {
+    if (Utils.isNumber(tx.size) && tx.size > 0) {
       newTx.feePerKb = +((tx.fees * 1000) / tx.size).toFixed();
     }
 
     if (opts.includeExtendedInfo) {
-      newTx.inputs = _.map(inputs, input => {
+      newTx.inputs = inputs.map(input => {
         return _.pick(input, 'address', 'amount', 'isMine');
       });
-      newTx.outputs = _.map(outputs, output => {
+      newTx.outputs = outputs.map(output => {
         return _.pick(output, 'address', 'amount', 'isMine');
       });
     } else {
-      outputs = _.filter(outputs, {
-        isChange: false
-      });
+      outputs = outputs.filter(o => !o.isChange);
       if (action == 'received') {
-        outputs = _.filter(outputs, {
-          isMine: true
-        });
+        outputs = outputs.filter(o => o.isMine);
       }
-      newTx.outputs = _.map(outputs, formatOutput);
+      newTx.outputs = outputs.map(o => ({
+        amount: o.amount,
+        address: o.address
+      }));
     }
 
     return newTx;
@@ -3899,10 +3860,10 @@ export class WalletService implements IWalletService {
       tx.creatorName = proposal.creatorName;
       tx.message = proposal.message;
       tx.nonce = proposal.nonce;
-      tx.actions = _.map(proposal.actions, action => {
+      tx.actions = proposal.actions.map(action => {
         return _.pick(action, ['createdOn', 'type', 'copayerId', 'copayerName', 'comment']);
       });
-      _.each(tx.outputs, output => {
+      for (const output of tx.outputs) {
         const query = {
           toAddress: output.address,
           amount: output.amount
@@ -3911,7 +3872,7 @@ export class WalletService implements IWalletService {
           const txpOut = proposal.outputs.find(o => o.toAddress === output.address && o.amount === output.amount);
           output.message = txpOut ? txpOut.message : null;
         }
-      });
+      }
       tx.customData = proposal.customData;
 
       tx.createdOn = proposal.createdOn;
@@ -4122,7 +4083,7 @@ export class WalletService implements IWalletService {
 
   tagLowFeeTxs(wallet: IWallet, txs: any[], cb) {
     const unconfirmed = txs.filter(tx => tx.confirmations === 0);
-    if (_.isEmpty(unconfirmed)) return cb();
+    if (!unconfirmed.length) return cb();
 
     this.getFeeLevels(
       {
@@ -4138,9 +4099,9 @@ export class WalletService implements IWalletService {
             this.logi('Cannot compute super economy fee level from blockchain');
           } else {
             const minFeePerKb = level.feePerKb;
-            _.each(unconfirmed, tx => {
+            for (const tx of unconfirmed) {
               tx.lowFees = tx.feePerKb < minFeePerKb;
-            });
+            }
           }
         }
         return cb();
@@ -4289,11 +4250,11 @@ export class WalletService implements IWalletService {
             }
 
             // update confirmations from height
-            _.each(oldTxs, x => {
+            for (const x of oldTxs) {
               if (x.blockheight > 0 && bcHeight >= x.blockheight) {
                 x.confirmations = bcHeight - x.blockheight + 1;
               }
-            });
+            }
 
             resultTxs = resultTxs.concat(oldTxs);
             return next();
@@ -4311,7 +4272,7 @@ export class WalletService implements IWalletService {
             CONFIRMATIONS_TO_START_CACHING = Constants.CONFIRMATIONS_TO_START_CACHING[wallet.chain];
           }
 
-          txsToCache = _.filter(lastTxs, i => {
+          txsToCache = lastTxs.filter(i => {
             if (i.confirmations < CONFIRMATIONS_TO_START_CACHING) {
               return false;
             }
@@ -4358,7 +4319,7 @@ export class WalletService implements IWalletService {
 
     // 50 is accepted by insight.
     // TODO move it to a bigger number with v8 is fully deployed
-    opts.limit = isNaN(opts.limit) ? 50 : Number(opts.limit);
+    opts.limit = !Utils.isNumber(opts.limit) ? 50 : Number(opts.limit);
     if (opts.limit > Defaults.HISTORY_LIMIT) return cb(Errors.HISTORY_LIMIT_EXCEEDED);
 
     this.getWallet({}, (err, wallet) => {
@@ -4380,7 +4341,7 @@ export class WalletService implements IWalletService {
             this.getTxHistoryV8(bc, wallet, opts, from, opts.limit, next);
           },
           (txs: { items: Array<{ time: number }> }, next) => {
-            if (!txs || _.isEmpty(txs.items)) {
+            if (!txs || !txs.items?.length) {
               return next();
             }
             // TODO optimize this...
@@ -4427,7 +4388,7 @@ export class WalletService implements IWalletService {
           const indexedProposals = _.keyBy(res.txps, 'txid');
           const indexedNotes = _.keyBy(res.notes, 'txid');
 
-          const finalTxs = _.map(res.txs.items, tx => {
+          const finalTxs = res.txs.items.map(tx => {
             WalletService._addProposalInfo(tx, indexedProposals, opts);
             WalletService._addNotesInfo(tx, indexedNotes);
             return tx;
@@ -4538,7 +4499,7 @@ export class WalletService implements IWalletService {
 
       // when powerScanning, we just accept gap<=3
       if (step > 1) {
-        gap = _.min([gap, 3]);
+        gap = Math.min(gap, 3);
       }
 
       async.whilst(
@@ -4560,7 +4521,7 @@ export class WalletService implements IWalletService {
         },
         err => {
           derivator.rewind(gap);
-          return cb(err, _.dropRight(allAddresses, gap));
+          return cb(err, allAddresses.slice(0, -gap));
         }
       );
     };
@@ -4682,7 +4643,7 @@ export class WalletService implements IWalletService {
    * @returns {Array} rates - The exchange rate.
    */
   getFiatRates(opts, cb) {
-    if (_.isNaN(opts.ts) || _.isArray(opts.ts)) return cb(new ClientError('Invalid timestamp'));
+    if (isNaN(opts.ts) || Array.isArray(opts.ts)) return cb(new ClientError('Invalid timestamp'));
 
     this.fiatRateService.getRates(opts, (err, rates) => {
       if (err) return cb(err);
@@ -4701,7 +4662,7 @@ export class WalletService implements IWalletService {
    */
   getFiatRatesByCoin(opts, cb) {
     if (!checkRequired(opts, ['coin'], cb)) return;
-    if (_.isNaN(opts.ts) || _.isArray(opts.ts)) return cb(new ClientError('Invalid timestamp'));
+    if (isNaN(opts.ts) || Array.isArray(opts.ts)) return cb(new ClientError('Invalid timestamp'));
 
     this.fiatRateService.getRatesByCoin(opts, (err, rate) => {
       if (err) return cb(err);
@@ -7691,12 +7652,12 @@ export class WalletService implements IWalletService {
 
 function checkRequired(obj, args, cb?: (e: any) => void) {
   const missing = Utils.getMissingFields(obj, args);
-  if (_.isEmpty(missing)) {
+  if (!missing.length) {
     return true;
   }
 
-  if (_.isFunction(cb)) {
-    return cb(new ClientError('Required argument: ' + _.first(missing) + ' missing.'));
+  if (typeof cb === 'function') {
+    return cb(new ClientError('Required argument: ' + missing[0] + ' missing.'));
   }
 
   return false;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -68,13 +68,13 @@ let initialized = false;
 let doNotCheckV8 = false;
 let isMoralisInitialized = false;
 
-let lock;
-let storage;
-let blockchainExplorer;
+let lock: Lock;
+let storage: Storage;
+let blockchainExplorer: V8;
 let blockchainExplorerOpts;
-let messageBroker;
-let fiatRateService;
-let serviceVersion;
+let messageBroker: MessageBroker;
+let fiatRateService: FiatRateService;
+let serviceVersion: string;
 
 interface IAddress {
   coin: string;
@@ -86,12 +86,12 @@ interface IAddress {
 }
 
 export interface IWalletService {
-  lock: any;
+  lock: Lock;
   storage: Storage;
-  blockchainExplorer: any;
+  blockchainExplorer: V8;
   blockchainExplorerOpts: any;
-  messageBroker: any;
-  fiatRateService: any;
+  messageBroker: MessageBroker;
+  fiatRateService: FiatRateService;
   notifyTicker: number;
   userAgent: string;
   walletId: string;
@@ -112,12 +112,12 @@ function boolToNum(x: boolean) {
  * @constructor
  */
 export class WalletService implements IWalletService {
-  lock: any;
+  lock: Lock;
   storage: Storage;
   blockchainExplorer: V8;
   blockchainExplorerOpts: any;
-  messageBroker: any;
-  fiatRateService: any;
+  messageBroker: MessageBroker;
+  fiatRateService: FiatRateService;
   notifyTicker: number;
   userAgent: string;
   walletId: string;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3497,7 +3497,7 @@ export class WalletService implements IWalletService {
       this.storage.fetchAddressesByWalletId(walletId, moves3.map(m => m.address), (err, addrs) => {
         if (err) return cb(err);
 
-        const isChangeAddress = _.countBy(addrs.filter(a => a.isChange === true), 'address');
+        const isChangeAddress = _.countBy(addrs.filter(a => a.isChange), 'address');
         for (const x of Object.values(moves)) {
           x.outputs = x.outputs.filter(o => !isChangeAddress[o.address]);
         }

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3399,10 +3399,10 @@ export class WalletService implements IWalletService {
         (err, res) => {
           if (err) return cb(err);
 
-          const notifications = res.flatMap((n: INotification) => {
-            n.walletId = this.walletId;
-            return n;
-          }).sort((a, b) => a.id - b.id);
+          const notifications = res
+            .flat()
+            .map((n: INotification) => ({ ...n, walletId: this.walletId }))
+            .sort((a, b) => a.id - b.id);
 
           return cb(null, notifications);
         }

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -39,8 +39,8 @@ const collections = {
   LOCKS: 'locks'
 };
 
-const Constants = Common.Constants;
 const Defaults = Common.Defaults;
+const Utils = Common.Utils;
 
 const ObjectID = mongodb.ObjectID;
 
@@ -651,7 +651,7 @@ export class Storage {
         if (err) return cb(err);
         if (!result) return cb();
 
-        return cb(null, result.map(Address.fromObj));
+        return cb(null, Utils.sortAsc(result.map(Address.fromObj), 'createdOn', 'path'));
       });
   }
 

--- a/packages/bitcore-wallet-service/test/integration/server.js
+++ b/packages/bitcore-wallet-service/test/integration/server.js
@@ -74,9 +74,9 @@ describe('Wallet service', function() {
     config.suspendedChains = [];
 
     // restore defaults, cp values
-    _.each(_.keys(VanillaDefaults), (x) => {
+    for (const x of Object.keys(VanillaDefaults)) {
       Defaults[x] = VanillaDefaults[x];
-    });
+    }
 
     helpers.beforeEach(function(res) {
       done();
@@ -927,17 +927,13 @@ describe('Wallet service', function() {
               copayer.customData.should.equal('dummy custom data');
               server.getNotifications({}, function(err, notifications) {
                 should.not.exist(err);
-                var notif = _.find(notifications, {
-                  type: 'NewCopayer'
-                });
+                var notif = notifications.find(n => n.type === 'NewCopayer');
                 should.exist(notif);
                 notif.data.walletId.should.equal(walletId);
                 notif.data.copayerId.should.equal(copayerId);
                 notif.data.copayerName.should.equal('me');
 
-                notif = _.find(notifications, {
-                  type: 'WalletComplete'
-                });
+                notif = notifications.find(n => n.type === 'WalletComplete');
                 should.not.exist(notif);
                 done();
               });
@@ -1244,9 +1240,7 @@ describe('Wallet service', function() {
             wallet.publicKeyRing.length.should.equal(3);
             server.getNotifications({}, function(err, notifications) {
               should.not.exist(err);
-              var notif = _.find(notifications, {
-                type: 'WalletComplete'
-              });
+              var notif = notifications.find(n => n.type === 'WalletComplete');
               should.exist(notif);
               notif.data.walletId.should.equal(wallet.id);
               done();
@@ -1259,9 +1253,7 @@ describe('Wallet service', function() {
         helpers.createAndJoinWallet(1, 1, function(server) {
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'WalletComplete'
-            });
+            var notif = notifications.find(n => n.type === 'WalletComplete');
             should.not.exist(notif);
             done();
           });
@@ -1513,7 +1505,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
           };
 
-          async.eachSeries(_.range(2), function(i, next) {
+          async.eachSeries(new Array(2).fill(0), function(i, next) {
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function() {
               next();
             });
@@ -1577,7 +1569,7 @@ describe('Wallet service', function() {
                 }],
                 feePerKb: 100e2,
               };
-              async.eachSeries(_.range(2), function(i, next) {
+              async.eachSeries(new Array(2).fill(0), function(i, next) {
                 helpers.createAndPublishTx(server2, txOpts, TestData.copayers[1].privKey_1H_0, function() {
                   next();
                 });
@@ -1661,14 +1653,14 @@ describe('Wallet service', function() {
         should.not.exist(status.wallet.publicKeyRing);
         should.not.exist(status.wallet.pubKey);
         should.not.exist(status.wallet.addressManager);
-        _.each(status.wallet.copayers, function(copayer) {
+        for (const copayer of status.wallet.copayers) {
           should.not.exist(copayer.xPubKey);
           should.not.exist(copayer.requestPubKey);
           should.not.exist(copayer.signature);
           should.not.exist(copayer.requestPubKey);
           should.not.exist(copayer.addressManager);
           should.not.exist(copayer.customData);
-        });
+        }
         done();
       });
     });
@@ -1687,9 +1679,9 @@ describe('Wallet service', function() {
         should.exist(status.wallet.copayers[0].requestPubKey);
         should.exist(status.wallet.copayers[0].customData);
         // Do not return other copayer's custom data
-        _.each(_.tail(status.wallet.copayers), function(copayer) {
+        for (const copayer of status.wallet.copayers.slice(1)) {
           should.not.exist(copayer.customData);
-        });
+        }
         done();
       });
     });
@@ -1745,7 +1737,7 @@ describe('Wallet service', function() {
         should.not.exist(err);
         should.exist(status);
         should.exist(status.serverMessages);
-        _.isArray(status.serverMessages).should.be.true;
+        Array.isArray(status.serverMessages).should.be.true;
         status.serverMessages.should.deep.equal([{
           title: 'Test message 2',
           body: 'Only for bitpay livenet wallets',
@@ -1766,7 +1758,8 @@ describe('Wallet service', function() {
         should.not.exist(err);
         should.exist(status);
         should.exist(status.serverMessage);
-        _.isObject(status.serverMessage).should.be.true;
+        (typeof status.serverMessage === 'object').should.be.true;
+        (Array.isArray(status.serverMessage)).should.be.false;
         status.serverMessage.should.deep.equal({
           title: 'Deprecated Test message',
           body: 'Only for bitpay, old wallets',
@@ -1845,9 +1838,7 @@ describe('Wallet service', function() {
           address.type.should.equal('P2SH');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -1885,15 +1876,15 @@ describe('Wallet service', function() {
 
       it('should create many addresses on simultaneous requests', function(done) {
         var N = 5;
-        async.mapSeries(_.range(N), function(i, cb) {
+        async.mapSeries(new Array(N).fill(0), function(i, cb) {
           server.createAddress({}, cb);
         }, function(err, addresses) {
           addresses.length.should.equal(N);
-          _.each(_.range(N), function(i) {
+          for (var i = 0; i < N; i++) {
             addresses[i].path.should.equal('m/0/' + i);
-          });
+          }
           // No two identical addresses
-          _.uniq(_.map(addresses, 'address')).length.should.equal(N);
+          _.uniq(addresses.map(m => m.address)).length.should.equal(N);
           done();
         });
       });
@@ -1943,9 +1934,7 @@ describe('Wallet service', function() {
           address.coin.should.equal('bch');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -1955,15 +1944,15 @@ describe('Wallet service', function() {
 
       it('should create many addresses on simultaneous requests', function(done) {
         var N = 5;
-        async.mapSeries(_.range(N), function(i, cb) {
+        async.mapSeries(new Array(N).fill(0), function(i, cb) {
           server.createAddress({}, cb);
         }, function(err, addresses) {
           addresses.length.should.equal(N);
-          _.each(_.range(N), function(i) {
+          for (let i = 0; i < N; i++) {
             addresses[i].path.should.equal('m/0/' + i);
-          });
+          }
           // No two identical addresses
-          _.uniq(_.map(addresses, 'address')).length.should.equal(N);
+          _.uniq(addresses.map(a => a.address)).length.should.equal(N);
           done();
         });
       });
@@ -2012,9 +2001,7 @@ describe('Wallet service', function() {
           address.coin.should.equal('bch');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -2024,15 +2011,15 @@ describe('Wallet service', function() {
 
       it('should create many addresses on simultaneous requests', function(done) {
         var N = 5;
-        async.mapSeries(_.range(N), function(i, cb) {
+        async.mapSeries(new Array(N).fill(0), function(i, cb) {
           server.createAddress({}, cb);
         }, function(err, addresses) {
           addresses.length.should.equal(N);
-          _.each(_.range(N), function(i) {
+          for (let i = 0; i < N; i++) {
             addresses[i].path.should.equal('m/0/' + i);
-          });
+          }
           // No two identical addresses
-          _.uniq(_.map(addresses, 'address')).length.should.equal(N);
+          _.uniq(addresses.map(a => a.address)).length.should.equal(N);
           done();
         });
       });
@@ -2082,9 +2069,7 @@ describe('Wallet service', function() {
           address.coin.should.equal('bch');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -2108,9 +2093,7 @@ describe('Wallet service', function() {
           // notified address is Copay format
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
 
@@ -2152,9 +2135,7 @@ describe('Wallet service', function() {
           address.coin.should.equal('bch');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -2186,9 +2167,7 @@ describe('Wallet service', function() {
           address.type.should.equal('P2PKH');
           server.getNotifications({}, function(err, notifications) {
             should.not.exist(err);
-            var notif = _.find(notifications, {
-              type: 'NewAddress'
-            });
+            var notif = notifications.find(n => n.type === 'NewAddress');
             should.exist(notif);
             notif.data.address.should.equal(address.address);
             done();
@@ -2198,16 +2177,16 @@ describe('Wallet service', function() {
 
       it('should create many addresses on simultaneous requests', function(done) {
         var N = 5;
-        async.mapSeries(_.range(N), function(i, cb) {
+        async.mapSeries(new Array(N).fill(0), function(i, cb) {
           server.createAddress({}, cb);
         }, function(err, addresses) {
-          addresses = _.sortBy(addresses, 'path');
+          addresses = addresses.sort((a, b) => a.path - b.path);
           addresses.length.should.equal(N);
-          _.each(_.range(N), function(i) {
+          for (let i = 0; i < N; i++) {
             addresses[i].path.should.equal('m/0/' + i);
-          });
+          }
           // No two identical addresses
-          _.uniq(_.map(addresses, 'address')).length.should.equal(N);
+          _.uniq(addresses.map(a => a.address)).length.should.equal(N);
           done();
         });
       });
@@ -2216,7 +2195,7 @@ describe('Wallet service', function() {
         var MAX_MAIN_ADDRESS_GAP_old = Defaults.MAX_MAIN_ADDRESS_GAP;
         Defaults.MAX_MAIN_ADDRESS_GAP = 2;
         helpers.stubAddressActivity([]);
-        async.map(_.range(2), function(i, next) {
+        async.map(new Array(2).fill(0), function(i, next) {
           server.createAddress({}, next);
         }, function(err, addresses) {
           addresses.length.should.equal(2);
@@ -2252,7 +2231,7 @@ describe('Wallet service', function() {
         var MAX_MAIN_ADDRESS_GAP_old = Defaults.MAX_MAIN_ADDRESS_GAP;
         Defaults.MAX_MAIN_ADDRESS_GAP = 2;
         helpers.stubAddressActivity([]);
-        async.mapSeries(_.range(2), function(i, next) {
+        async.mapSeries(new Array(2).fill(0), function(i, next) {
           server.createAddress({}, next);
         }, function(err, addresses) {
           addresses.length.should.equal(2);
@@ -2296,9 +2275,7 @@ describe('Wallet service', function() {
             address.path.should.equal('m/0/0');
             server.getNotifications({}, function(err, notifications) {
               should.not.exist(err);
-              var notif = _.find(notifications, {
-                type: 'NewAddress'
-              });
+              var notif = notifications.find(n => n.type === 'NewAddress');
               should.exist(notif);
               notif.data.address.should.equal(address.address);
               done();
@@ -2406,9 +2383,7 @@ describe('Wallet service', function() {
             address.path.should.equal('m/0/0');
             server.getNotifications({}, function(err, notifications) {
               should.not.exist(err);
-              var notif = _.find(notifications, {
-                type: 'NewAddress'
-              });
+              var notif = notifications.find(n => n.type === 'NewAddress');
               should.exist(notif);
               notif.data.address.should.equal(address.address);
               done();
@@ -2762,7 +2737,7 @@ describe('Wallet service', function() {
         expected: 'email'
       }, {
         preferences: {
-          email: 'dummy@' + _.repeat('domain', 50),
+          email: 'dummy@' + new Array(50).fill('domain').join(''),
         },
         expected: 'email'
       }, {
@@ -2808,12 +2783,10 @@ describe('Wallet service', function() {
           should.not.exist(err);
           should.exist(utxos);
           utxos.length.should.equal(2);
-          _.sumBy(utxos, 'satoshis').should.equal(3 * 1e8);
+          utxos.reduce((sum, u) => sum += u.satoshis, 0).should.equal(3 * 1e8);
           server.getMainAddresses({}, function(err, addresses) {
             var utxo = utxos[0];
-            var address = _.find(addresses, {
-              address: utxo.address
-            });
+            var address = addresses.find(a => a.address === utxo.address);
             should.exist(address);
             utxo.path.should.equal(address.path);
             utxo.publicKeys.should.deep.equal(address.publicKeys);
@@ -2830,12 +2803,10 @@ describe('Wallet service', function() {
           should.not.exist(err);
           should.exist(utxos);
           utxos.length.should.equal(2);
-          _.sumBy(utxos, 'satoshis').should.equal(3 * 1e8);
+          utxos.reduce((sum, u) => sum += u.satoshis, 0).should.equal(3 * 1e8);
           server.getMainAddresses({}, function(err, addresses) {
             var utxo = utxos[0];
-            var address = _.find(addresses, {
-              address: utxo.address
-            });
+            var address = addresses.find(a => a.address === utxo.address);
             should.exist(address);
             utxo.path.should.equal(address.path);
             utxo.publicKeys.should.deep.equal(address.publicKeys);
@@ -2848,10 +2819,6 @@ describe('Wallet service', function() {
     it('should return empty UTXOs for specific addresses if network mismatch', function(done) {
       helpers.stubUtxos(server, wallet, [1, 2, 3], function(utxos) {
         _.uniqBy(utxos, 'address').length.should.be.above(1);
-        var address = utxos[0].address;
-        var amount = _.sumBy(_.filter(utxos, {
-          address: address
-        }), 'satoshis');
         server.getUtxos({
           addresses: ['mrM5kMkqZccK5MxZYSsM3SjqdMaNKLJgrJ']
         }, function(err, utxos) {
@@ -2864,10 +2831,6 @@ describe('Wallet service', function() {
     it('should return empty UTXOs for specific addresses if coin mismatch', function(done) {
       helpers.stubUtxos(server, wallet, [1, 2, 3], function(utxos) {
         _.uniqBy(utxos, 'address').length.should.be.above(1);
-        var address = utxos[0].address;
-        var amount = _.sumBy(_.filter(utxos, {
-          address: address
-        }), 'satoshis');
         server.getUtxos({
           addresses: ['CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X']
         }, function(err, utxos) {
@@ -2920,12 +2883,10 @@ describe('Wallet service', function() {
           should.not.exist(err);
           should.exist(utxos);
           utxos.length.should.equal(2);
-          _.sumBy(utxos, 'satoshis').should.equal(2 * 1e8 + 1000);
+          utxos.reduce((sum, u) => sum += u.satoshis, 0).should.equal(2 * 1e8 + 1000);
           server.getMainAddresses({}, function(err, addresses) {
             var utxo = utxos[0];
-            var address = _.find(addresses, {
-              address: utxo.address
-            });
+            var address = addresses.find(a => a.address === utxo.address);
             should.exist(address);
             utxo.path.should.equal(address.path);
             utxo.publicKeys.should.deep.equal(address.publicKeys);
@@ -2941,7 +2902,7 @@ describe('Wallet service', function() {
           should.not.exist(err);
           should.exist(utxos);
           utxos.length.should.equal(0);
-          _.sumBy(utxos, 'satoshis').should.equal(0);
+          utxos.reduce((sum, u) => sum += u.satoshis, 0).should.equal(0);
           done();
         });
       });
@@ -3140,8 +3101,8 @@ describe('Wallet service', function() {
           balance.byAddress[1].amount.should.equal(helpers.toSatoshi(2));
           server.getMainAddresses({}, function(err, addresses) {
             should.not.exist(err);
-            var addresses = _.uniq(_.map(addresses, 'address'));
-            _.intersection(addresses, _.map(balance.byAddress, 'address')).length.should.equal(2);
+            var addresses = _.uniq(addresses.map(a => a.address));
+            _.intersection(addresses, balance.byAddress.map(a => a.address)).length.should.equal(2);
             done();
           });
         });
@@ -3269,9 +3230,7 @@ describe('Wallet service', function() {
       });
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.urgent.feePerKb.should.equal(60000);
         fees.urgent.nbBlocks.should.equal(1);
 
@@ -3293,12 +3252,8 @@ describe('Wallet service', function() {
       blockchainExplorer.estimateFee = sinon.stub().yields('dummy error');
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item.feePerKb];
-        }));
-        var defaults = _.fromPairs(_.map(Defaults.FEE_LEVELS['btc'], function(item) {
-          return [item.name, item.defaultValue];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item.feePerKb]));
+        const defaults = Object.fromEntries(Defaults.FEE_LEVELS['btc'].map(item => [item.name, item.defaultValue]));
         fees.priority.should.equal(defaults.priority);
         fees.normal.should.equal(defaults.normal);
         fees.economy.should.equal(defaults.economy);
@@ -3318,16 +3273,12 @@ describe('Wallet service', function() {
       }, true);
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.urgent.feePerKb.should.equal(60003);
         blockchainExplorer.estimateFee = sinon.stub().yields('dummy error');
         server.getFeeLevels({}, function(err, fees) {
           should.not.exist(err);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
           fees.urgent.feePerKb.should.equal(60003);
           fees.superEconomy.feePerKb.should.equal(9001);
           Defaults.FEE_LEVEL_CACHE_DURATION = x;
@@ -3348,9 +3299,7 @@ describe('Wallet service', function() {
       }, true);
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.urgent.feePerKb.should.equal(60003);
         blockchainExplorer.estimateFee = sinon.stub().yields('dummy error');
         server.getFeeLevels({}, function(err, fees) {
@@ -3369,9 +3318,7 @@ describe('Wallet service', function() {
           }, true);
           server.getFeeLevels({}, function(err, fees) {
             should.not.exist(err);
-            fees = _.fromPairs(_.map(fees, function(item) {
-              return [item.level, item];
-            }));
+            fees = Object.fromEntries(fees.map(item => [item.level, item]));
             fees.urgent.feePerKb.should.equal(600);
             fees.superEconomy.feePerKb.should.equal(90);
             Defaults.FEE_LEVEL_CACHE_DURATION = x;
@@ -3397,9 +3344,7 @@ describe('Wallet service', function() {
       server.getFeeLevels({}, function(err, fees, cached) {
         should.not.exist(err);
         should.not.exist(cached);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
 
         //should use default value
@@ -3423,9 +3368,7 @@ describe('Wallet service', function() {
         server.getFeeLevels({}, function(err, fees, cached) {
           should.not.exist(cached);
           should.not.exist(err);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
           fees.urgent.feePerKb.should.equal(600);
           fees.superEconomy.feePerKb.should.equal(90);
 
@@ -3452,9 +3395,7 @@ describe('Wallet service', function() {
       server.getFeeLevels({}, function(err, fees, cached) {
         should.not.exist(err);
         should.not.exist(cached);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
 
         //should use default value
@@ -3478,9 +3419,7 @@ describe('Wallet service', function() {
         server.getFeeLevels({}, function(err, fees, cached) {
           should.not.exist(cached);
           should.not.exist(err);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
           fees.urgent.feePerKb.should.equal(600);
           fees.superEconomy.feePerKb.should.equal(90);
 
@@ -3511,9 +3450,7 @@ describe('Wallet service', function() {
       server.getFeeLevels({}, function(err, fees, cached) {
         should.not.exist(err);
         should.not.exist(cached);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
 
         //using the given value
@@ -3531,9 +3468,7 @@ describe('Wallet service', function() {
         server.getFeeLevels({}, function(err, fees, cached) {
           should.not.exist(err);
           should.exist(cached);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
           //old cached values
           fees.urgent.feePerKb.should.equal(750);
@@ -3555,9 +3490,7 @@ describe('Wallet service', function() {
       });
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.priority.feePerKb.should.equal(18000);
         fees.priority.nbBlocks.should.equal(2);
 
@@ -3583,9 +3516,7 @@ describe('Wallet service', function() {
       });
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
         fees.priority.feePerKb.should.equal(45000);
         fees.priority.nbBlocks.should.equal(1);
@@ -3599,9 +3530,7 @@ describe('Wallet service', function() {
       });
     });
     it('should get monotonically decreasing fee values', function(done) {
-      _.find(Defaults.FEE_LEVELS['btc'], {
-        nbBlocks: 6
-      }).defaultValue.should.equal(25000);
+      Defaults.FEE_LEVELS['btc'].find(lvl => lvl.nbBlocks === 6).defaultValue.should.equal(25000);
       helpers.stubFeeLevels({
         1: 45000,
         2: 18000,
@@ -3612,9 +3541,7 @@ describe('Wallet service', function() {
       });
       server.getFeeLevels({}, function(err, fees) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
 
         fees.priority.feePerKb.should.equal(45000);
         fees.priority.nbBlocks.should.equal(1);
@@ -3638,17 +3565,13 @@ describe('Wallet service', function() {
       }, true);
       server.getFeeLevels({}, function(err, fees, fromCache) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.urgent.feePerKb.should.equal(60000);
         fees.priority.feePerKb.should.equal(40000);
         should.not.exist(fromCache);
         server.getFeeLevels({}, function(err, fees, fromCache) {
           should.not.exist(err);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
           fees.urgent.feePerKb.should.equal(60000);
           fees.priority.feePerKb.should.equal(40000);
           fromCache.should.equal(true);
@@ -3665,18 +3588,14 @@ describe('Wallet service', function() {
       });
       server.getFeeLevels({}, function(err, fees, fromCache) {
         should.not.exist(err);
-        fees = _.fromPairs(_.map(fees, function(item) {
-          return [item.level, item];
-        }));
+        fees = Object.fromEntries(fees.map(item => [item.level, item]));
         fees.urgent.feePerKb.should.equal(60000);
         fees.priority.feePerKb.should.equal(40000);
         should.not.exist(fromCache);
         clock.tick(31 * 60 * 1000);
         server.getFeeLevels({}, function(err, fees, fromCache) {
           should.not.exist(err);
-          fees = _.fromPairs(_.map(fees, function(item) {
-            return [item.level, item];
-          }));
+          fees = Object.fromEntries(fees.map(item => [item.level, item]));
           fees.urgent.feePerKb.should.equal(60000);
           fees.priority.feePerKb.should.equal(40000);
           should.not.exist(fromCache);
@@ -3876,7 +3795,7 @@ describe('Wallet service', function() {
     }
   ];
 
-  _.each(testSet, function(x) {
+  for (const x of testSet) {
 
     const coin = x.coin;
     const ts = TO_SAT[coin];
@@ -4259,7 +4178,7 @@ describe('Wallet service', function() {
                     should.not.exist(err);
                     should.exist(tx);
                     tx.inputs.length.should.equal(2);
-                    var txids = _.map(tx.inputs, 'txid');
+                    var txids = tx.inputs.map(i => i.txid);
                     txids.should.contain(utxos[0].txid);
                     txids.should.contain(utxos[2].txid);
                     done();
@@ -4504,16 +4423,14 @@ describe('Wallet service', function() {
                 should.exist(txp);
                 server.getNotifications({}, function(err, notifications) {
                   should.not.exist(err);
-                  _.map(notifications, 'type').should.not.contain('NewTxProposal');
+                  notifications.map(n => n.type).should.not.contain('NewTxProposal');
                   var publishOpts = helpers.getProposalSignatureOpts(txp, TestData.copayers[0].privKey_1H_0);
                   server.publishTx(publishOpts, function(err) {
                     should.not.exist(err);
                     server.getNotifications({}, function(err, notifications) {
                       should.not.exist(err);
 
-                      var n = _.find(notifications, {
-                        'type': 'NewTxProposal'
-                      });
+                      var n = notifications.find(n => n.type === 'NewTxProposal');
                       should.exist(n);
                       should.exist(n.data.txProposalId);
                       should.exist(n.data.message);
@@ -5242,7 +5159,7 @@ describe('Wallet service', function() {
           it('should fail to create a tx exceeding max size in kb', function(done) {
             Defaults.MAX_TX_SIZE_IN_KB_BTC = 1;
 
-            helpers.stubUtxos(server, wallet, _.range(1, 10, 0), { coin }, function() {
+            helpers.stubUtxos(server, wallet, new Array(9).fill(1), { coin }, function() {
               let x = [];
               x.push({
                 toAddress: addressStr,
@@ -5366,7 +5283,7 @@ describe('Wallet service', function() {
                       should.not.exist(err);
                       balance.totalAmount.should.equal(3.6 * TO_SAT[coin]);
                       if (coin != 'eth') {
-                        var amountInputs = _.sumBy(txs[0].inputs, 'satoshis');
+                        var amountInputs = txs[0].inputs.reduce((sum, input) => sum += input.satoshis, 0);
                         balance.lockedAmount.should.equal(amountInputs);
                         balance.lockedAmount.should.be.below(balance.totalAmount);
                         balance.availableAmount.should.equal(balance.totalAmount - balance.lockedAmount);
@@ -5520,12 +5437,10 @@ describe('Wallet service', function() {
             }
             helpers.stubUtxos(server, wallet, amount, function() {
               var txOpts = {
-                outputs: _.times(30, function(i) {
-                  return {
-                    toAddress: addressStr,
-                    amount: (i + 1) * outputAmount,
-                  };
-                }),
+                outputs: new Array(30).fill(0).map((_, i) => ({
+                  toAddress: addressStr,
+                  amount: (i + 1) * outputAmount,
+                })),
                 feePerKb: 123e2,
               };
               txOpts = Object.assign(txOpts, flags);
@@ -5534,9 +5449,9 @@ describe('Wallet service', function() {
                 should.exist(txp);
                 var t = ChainService.getBitcoreTx(txp);
                 var changeOutput = t.getChangeOutput().satoshis;
-                var outputs = _.without(_.map(t.outputs, 'satoshis'), changeOutput);
+                var outputs = t.outputs.map(o => o.satoshis).filter(o => o !== changeOutput);
 
-                outputs.should.not.deep.equal(_.map(txOpts.outputs, 'amount'));
+                outputs.should.not.deep.equal(txOpts.outputs.map(o => o.amount));
                 txOpts.noShuffleOutputs = true;
                 txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, txp) {
@@ -5545,9 +5460,9 @@ describe('Wallet service', function() {
 
                   t = ChainService.getBitcoreTx(txp);
                   changeOutput = t.getChangeOutput().satoshis;
-                  outputs = _.without(_.map(t.outputs, 'satoshis'), changeOutput);
+                  outputs = t.outputs.map(o => o.satoshis).filter(o => o !== changeOutput);
 
-                  outputs.should.deep.equal(_.map(txOpts.outputs, 'amount'));
+                  outputs.should.deep.equal(txOpts.outputs.map(o => o.amount));
                   done();
                 });
               });
@@ -5566,7 +5481,8 @@ describe('Wallet service', function() {
         helpers.createAndJoinWallet(2, 2, function(s, w) {
           server = s;
           wallet = w;
-          helpers.stubUtxos(server, wallet, _.range(2, 6), function() {
+          const range2to5 = new Array(4).fill(0).map((_, i) => i + 2);
+          helpers.stubUtxos(server, wallet, range2to5, function() {
             done();
           });
         });
@@ -5589,7 +5505,7 @@ describe('Wallet service', function() {
         async.series([
 
           function(next) {
-            async.each(_.range(3), function(i, next) {
+            async.each(new Array(3).fill(0), function(i, next) {
               txOpts = Object.assign(txOpts, flags);
               helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
                 server.rejectTx({
@@ -5778,11 +5694,12 @@ describe('Wallet service', function() {
         });
         it('should return inputs in random order', function(done) {
           // NOTE: this test has a chance of failing of 1 in 1'073'741'824 :P
-          helpers.stubUtxos(server, wallet, _.range(1, 31), function(utxos) {
+          const range1to30 = new Array(30).fill(0).map((_, i) => i + 1);
+          helpers.stubUtxos(server, wallet, range1to30, function(utxos) {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
-                amount: _.sumBy(utxos, 'satoshis') - 0.5e8,
+                amount: utxos.reduce((sum, u) => sum += u.satoshis, 0) - 0.5e8,
               }],
               feePerKb: 100e2,
             };
@@ -5790,9 +5707,9 @@ describe('Wallet service', function() {
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
-              var amounts = _.map(txp.inputs, 'satoshis');
+              var amounts = txp.inputs.map(i => i.satoshis);
               amounts.length.should.equal(30);
-              _.every(amounts, function(amount, i) {
+              amounts.every(function(amount, i) {
                 if (i == 0) return true;
                 return amount < amounts[i - 1];
               }).should.be.false;
@@ -5834,7 +5751,7 @@ describe('Wallet service', function() {
               should.not.exist(err);
               should.exist(txp);
               txp.inputs.length.should.equal(3);
-              _.every(txp.inputs, function(input) {
+              txp.inputs.every(function(input) {
                 return input == 100e2;
               });
               done();
@@ -5885,9 +5802,7 @@ describe('Wallet service', function() {
           });
         });
         it('should select smallest big utxo if small utxos exceed maximum fee', function(done) {
-          helpers.stubUtxos(server, wallet, [3, 1, 2].concat(_.times(20, function() {
-            return '1000bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, [3, 1, 2].concat(new Array(20).fill('1000bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -5932,7 +5847,7 @@ describe('Wallet service', function() {
           Defaults.MAX_TX_SIZE_IN_KB_XRP = 2;
 
 
-          helpers.stubUtxos(server, wallet, [100].concat(_.range(1, 20, 0)), function() {
+          helpers.stubUtxos(server, wallet, [100].concat(new Array(19).fill(1)), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6011,9 +5926,7 @@ describe('Wallet service', function() {
           });
         });
         it('should prefer a higher fee (breaking all limits) if inputs have 6+ confirmations', function(done) {
-          helpers.stubUtxos(server, wallet, ['2c 2000bit'].concat(_.times(20, function() {
-            return '100bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, ['2c 2000bit'].concat(new Array(20).fill('100bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6025,7 +5938,7 @@ describe('Wallet service', function() {
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
-              _.every(txp.inputs, function(input) {
+              txp.inputs.every(function(input) {
                 return input == 100e2;
               });
               done();
@@ -6052,9 +5965,7 @@ describe('Wallet service', function() {
           });
         });
         it('should ignore utxos too small to pay for fee', function(done) {
-          helpers.stubUtxos(server, wallet, ['1c200bit', '200bit'].concat(_.times(20, function() {
-            return '1bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, ['1c200bit', '200bit'].concat(new Array(20).fill('1bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6072,9 +5983,7 @@ describe('Wallet service', function() {
           });
         });
         it('should ignore utxos not economically worth to send and fail if not enough utxos to cover fees', function(done) {
-          helpers.stubUtxos(server, wallet, [].concat(_.times(20, function() {
-            return '10bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, [].concat(new Array(20).fill('10bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6091,9 +6000,7 @@ describe('Wallet service', function() {
           });
         });
         it('should use small utxos if fee is low', function(done) {
-          helpers.stubUtxos(server, wallet, [].concat(_.times(10, function() {
-            return '30bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, [].concat(new Array(10).fill('30bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6123,7 +6030,7 @@ describe('Wallet service', function() {
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               txp.inputs.length.should.equal(1);
-              (_.sumBy(txp.inputs, 'satoshis') - txp.outputs[0].amount - txp.fee).should.equal(0);
+              (txp.inputs.reduce((sum, i) => sum += i.satoshis, 0) - txp.outputs[0].amount - txp.fee).should.equal(0);
               var changeOutput = ChainService.getBitcoreTx(txp).getChangeOutput();
               should.not.exist(changeOutput);
               done();
@@ -6131,9 +6038,7 @@ describe('Wallet service', function() {
           });
         });
         it('should ignore small utxos if fee is higher', function(done) {
-          helpers.stubUtxos(server, wallet, [].concat(_.times(10, function() {
-            return '30bit';
-          })), function() {
+          helpers.stubUtxos(server, wallet, [].concat(new Array(10).fill('30bit')), function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -6207,7 +6112,7 @@ describe('Wallet service', function() {
         });
       });
     };
-  });
+  }
 
   describe('#createTX Segwit tests', () => {
     var server, wallet;
@@ -6990,7 +6895,7 @@ describe('Wallet service', function() {
           }, function(err, notes) {
             should.not.exist(err);
             notes.length.should.equal(2);
-            _.difference(_.map(notes, 'txid'), ['123', '456']).should.be.empty;
+            _.difference(notes.map(n => n.txid), ['123', '456']).should.be.empty;
             next();
           });
         },
@@ -7294,16 +7199,17 @@ describe('Wallet service', function() {
     });
     it('should return inputs in random order', function(done) {
       // NOTE: this test has a chance of failing of 1 in 1'073'741'824 :P
-      helpers.stubUtxos(server, wallet, _.range(1, 31), function(utxos) {
+      const range1to30 = new Array(30).fill(0).map((_, i) => i + 1);
+      helpers.stubUtxos(server, wallet, range1to30, function(utxos) {
         server.getSendMaxInfo({
           feePerKb: 100e2,
           returnInputs: true
         }, function(err, info) {
           should.not.exist(err);
           should.exist(info);
-          var amounts = _.map(info.inputs, 'satoshis');
+          var amounts = info.inputs.map(i => i.satoshis);
           amounts.length.should.equal(30);
-          _.every(amounts, function(amount, i) {
+          amounts.every(function(amount, i) {
             if (i == 0) return true;
             return amount < amounts[i - 1];
           }).should.be.false;
@@ -7410,7 +7316,7 @@ describe('Wallet service', function() {
       Defaults.MAX_TX_SIZE_IN_KB_BTC = 2;
       Defaults.MAX_TX_SIZE_IN_KB_ETH = 2;
       Defaults.MAX_TX_SIZE_IN_KB_XRP = 2;
-      helpers.stubUtxos(server, wallet, _.range(1, 10, 0), function() {
+      helpers.stubUtxos(server, wallet, new Array(9).fill(1), function() {
         server.getSendMaxInfo({
           feePerKb: 10000,
           returnInputs: true,
@@ -8139,7 +8045,8 @@ describe('Wallet service', function() {
       helpers.createAndJoinWallet(2, 2, function(s, w) {
         server = s;
         wallet = w;
-        helpers.stubUtxos(server, wallet, _.range(1, 9), function() {
+        const range1to8 = new Array(8).fill(0).map((_, i) => i + 1);
+        helpers.stubUtxos(server, wallet, range1to8, function() {
           var txOpts = {
             outputs: [{
               toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -8401,7 +8308,8 @@ describe('Wallet service', function() {
         helpers.createAndJoinWallet(2, 3, function(s, w) {
           server = s;
           wallet = w;
-          helpers.stubUtxos(server, wallet, _.range(1, 9), function() {
+          const range1to8 = new Array(8).fill(0).map((_, i) => i + 1);
+          helpers.stubUtxos(server, wallet, range1to8, function() {
             var txOpts = {
               outputs: [{
                 toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -8501,7 +8409,7 @@ describe('Wallet service', function() {
           var tx = txs[0];
           tx.id.should.equal(txid);
 
-          var signatures = _.take(helpers.clientSign(tx, TestData.copayers[0].xPrivKey_44H_0H_0H), tx.inputs.length - 1);
+          var signatures = helpers.clientSign(tx, TestData.copayers[0].xPrivKey_44H_0H_0H).slice(0, tx.inputs.length - 1);
           server.signTx({
             txProposalId: txid,
             signatures: signatures,
@@ -8913,7 +8821,8 @@ describe('Wallet service', function() {
       helpers.createAndJoinWallet(2, 3, function(s, w) {
         server = s;
         wallet = w;
-        helpers.stubUtxos(server, wallet, _.range(1, 9), function() {
+        const range1to8 = new Array(8).fill(0).map((_, i) => i + 1);
+        helpers.stubUtxos(server, wallet, range1to8, function() {
           done();
         });
       });
@@ -8996,7 +8905,7 @@ describe('Wallet service', function() {
             action.type.should.equal('accept');
             server.getNotifications({}, function(err, notifications) {
               should.not.exist(err);
-              var last = _.last(notifications);
+              var last = notifications[notifications.length - 1];
               last.type.should.not.equal('TxProposalFinallyAccepted');
               next(null, txp);
             });
@@ -9026,7 +8935,7 @@ describe('Wallet service', function() {
             txp.actions.length.should.equal(2);
             server.getNotifications({}, function(err, notifications) {
               should.not.exist(err);
-              var last = _.last(notifications);
+              var last = notifications[notifications.length - 1];
               last.type.should.equal('TxProposalFinallyAccepted');
               last.walletId.should.equal(wallet.id);
               last.creatorId.should.equal(wallet.copayers[1].id);
@@ -9193,7 +9102,8 @@ describe('Wallet service', function() {
       helpers.createAndJoinWallet(1, 1, function(s, w) {
         server = s;
         wallet = w;
-        helpers.stubUtxos(server, wallet, _.range(1, 11), function() {
+        const range1to10 = new Array(10).fill(0).map((_, i) => i + 1);
+        helpers.stubUtxos(server, wallet, range1to10, function() {
           var txOpts = {
             outputs: [{
               toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -9202,7 +9112,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-          async.eachSeries(_.range(10), function(i, next) {
+          async.eachSeries(new Array(10).fill(0), function(i, next) {
             clock.tick(10 * 1000);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
 
@@ -9224,7 +9134,7 @@ describe('Wallet service', function() {
         limit: 8
       }, function(err, txps) {
         should.not.exist(err);
-        var times = _.map(txps, 'createdOn');
+        var times = txps.map(txp => txp.createdOn);
         times.should.deep.equal([100, 90, 80, 70, 60]);
         done();
       });
@@ -9235,7 +9145,7 @@ describe('Wallet service', function() {
         limit: 5
       }, function(err, txps) {
         should.not.exist(err);
-        var times = _.map(txps, 'createdOn');
+        var times = txps.map(txp => txp.createdOn);
         times.should.deep.equal([50, 40, 30, 20, 10]);
         done();
       });
@@ -9245,7 +9155,7 @@ describe('Wallet service', function() {
         limit: 4
       }, function(err, txps) {
         should.not.exist(err);
-        var times = _.map(txps, 'createdOn');
+        var times = txps.map(txp => txp.createdOn);
         times.should.deep.equal([100, 90, 80, 70]);
         done();
       });
@@ -9253,7 +9163,7 @@ describe('Wallet service', function() {
     it('should pull all txs', function(done) {
       server.getTxs({}, function(err, txps) {
         should.not.exist(err);
-        var times = _.map(txps, 'createdOn');
+        var times = txps.map(txp => txp.createdOn);
         times.should.deep.equal([100, 90, 80, 70, 60, 50, 40, 30, 20, 10]);
         done();
       });
@@ -9265,7 +9175,7 @@ describe('Wallet service', function() {
           maxTs: 70,
         }, function(err, txps) {
           should.not.exist(err);
-          var times = _.map(txps, 'createdOn');
+          var times = txps.map(txp => txp.createdOn);
           times.should.deep.equal([70, 60, 50]);
           done();
         });
@@ -9281,7 +9191,9 @@ describe('Wallet service', function() {
       helpers.createAndJoinWallet(1, 1, function(s, w) {
         server = s;
         wallet = w;
-        helpers.stubUtxos(server, wallet, _.range(4), function() {
+        clock.tick(25 * 1000);
+        const range0to4 = new Array(4).fill(0).map((_, i) => i);
+        helpers.stubUtxos(server, wallet, range0to4, function() {
           var txOpts = {
             outputs: [{
               toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
@@ -9290,7 +9202,7 @@ describe('Wallet service', function() {
             feePerKb: 100e2,
             message: 'some message',
           };
-          async.eachSeries(_.range(3), function(i, next) {
+          async.eachSeries(new Array(3).fill(0), function(i, next) {
             clock.tick(25 * 1000);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
               next();
@@ -9308,12 +9220,12 @@ describe('Wallet service', function() {
     it('should pull all notifications', function(done) {
       server.getNotifications({}, function(err, notifications) {
         should.not.exist(err);
-        var types = _.map(notifications, 'type');
+        var types = notifications.map(n => n.type);
         types.should.deep.equal(['NewCopayer', 'NewAddress', 'NewAddress', 'NewTxProposal', 'NewTxProposal', 'NewTxProposal']);
-        var walletIds = _.uniq(_.map(notifications, 'walletId'));
+        var walletIds = _.uniq(notifications.map(n => n.walletId));
         walletIds.length.should.equal(1);
         walletIds[0].should.equal(wallet.id);
-        var creators = _.uniq(_.compact(_.map(notifications, 'creatorId')));
+        var creators = _.uniq(notifications.map(n => n.creatorId).filter(c => !!c));
         creators.length.should.equal(1);
         creators[0].should.equal(wallet.copayers[0].id);
         done();
@@ -9326,6 +9238,7 @@ describe('Wallet service', function() {
       helpers.createAndJoinWallet(1, 1, { coin: 'bch' }, function(s, w) {
         s2 = s;
         w2 = w;
+        clock.tick(25 * 1000);
         helpers.createAddresses(s2, w2, 1, 1, function(main, change) {
           addr = main[0].address;
           // Simulate new block notification
@@ -9343,9 +9256,9 @@ describe('Wallet service', function() {
               minTs: +Date.now() - (60 * 1000),
             }, function(err, notifications) {
               should.not.exist(err);
-              var types = _.map(notifications, 'type');
+              var types = notifications.map(n => n.type);
               types.should.deep.equal(['NewCopayer', 'NewIncomingTx']);
-              var walletIds = _.uniq(_.map(notifications, 'walletId'));
+              var walletIds = _.uniq(notifications.map(n => n.walletId));
               walletIds.length.should.equal(1);
               walletIds[0].should.equal(w2.id);
               done();
@@ -9379,9 +9292,9 @@ describe('Wallet service', function() {
             minTs: +Date.now() - (60 * 1000),
           }, function(err, notifications) {
             should.not.exist(err);
-            var types = _.map(notifications, 'type');
+            var types = notifications.map(n => n.type);
             types.should.deep.equal(['NewTxProposal', 'NewTxProposal', 'NewBlock']);
-            var walletIds = _.uniq(_.map(notifications, 'walletId'));
+            var walletIds = _.uniq(notifications.map(n => n.walletId));
             walletIds.length.should.equal(1);
             walletIds[0].should.equal(wallet.id);
             done();
@@ -9394,7 +9307,7 @@ describe('Wallet service', function() {
         minTs: +Date.now() - (60 * 1000),
       }, function(err, notifications) {
         should.not.exist(err);
-        var types = _.map(notifications, 'type');
+        var types = notifications.map(n => n.type);
         types.should.deep.equal(['NewTxProposal', 'NewTxProposal']);
         done();
       });
@@ -9402,14 +9315,14 @@ describe('Wallet service', function() {
     it('should pull notifications after a given notification id', function(done) {
       server.getNotifications({}, function(err, notifications) {
         should.not.exist(err);
-        var from = _.head(_.takeRight(notifications, 2)).id; // second to last
+        var from = notifications.slice(-2)[0].id; // second to last
         server.getNotifications({
           notificationId: from,
           minTs: +Date.now() - (60 * 1000),
         }, function(err, res) {
           should.not.exist(err);
           res.length.should.equal(1);
-          res[0].id.should.equal(_.head(_.takeRight(notifications)).id);
+          res[0].id.should.equal(notifications[notifications.length -1].id);
           done();
         });
       });
@@ -9417,7 +9330,7 @@ describe('Wallet service', function() {
     it('should return empty if no notifications found after a given id', function(done) {
       server.getNotifications({}, function(err, notifications) {
         should.not.exist(err);
-        var from = _.head(_.takeRight(notifications)).id; // last one
+        var from = notifications[notifications.length - 1].id; // last one
         server.getNotifications({
           notificationId: from,
         }, function(err, res) {
@@ -9461,7 +9374,7 @@ describe('Wallet service', function() {
           }, function(err, notifications) {
             should.not.exist(err);
             notifications.length.should.equal(2);
-            var types = _.map(notifications, 'type');
+            var types = notifications.map(n => n.type);
             types.should.deep.equal(['TxProposalAcceptedBy', 'TxProposalFinallyAccepted']);
             done();
           });
@@ -9480,7 +9393,7 @@ describe('Wallet service', function() {
           }, function(err, notifications) {
             should.not.exist(err);
             notifications.length.should.equal(2);
-            var types = _.map(notifications, 'type');
+            var types = notifications.map(n => n.type);
             types.should.deep.equal(['TxProposalRejectedBy', 'TxProposalFinallyRejected']);
             done();
           });
@@ -9506,7 +9419,7 @@ describe('Wallet service', function() {
             }, function(err, notifications) {
               should.not.exist(err);
               notifications.length.should.equal(3);
-              var types = _.map(notifications, 'type');
+              var types = notifications.map(n => n.type);
               types.should.deep.equal(['TxProposalAcceptedBy', 'TxProposalFinallyAccepted', 'NewOutgoingTx']);
               done();
             });
@@ -9536,7 +9449,7 @@ describe('Wallet service', function() {
             }, function(err, notifications) {
               should.not.exist(err);
               notifications.length.should.equal(3);
-              var types = _.map(notifications, 'type');
+              var types = notifications.map(n => n.type);
               types.should.deep.equal(['TxProposalAcceptedBy', 'TxProposalFinallyAccepted', 'NewOutgoingTxByThirdParty']);
               done();
             });
@@ -9782,7 +9695,7 @@ describe('Wallet service', function() {
             server.storage.fetchAddresses(wallet.id, function(err, addresses) {
               should.exist(addresses);
               addresses.length.should.equal(expectedPaths.length);
-              var paths = _.map(addresses, 'path');
+              var paths = addresses.map(n => n.path);
               _.difference(paths, expectedPaths).length.should.equal(0);
               server.createAddress({}, function(err, address) {
                 should.not.exist(err);
@@ -9815,7 +9728,7 @@ describe('Wallet service', function() {
             server.storage.fetchAddresses(wallet.id, function(err, addresses) {
               should.exist(addresses);
               addresses.length.should.equal(expectedPaths.length);
-              var paths = _.map(addresses, 'path');
+              var paths = addresses.map(n => n.path);
               _.difference(paths, expectedPaths).length.should.equal(0);
               server.createAddress({}, function(err, address) {
                 should.not.exist(err);
@@ -10087,7 +10000,7 @@ describe('Wallet service', function() {
             server.storage.fetchAddresses(wallet.id, function(err, addresses) {
               should.exist(addresses);
               addresses.length.should.equal(expectedPaths.length);
-              var paths = _.map(addresses, 'path');
+              var paths = addresses.map(n => n.path);
               _.difference(paths, expectedPaths).length.should.equal(0);
               server.createAddress({}, function(err, address) {
                 should.not.exist(err);

--- a/packages/bitcore-wallet-service/test/utils.js
+++ b/packages/bitcore-wallet-service/test/utils.js
@@ -348,6 +348,58 @@ describe('Utils', function() {
     });
   });
 
+  describe('#sortAsc', function() {
+    it('should sort a simple array', function() {
+      const res = Utils.sortAsc([3, 1, 2]);
+      res.should.deep.equal([1, 2, 3]);
+    });
 
+    it('should sort a simple array with undefined values', function() {
+      const res = Utils.sortAsc([3, undefined, 1, 2, '\uFFFE']);
+      res.should.deep.equal([1, 2, 3, '\uFFFE', undefined]); // undefined should be in last position
+    });
+
+    it('should sort a simple array with bool values', function() {
+      const res = Utils.sortAsc([3, true, 1, true, 2, false]);
+      res.should.deep.equal([false, true, 1, true, 2, 3]); // false is considered as 0, true as 1
+    });
+
+    it('should sort a simple array with NaN values', function() {
+      const res = Utils.sortAsc([3, NaN, 1, 2]);
+      res.should.deep.equal([NaN, 1, 2, 3]); // NaN should be considered 0
+    });
+
+    it('should sort a simple array with null values', function() {
+      const res = Utils.sortAsc([3, 1, null, 2, 0, null]);
+      res.should.deep.equal([null, 0, null, 1, 2, 3]); // null is considered as 0
+    });
+
+    it('should sort an array of objects', function() {
+      const res = Utils.sortAsc([{ a: 3 }, { a: 1 }, { a: 2 }], 'a');
+      res.should.deep.equal([
+        { a: 1 },
+        { a: 2 },
+        { a: 3 }
+      ]);
+    });
+
+    it('should sort an array of objects with priority', function() {
+      const res = Utils.sortAsc([{ a: 2, b: 2 }, { a: 1, b: 3 }, { a: 2, b: 1 }], 'a', 'b');
+      res.should.deep.equal([
+        { a: 1, b: 3 },
+        { a: 2, b: 1 },
+        { a: 2, b: 2 }
+      ]);
+    });
+
+    it('should sort an array of objects with nested key', function() {
+      const res = Utils.sortAsc([{ a: { b: 3 }}, { a: { b: 1 }}, { a: { b: 2 }}], ['a', 'b']);
+      res.should.deep.equal([
+        { a: { b: 1 }},
+        { a: { b: 2 }},
+        { a: { b: 3 }}
+      ]);
+    });
+  });
 
 });


### PR DESCRIPTION
This PR:

* Adds a thorough scanning feature for support wallets to be able to remediate an txs that _should_ be attached to a wallet but for some reason aren't
* Cleans up lodash calls that are easily replaced by native calls (e.g. .filter, .map, .reduce, .slice, loops...)
* Adds types to vars for easier navigation through code