### PR TITLE
[Insight] Fix difficulty calculation

### DIFF
--- a/packages/insight/src/components/block-details.tsx
+++ b/packages/insight/src/components/block-details.tsx
@@ -12,6 +12,7 @@ import {routerFadeIn} from '../utilities/animations';
 import {
   getApiRoot,
   getConvertedValue,
+  getDifficultyFromBits,
   getFee,
   getFormattedDate,
   normalizeParams,
@@ -147,7 +148,7 @@ const BlockDetails: FC<BlockDetailsProps> = ({currency, network, block}) => {
                 <SharedTile title='Merkle Root' description={summary.merkleRoot} />
                 <SharedTile
                   title='Difficulty'
-                  description={(0x1d00ffff / summary.bits).toString()}
+                  description={getDifficultyFromBits(summary.bits).toString()}
                 />
                 <SharedTile title='Bits' description={summary.bits} />
                 <SharedTile title='Size (bytes)' description={summary.size} />

--- a/packages/insight/src/utilities/helper-methods.ts
+++ b/packages/insight/src/utilities/helper-methods.ts
@@ -182,3 +182,9 @@ export const getLib = (currency: string) => {
       return BitcoreLibLtc;
   }
 };
+
+export const getDifficultyFromBits = (bits: number) => {
+  const maxBody = Math.log(0x00ffff);
+  const scaland = Math.log(256);
+  return Math.exp(maxBody - Math.log(bits & 0x00ffffff) + scaland * (0x1d - ((bits & 0xff000000) >> 24)));
+}


### PR DESCRIPTION
Recent blocks in the blockchain where showing a difficulty of ~ 1.29. Fixed the difficulty calculation so it now aligns with other block chain explorers like blockchain.com. I used calculations from https://en.bitcoin.it/wiki/Difficulty.