### PR TITLE
[BCC] Fix non-mainnet token utils

### DIFF
--- a/packages/bitcore-client/bin/wallet-balance
+++ b/packages/bitcore-client/bin/wallet-balance
@@ -26,7 +26,7 @@ async function main() {
   const { name, path, time, storageType, token: tokenName, account = 0, normalize } = program.opts();
   wallet = await Wallet.loadWallet({ name, path, storageType });
   const tokenObj = wallet.getTokenObj({ tokenName }); // null if no tokenName provided
-  const currencyObj = await utils.getCurrencyObj(wallet.chain, tokenObj?.address);
+  const currencyObj = await utils.getCurrencyObj(wallet.chain, tokenObj?.address, !wallet.isMainnet());
   const currency = currencyObj?.displayCode || tokenName || wallet.chain;
   const decimals = Number(tokenObj?.decimals || currencyObj?.decimals || 0);
   let accountAddress;

--- a/packages/bitcore-client/bin/wallet-send
+++ b/packages/bitcore-client/bin/wallet-send
@@ -32,7 +32,7 @@ const main = async () => {
     const from = await wallet.deriveAddress(account); // only used for non-UTXO chains
     const chain = wallet.chain;
     const tokenObj = wallet.getTokenObj({ tokenName }); // null if no tokenName is provided
-    const currencyObj = await utils.getCurrencyObj(chain, tokenObj?.address);
+    const currencyObj = await utils.getCurrencyObj(chain, tokenObj?.address, !wallet.isMainnet());
     const { decimals } = currencyObj;
     const scale = Math.pow(10, decimals);
     const recipients = [];

--- a/packages/bitcore-client/bin/wallet-tx-list
+++ b/packages/bitcore-client/bin/wallet-tx-list
@@ -31,7 +31,7 @@ const main = async () => {
     } else {
       list.pause(); // Pause list to prevent race condition where it starts streaming while awaiting getCurrencyObj
       const tokenObj = wallet.getTokenObj({ tokenName }); // null if no tokenName provided
-      const currencyObj = await utils.getCurrencyObj(wallet.chain, tokenObj?.address);
+      const currencyObj = await utils.getCurrencyObj(wallet.chain, tokenObj?.address, !wallet.isMainnet());
       let txs = '[';
       list.pipe(new Writable({
         objectMode: true,

--- a/packages/bitcore-client/src/utils.ts
+++ b/packages/bitcore-client/src/utils.ts
@@ -6,9 +6,10 @@ class Utils {
     return new Promise(r => setTimeout(r, ms));
   }
 
-  async getCurrencies(): Promise<any[]> {
+  async getCurrencies(test?: boolean): Promise<any[]> {
+    const baseUrl = process.env.BITPAY_BASEURL || `https://${test ? 'test.' : ''}bitpay.com`;
     const data = await new Promise<string>((resolve, reject) => {
-      https.get('https://bitpay.com/currencies', res => {
+      https.get(`${baseUrl}/currencies`, res => {
         if (res.statusCode !== 200) {
           reject(new Error('Request Failed'));
         }
@@ -22,8 +23,8 @@ class Utils {
     return JSON.parse(data).data;
   }
 
-  async getCurrencyObj(chain: string, contractAddress: string) {
-    const currencies = await this.getCurrencies();
+  async getCurrencyObj(chain: string, contractAddress: string, test?: boolean) {
+    const currencies = await this.getCurrencies(test);
     if (contractAddress) {
       return currencies.find(c => c.chain === chain && c.contractAddress === contractAddress);
     }

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -848,6 +848,10 @@ export class Wallet {
       return 0;
     }
   }
+
+  isMainnet() {
+    return this.network === 'mainnet' || this.network === 'livenet';
+  }
 }
 
 export const AddressTypes = {


### PR DESCRIPTION
This PR:

* Fixes calling getCurrencyObj() with a testnet or regtest wallet