### PR TITLE
[BCW] Make bitcore-wallet private to bypass publish

### DIFF
--- a/packages/bitcore-wallet/package.json
+++ b/packages/bitcore-wallet/package.json
@@ -3,6 +3,7 @@
   "description": "A CLI Mutisig HD Bitcoin Wallet, demo for Bitcore Wallet Service",
   "author": "BitPay Inc",
   "version": "10.9.3",
+  "private": true,
   "keywords": [
     "bitcoin",
     "copay",


### PR DESCRIPTION
`bitcore-wallet` is unmaintained and needs to be skipped when publishing.