### PR TITLE
Insight Feature: Pill showing chain/network search context

### DIFF
--- a/packages/insight/src/components/search.tsx
+++ b/packages/insight/src/components/search.tsx
@@ -41,6 +41,10 @@ const PillBubble = styled.div`
   border-radius: 25px;
   cursor: pointer;
   background: ${Slate30};
+
+  &:hover {
+    background: #C1C4C7;
+  }
 `
 
 interface SearchProps {

--- a/packages/insight/src/components/search.tsx
+++ b/packages/insight/src/components/search.tsx
@@ -33,12 +33,14 @@ const SearchForm = styled.form<{ borderBottom?: boolean }>`
 
 const PillBubble = styled.div`
   padding: 7px;
-  cursor: pointer;
+  padding-right: 10px;
+  margin-right: 10px;
   display: flex;
   align-items: center;
-  background: ${Slate30};
-  border-radius: 25px;
   height: 40px;
+  border-radius: 25px;
+  cursor: pointer;
+  background: ${Slate30};
 `
 
 interface SearchProps {
@@ -46,6 +48,7 @@ interface SearchProps {
   id?: string;
   setErrorMessage?: any;
 }
+
 const Search: FC<SearchProps> = ({borderBottom, id, setErrorMessage}) => {
   const navigate = useNavigate();
   const theme = useTheme();
@@ -160,7 +163,7 @@ const Search: FC<SearchProps> = ({borderBottom, id, setErrorMessage}) => {
       pill ?
         <PillBubble onClick={() => setPill(false)}>
           <img src={img} style={{height: '120%'}}></img>
-          <p style={{textTransform: 'capitalize', color: Black, padding: '2px'}}>{network}</p>
+          <p style={{textTransform: 'capitalize', color: Black, padding: '2px', paddingLeft: '5px'}}>{network}</p>
         </PillBubble>
       : <></>
     );

--- a/packages/insight/src/components/search.tsx
+++ b/packages/insight/src/components/search.tsx
@@ -7,16 +7,6 @@ import SearchDarkSvg from 'src/assets/images/search-dark.svg';
 import {Black, LightBlack, Slate, Slate30} from '../assets/styles/colors';
 import {useAppSelector} from '../utilities/hooks';
 
-const HeaderChip = styled.div`
-  margin: 0 0.1rem;
-  background-color: ${Slate30};
-  border-radius: 25px;
-  padding: 0.2rem 0.5rem;
-  color: ${Black};
-  text-transform: capitalize;
-  font-size: 14px;
-`;
-
 const SearchInput = styled.input`
   background: no-repeat scroll 7px 7px;
   padding-left: 2px;
@@ -40,6 +30,16 @@ const SearchForm = styled.form<{ borderBottom?: boolean }>`
   border-bottom: ${({borderBottom, theme: {colors}}) =>
     borderBottom ? `1px solid ${colors.borderColor}` : 'none'};
 `;
+
+const PillBubble = styled.div`
+  padding: 7px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  background: ${Slate30};
+  border-radius: 25px;
+  height: 40px;
+`
 
 interface SearchProps {
   borderBottom?: boolean;
@@ -158,10 +158,10 @@ const Search: FC<SearchProps> = ({borderBottom, id, setErrorMessage}) => {
   const Pill: FC<{img?: string, network: string }> = ({ img, network }) => {
     return (
       pill ?
-        <span onClick={() => setPill(false)} style={{cursor: 'pointer', display: 'flex', alignItems: 'center', padding: '2px'}}>
-          <img src={img} style={{padding: '5px', height: '39px'}}></img>
-          <HeaderChip>{network}</HeaderChip>
-        </span>
+        <PillBubble onClick={() => setPill(false)}>
+          <img src={img} style={{height: '120%'}}></img>
+          <p style={{textTransform: 'capitalize', color: Black, padding: '2px'}}>{network}</p>
+        </PillBubble>
       : <></>
     );
   }


### PR DESCRIPTION
Added a pill next to the insight search bar showing the bitcoin currency and network the search will be in.  
![image](https://github.com/user-attachments/assets/badbd5d3-61c6-4082-8481-f170839ceb48)
The pill can be removed by clicking it.
![image](https://github.com/user-attachments/assets/6a398db1-b538-46d8-ac43-b1de8a388449)
It works on all chains.
![image](https://github.com/user-attachments/assets/4b5f508c-6a0d-49e9-9e39-26a1e365e1a0)