### PR TITLE
[Libs, BCC] Fix BN conversions; Fix BCC tx list stream

### DIFF
--- a/packages/bitcore-client/bin/wallet-tx-list
+++ b/packages/bitcore-client/bin/wallet-tx-list
@@ -29,6 +29,7 @@ const main = async () => {
     if (raw) {
       list.pipe(process.stdout);
     } else {
+      list.pause(); // Pause list to prevent race condition where it starts streaming while awaiting getCurrencyObj
       const tokenObj = wallet.getTokenObj({ tokenName }); // null if no tokenName provided
       const currencyObj = await utils.getCurrencyObj(wallet.chain, tokenObj?.address);
       let txs = '[';
@@ -47,7 +48,8 @@ const main = async () => {
           }
           done();
         }
-      }))
+      }));
+      list.resume();
     }
   } catch (e) {
     console.error(e);

--- a/packages/bitcore-lib-cash/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib-cash/lib/crypto/ecdsa.js
@@ -212,8 +212,8 @@ const sign = function(hashbuf, privkey, opts) {
   s = toLowS(s);
 
   return new Signature({
-    s: BN.fromBuffer(s.toBuffer({ endian }), { endian }),
-    r: BN.fromBuffer(r.toBuffer({ endian }), { endian }),
+    s: BN.fromBuffer(s.toBuffer()),
+    r: BN.fromBuffer(r.toBuffer()),
     compressed: privkey.publicKey.compressed
   });
 };

--- a/packages/bitcore-lib-doge/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib-doge/lib/crypto/ecdsa.js
@@ -212,8 +212,8 @@ const sign = function(hashbuf, privkey, opts) {
   s = toLowS(s);
 
   return new Signature({
-    s: BN.fromBuffer(s.toBuffer({ endian }), { endian }),
-    r: BN.fromBuffer(r.toBuffer({ endian }), { endian }),
+    s: BN.fromBuffer(s.toBuffer()),
+    r: BN.fromBuffer(r.toBuffer()),
     compressed: privkey.publicKey.compressed
   });
 };

--- a/packages/bitcore-lib-ltc/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib-ltc/lib/crypto/ecdsa.js
@@ -212,8 +212,8 @@ const sign = function(hashbuf, privkey, opts) {
   s = toLowS(s);
 
   return new Signature({
-    s: BN.fromBuffer(s.toBuffer({ endian }), { endian }),
-    r: BN.fromBuffer(r.toBuffer({ endian }), { endian }),
+    s: BN.fromBuffer(s.toBuffer()),
+    r: BN.fromBuffer(r.toBuffer()),
     compressed: privkey.publicKey.compressed
   });
 };

--- a/packages/bitcore-lib/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib/lib/crypto/ecdsa.js
@@ -212,8 +212,8 @@ const sign = function(hashbuf, privkey, opts) {
   s = toLowS(s);
 
   return new Signature({
-    s: BN.fromBuffer(s.toBuffer({ endian }), { endian }),
-    r: BN.fromBuffer(r.toBuffer({ endian }), { endian }),
+    s: BN.fromBuffer(s.toBuffer()),
+    r: BN.fromBuffer(r.toBuffer()),
     compressed: privkey.publicKey.compressed
   });
 };


### PR DESCRIPTION
This PR:
* Fixes an issue when r/s.toBuffer() doesn't take an opts object which potentially causes them to be reversed which produces an invalid sig. We can just remove the endian params since it's not a stored value on the BN instance, so toBuffer() and fromBuffer() will just result in the same buffer moving between BN instances.
* Fixes a race condition in the bitcore-client tx list util

The former is due to the monkey patching of BN.js. I started going down the path of un-monkey patching it, but that was a bigger fix and this is fairly urgent to get out before 10.8.8 becomes more prevalent.