### PR TITLE
Draft: [BWS] Refresh transaction proposal on publish

### DIFF
--- a/packages/bitcore-wallet-service/src/externalServices/oneInch.ts
+++ b/packages/bitcore-wallet-service/src/externalServices/oneInch.ts
@@ -119,6 +119,7 @@ export class OneInchService {
           arb: 42161,
           base: 8453,
           op: 10,
+          sol: 501
         };
 
         const chainId = chainIdMap[chain];

--- a/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/btc/index.ts
@@ -1013,4 +1013,8 @@ export class BtcChain implements IChain {
   getReserve(server: WalletService, wallet: IWallet, cb: (err?, reserve?: number) => void) {
     return cb(null, 0);
   }
+
+  refreshTxData(_server: WalletService, txp, _opts, cb) {
+    return cb(null, txp);
+  }
 }

--- a/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/eth/index.ts
@@ -648,4 +648,8 @@ export class EthChain implements IChain {
   getReserve(server: WalletService, wallet: IWallet, cb: (err?, reserve?: number) => void) {
     return cb(null, 0);
   }
+
+  refreshTxData(_server: WalletService, txp, _opts, cb) {
+    return cb(null, txp);
+  }
 }

--- a/packages/bitcore-wallet-service/src/lib/chain/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/index.ts
@@ -73,6 +73,7 @@ export interface IChain {
   onCoin(coin: any): INotificationData | null;
   onTx(tx: any): INotificationData | null;
   getReserve(server: WalletService, wallet: IWallet, cb: (err?, reserve?: number) => void);
+  refreshTxData(server: WalletService, txp: ITxProposal, opts: { noCashAddr: boolean } & any, cb);
 }
 
 const chains: { [chain: string]: IChain } = {
@@ -221,6 +222,10 @@ class ChainProxy {
 
   getReserve(server: WalletService, wallet: IWallet, cb: (err?, reserve?: number) => void) {
     return this.get(wallet.chain).getReserve(server, wallet, cb);
+  }
+
+  refreshTxData(server, txp, opts, cb) {
+    return this.get(txp.chain).refreshTxData(server, txp, opts, cb);
   }
 }
 

--- a/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
@@ -267,8 +267,8 @@ export class SolChain implements IChain {
     });
   }
 
