### PR TITLE
Fix: testnet evm address suffix removal

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -546,7 +546,7 @@ export class EthChain implements IChain {
 
   addressFromStorageTransform(network, address): void {
     if (network != 'livenet') {
-      const x = address.address.indexOf(':' + network);
+      const x = address.address.indexOf(':');
       if (x >= 0) {
         address.address = address.address.substr(0, x);
       }


### PR DESCRIPTION
Older testnet EVM wallet addresses are currently stored in mongo with a `:testnet` suffix for indexing purposes. This suffix is never supposed to reach the client (it is supposed to be removed by the `addressFromStorageTransform` method). But ever since support was added for multiple testnets, the `addressFromStorageTransform` method has begun failing to remove the `:testnet` suffix because it expects the suffix to match the new names of the testnet networks (e.g., sepolia). This PR ensures all suffixes are removed before the address reaches the client.