### PR TITLE
[bitcore-client] add a bin for bitcore-wallet to make it a cli

### DIFF
--- a/packages/bitcore-client/package.json
+++ b/packages/bitcore-client/package.json
@@ -5,6 +5,9 @@
   "author": "Justin Langston <nitsujlangston@gmail.com>",
   "main": "./ts_build/src/index.js",
   "types": "./ts_build/src/index.d.ts",
+  "bin": {
+    "bitcore-wallet": "./bin/wallet"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
# What?

* Add a `bin` for bitcore-wallet so you can `npm i -g bitcore-client` and then call `bitcore-wallet`
* Open to other names other then `bitcore-wallet`