-  refreshTxData(server: WalletService, txp, _opts, cb) {
-    if (txp.blockHeight || txp.blockHash) {
+  refreshTxData(server: WalletService, txp, opts, cb) {
+    if ((txp.blockHeight || txp.blockHash) && opts.refresh) {
       server._getBlockchainHeight(txp.chain, txp.network, (err, height, hash) => {
         if (err) return cb(err);
         txp.blockHeight = height;

--- a/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
@@ -267,9 +267,23 @@ export class SolChain implements IChain {
     });
   }
 
+  refreshTxData(server: WalletService, txp, _opts, cb) {
+    if (txp.blockHeight || txp.blockHash) {
+      server._getBlockchainHeight(txp.chain, txp.network, (err, height, hash) => {
+        if (err) return cb(err);
+        txp.blockHeight = height;
+        txp.blockHash = hash;
+        return cb(null, txp);
+      });
+    } else {
+      return cb(null, txp);
+    }
+  }
+
   getReserve(server: WalletService, wallet: IWallet, cb: (err?, reserve?: number) => void) {
     return cb(null, 0);
   }
+
   getSizeSafetyMargin() {
     return 0;
   }

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -310,4 +310,8 @@ export class XrpChain implements IChain {
       return cb(null, reserve);
     });
   }
+
+  refreshTxData(_server: WalletService, txp, _opts, cb) {
+    return cb(null, txp);
+  }
 }

--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -280,10 +280,10 @@ export const Defaults = {
   BALANCE_CACHE_DURATION: 10,
 
   // Cache time for blockchain height (in ms)
-  // this is actually erased on 'new block' notifications
-  // so, 30m seems fine
-  BLOCKHEIGHT_CACHE_TIME: 30 * 60 * 1000,
-
+  BLOCKHEIGHT_CACHE_TIME: {
+    default: 30 * 60 * 1000, // this is erased on 'new block' notifications so, 30m seems fine
+    sol: 5 * 1000 // 5 seconds - Solana needs to maintain the freshes blockheight to land txs consistently
+  },
   // Cache time fee levels (in ms)
   FEE_LEVEL_CACHE_DURATION: 6 * 60 * 1000,
 

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -89,6 +89,8 @@ export interface ITxProposal {
   category?: string;
   priorityFee?: number;
   computeUnits?: number;
+  refreshOnPublish?: boolean;
+  prePublishRaw?: string;
 }
 
 export class TxProposal {
@@ -168,6 +170,8 @@ export class TxProposal {
   category?: string;
   priorityFee?: number;
   computeUnits?: number;
+  refreshOnPublish?: boolean;
+  prePublishRaw?: string;
 
   static create(opts) {
     opts = opts || {};
@@ -281,6 +285,8 @@ export class TxProposal {
     x.computeUnits = opts.computeUnits;
     x.priorityFee = opts.priorityFee;
 
+    x.refreshOnPublish = opts.refreshOnPublish;
+
     return x;
   }
 
@@ -366,6 +372,9 @@ export class TxProposal {
     x.category = obj.category; // kind of transaction: transfer, account creation, nonce creation, etc
     x.computeUnits = obj.computeUnits;
     x.priorityFee = obj.priorityFee;
+
+    x.refreshOnPublish = obj.refreshOnPublish;
+    x.prePublishRaw = obj.prePublishRaw;
 
     if (x.status == 'broadcasted') {
       x.raw = obj.raw;
@@ -501,6 +510,10 @@ export class TxProposal {
 
   reject(copayerId, reason) {
     this.addAction(copayerId, 'reject', reason);
+  }
+
+  isRepublishEnabled() {
+    return !!this.refreshOnPublish
   }
 
   isTemporary() {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3675,10 +3675,7 @@ export class WalletService implements IWalletService {
 
   _getBlockchainHeight(chain, network, cb) {
     const cacheKey = Storage.BCHEIGHT_KEY + ':' + chain + ':' + network;
-    let cacheTime = Defaults.BLOCKHEIGHT_CACHE_TIME;
-    if (chain.toLowerCase() === 'sol') {
-      cacheTime = 5 * 1000; // 5 seconds - Solana needs to maintain the freshes blockheight to land txs consistently
-    }
+    const cacheTime = Defaults.BLOCKHEIGHT_CACHE_TIME[chain.toLowerCase()] || Defaults.BLOCKHEIGHT_CACHE_TIME.default;
 
     this.storage.checkAndUseGlobalCache(cacheKey, cacheTime, (err, values) => {
       if (err) return cb(err);

--- a/packages/bitcore-wallet-service/test/integration/history.js
+++ b/packages/bitcore-wallet-service/test/integration/history.js
@@ -382,11 +382,11 @@ describe('History', function() {
 
     it('should get tx history from cache and bc mixed, updating confirmations', function(done) {
       var _cache = Defaults.CONFIRMATIONS_TO_START_CACHING;
-      var _time = Defaults.BLOCKHEIGHT_CACHE_TIME ;
+      var _time = Defaults.BLOCKHEIGHT_CACHE_TIME.default ;
       Defaults.CONFIRMATIONS_TO_START_CACHING = 10;
 
       // remove bc tip cache.
-      Defaults.BLOCKHEIGHT_CACHE_TIME = 0;
+      Defaults.BLOCKHEIGHT_CACHE_TIME = { default: 0 };
       helpers.stubHistory(50, BCHEIGHT); //(0->49)
 
       // this call is to fill the cache
@@ -405,7 +405,7 @@ describe('History', function() {
             tx.confirmations.should.equal(i + heightOffset);
             i++;
           });
-          Defaults.BLOCKHEIGHT_CACHE_TIME = _time;
+          Defaults.BLOCKHEIGHT_CACHE_TIME.default = _time;
           Defaults.CONFIRMATIONS_TO_START_CACHING = _cache;
           done();
         });

--- a/packages/crypto-wallet-core/src/derivation/sol/index.ts
+++ b/packages/crypto-wallet-core/src/derivation/sol/index.ts
@@ -1,6 +1,6 @@
 import { encoding, HDPrivateKey } from 'bitcore-lib';
 import * as ed25519 from 'ed25519-hd-key';
-import { default as Deriver, IDeriver, Key } from '..';
+import { DeriverProxy, IDeriver, Key } from '..';
 
 export class SolDeriver implements IDeriver {
   deriveAddress(_network, _xpubkey, _addressIndex, _isChange) {
@@ -30,7 +30,7 @@ export class SolDeriver implements IDeriver {
 
   derivePrivateKey(network, xPriv, addressIndex, isChange, addressType) {
     const changeNum = isChange ? 1 : 0;
-    const pathPrefix = Deriver.pathFor('SOL', network, addressIndex);
+    const pathPrefix = new DeriverProxy().pathFor('SOL', network, addressIndex);
     const path = `${pathPrefix}/${changeNum}'`;
     return this.derivePrivateKeyWithPath(network, xPriv, path, addressType);
   };


### PR DESCRIPTION
This PR allows a transaction proposal to refresh relevant data on publish.* This is helpful for Solana transactions. Recent blockhash's are necessary to send transactions but blockhash's become invalid after 1 minute. Transaction proposals that sit become stale quickly hence the need for a refresh mechanism.

This PR also allows proposals to be published more than once. This will allow refreshes as needed. For a proposal to be republished it will need `refreshOnPublish: true` set on txp creation. This is set automatically for Solana txps that do not use nonces. Additionally, we save the original raw tx pre refresh for verification consistency. 

With these changes it is recommended to run publish before signing and broadcasting for all BWS assisted Solana transactions.

Additional Changes
- decreasing Solana blockheight cache to maintain fresh data
- adding Solana to 1inch mapping

***This feature will also allow better nonce management for EVM chains as we can update the proposal with a desired nonce right before signing.