### PR TITLE
[BWC] Allow getNonce for XRP

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -2602,8 +2602,8 @@ export class API extends EventEmitter {
   // */
   getNonce(opts, cb) {
     $.checkArgument(
-      Constants.EVM_CHAINS.includes(opts.chain),
-      'Invalid chain: must be EVM based'
+      [...Constants.EVM_CHAINS, 'xrp'].includes(opts.chain),
+      'Invalid chain: must be XRP or EVM based'
     );
 
     var qs = [];


### PR DESCRIPTION
We want to be able to create xrp proposals client side with predefined nonce's. As a result, getNonce needs to allow xrp.