### PR TITLE
[BWS] Fix noisy logs in bws

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -98,6 +98,9 @@ class ChainProxy {
    */
   getChain(coin: string): string {
     try {
+      if (coin === undefined) { // This happens frequently for very old btc wallets/addresses
+        return Defaults.CHAIN;
+      }
       // TODO add a warning that we are not including chain
       let normalizedChain = coin.toLowerCase();
       if (

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3897,7 +3897,7 @@ export class WalletService implements IWalletService {
       tx.actions = proposal.actions.map(action => {
         return _.pick(action, ['createdOn', 'type', 'copayerId', 'copayerName', 'comment']);
       });
-      for (const output of tx.outputs) {
+      for (const output of tx.outputs || []) {
         const query = {
           toAddress: output.address,
           amount: output.amount


### PR DESCRIPTION
This PR:

* Fixes an issue where it's trying to iterate over a nullish `txp.outputs`
* Short circuits getChain() when coin === undefined instead of throwing and logging, which becomes very noisy