### PR TITLE
fix: update sinon sandbox creation method

### DIFF
--- a/packages/bitcore-wallet-client/test/log.js
+++ b/packages/bitcore-wallet-client/test/log.js
@@ -58,7 +58,7 @@ describe('log utils', function () {
   });
 
   it('should log nothing if logLevel is set to silent', function () {
-    var sandbox = sinon.sandbox.create();
+    var sandbox = sinon.createSandbox();
     var cl = sandbox.stub(console, 'log');
 
     log.setLevel('silent');


### PR DESCRIPTION
I’ve updated the code to use the correct method for creating a sandbox in Sinon. The previous method `sinon.sandbox.create()` has been deprecated and replaced by `sinon.createSandbox()` in newer versions of Sinon.

**Fixed:**
```js
var sandbox = sinon.createSandbox();
```  
This ensures compatibility with current versions of Sinon.