### PR TITLE
[Libs] Support common address type strings

### DIFF
--- a/packages/bitcore-lib-cash/lib/address.js
+++ b/packages/bitcore-lib-cash/lib/address.js
@@ -70,8 +70,11 @@ function Address(data, network, type) {
     throw new TypeError('Second argument must be "livenet", "testnet", or "regtest".');
   }
 
-  if (type && (type !== Address.PayToPublicKeyHash && type !== Address.PayToScriptHash)) {
-    throw new TypeError('Third argument must be "pubkeyhash" or "scripthash".');
+  if (type) {
+    if (!Address.isValid(type)) {
+      throw new TypeError('Third argument must be one of: "' + Address.AllTypes.join('", "') + '".');
+    }
+    type = Address.TypesMap[type.toLowerCase()];
   }
 
   var info = this._classifyArguments(data, network, type);
@@ -116,10 +119,31 @@ Address.prototype._classifyArguments = function(data, network, type) {
   }
 };
 
-/** @static */
+Address.TypesMap = {};
+
 Address.PayToPublicKeyHash = 'pubkeyhash';
-/** @static */
+Address.PayToPublicKeyHashAlt = 'p2pkh';
+Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
+Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
+Address.isPayToPublicKeyHash = function(type) {
+  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToScriptHash = 'scripthash';
+Address.PayToScriptHashAlt = 'p2sh';
+Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
+Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
+Address.isPayToScriptHash = function(type) {
+  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+};
+
+Address.isValidType = function(type) {
+  return Address.isPayToPublicKeyHash(type) ||
+    Address.isPayToScriptHash(type);
+};
+
+Address.AllTypes = Object.keys(Address.TypesMap);
+
 
 /**
  * @param {Buffer} hash - An instance of a hash Buffer
@@ -586,7 +610,7 @@ Address.isValid = function(data, network, type) {
  * @return boolean
  */
 Address.prototype.isPayToPublicKeyHash = function() {
-  return this.type === Address.PayToPublicKeyHash;
+  return this.type === Address.isPayToPublicKeyHash;
 };
 
 /**

--- a/packages/bitcore-lib-cash/lib/address.js
+++ b/packages/bitcore-lib-cash/lib/address.js
@@ -71,7 +71,7 @@ function Address(data, network, type) {
   }
 
   if (type) {
-    if (!Address.isValid(type)) {
+    if (!Address.isValidType(type)) {
       throw new TypeError('Third argument must be one of: "' + Address.AllTypes.join('", "') + '".');
     }
     type = Address.TypesMap[type.toLowerCase()];
@@ -126,7 +126,7 @@ Address.PayToPublicKeyHashAlt = 'p2pkh';
 Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
 Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
 Address.isPayToPublicKeyHash = function(type) {
-  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToScriptHash = 'scripthash';
@@ -134,7 +134,7 @@ Address.PayToScriptHashAlt = 'p2sh';
 Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
 Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
 Address.isPayToScriptHash = function(type) {
-  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type.toLowerCase());
 };
 
 Address.isValidType = function(type) {
@@ -610,7 +610,7 @@ Address.isValid = function(data, network, type) {
  * @return boolean
  */
 Address.prototype.isPayToPublicKeyHash = function() {
-  return this.type === Address.isPayToPublicKeyHash;
+  return this.type === Address.PayToPublicKeyHash;
 };
 
 /**

--- a/packages/bitcore-lib-cash/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/lib/transaction/transaction.js
@@ -758,6 +758,7 @@ Transaction.prototype.hasAllUtxoInfo = function() {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.fee = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._fee = amount;
   this._updateChangeOutput();
@@ -773,6 +774,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
+  amount = parseFloat(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -789,6 +791,7 @@ Transaction.prototype.feePerKb = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerByte = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();
@@ -821,6 +824,7 @@ Transaction.prototype.change = function(address) {
  * @return {Transaction} this, for chaining
  */
  Transaction.prototype.escrow = function(address, amount) {
+  amount = parseInt(amount);
   $.checkArgument(this.inputs.length > 0, 'inputs must have already been set when setting escrow');
   $.checkArgument(this.outputs.length > 0, 'non-change outputs must have already been set when setting escrow');
   $.checkArgument(!this.getChangeOutput(), 'change must still be unset when setting escrow');
@@ -870,10 +874,8 @@ Transaction.prototype.to = function(address, amount) {
     return this;
   }
 
-  $.checkArgument(
-    JSUtil.isNaturalNumber(amount),
-    'Amount is expected to be a positive integer'
-  );
+  amount = parseInt(amount);
+  $.checkArgument(JSUtil.isNaturalNumber(amount), 'Amount is expected to be a positive integer');
   this.addOutput(new Output({
     script: Script(new Address(address)),
     satoshis: amount

--- a/packages/bitcore-lib-cash/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-cash/lib/transaction/transaction.js
@@ -774,7 +774,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
-  amount = parseFloat(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -791,7 +791,7 @@ Transaction.prototype.feePerKb = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerByte = function(amount) {
-  amount = parseInt(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();

--- a/packages/bitcore-lib-cash/test/address.js
+++ b/packages/bitcore-lib-cash/test/address.js
@@ -37,7 +37,7 @@ describe('Address', function() {
   it('should throw an error because of bad type param', function() {
     (function() {
       return new Address(PKHLivenet[0], 'livenet', 'pubkey');
-    }).should.throw('Third argument must be "pubkeyhash" or "scripthash"');
+    }).should.throw('Third argument must be one of: "pubkeyhash", "p2pkh", "scripthash", "p2sh".');
   });
 
   describe('bitcoind compliance', function() {

--- a/packages/bitcore-lib-cash/test/publickey.js
+++ b/packages/bitcore-lib-cash/test/publickey.js
@@ -359,11 +359,11 @@ describe('PublicKey', function() {
       ['L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g', 'CTtcbLKQtFW3tR4x2ADdqrbiJVfZQD9cFm']
     ];
 
-    data.forEach(function(d){
+    for (const d of data) {
       var publicKey = PrivateKey.fromWIF(d[0]).toPublicKey();
       var address = Address.fromString(d[1]);
       address.hashBuffer.should.deep.equal(publicKey._getID());
-    });
+    }
 
   });
 

--- a/packages/bitcore-lib-doge/lib/address.js
+++ b/packages/bitcore-lib-doge/lib/address.js
@@ -122,7 +122,7 @@ Address.PayToPublicKeyHashAlt = 'p2pkh';
 Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
 Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
 Address.isPayToPublicKeyHash = function(type) {
-  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToScriptHash = 'scripthash';
@@ -130,7 +130,7 @@ Address.PayToScriptHashAlt = 'p2sh';
 Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
 Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
 Address.isPayToScriptHash = function(type) {
-  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type.toLowerCase());
 };
 
 Address.isValidType = function(type) {

--- a/packages/bitcore-lib-doge/lib/address.js
+++ b/packages/bitcore-lib-doge/lib/address.js
@@ -66,8 +66,11 @@ function Address(data, network, type) {
     throw new TypeError('Second argument must be "livenet" or "testnet".');
   }
 
-  if (type && (type !== Address.PayToPublicKeyHash && type !== Address.PayToScriptHash)) {
-    throw new TypeError('Third argument must be "pubkeyhash" or "scripthash".');
+  if (type) {
+    if (!Address.isValidType(type)) {
+      throw new TypeError('Third argument must be one of: "' + Address.AllTypes.join('", "') + '".');
+    }
+    type = Address.TypesMap[type.toLowerCase()];
   }
 
   var info = this._classifyArguments(data, network, type);
@@ -112,10 +115,30 @@ Address.prototype._classifyArguments = function(data, network, type) {
   }
 };
 
-/** @static */
+Address.TypesMap = {};
+
 Address.PayToPublicKeyHash = 'pubkeyhash';
-/** @static */
+Address.PayToPublicKeyHashAlt = 'p2pkh';
+Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
+Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
+Address.isPayToPublicKeyHash = function(type) {
+  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToScriptHash = 'scripthash';
+Address.PayToScriptHashAlt = 'p2sh';
+Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
+Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
+Address.isPayToScriptHash = function(type) {
+  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+};
+
+Address.isValidType = function(type) {
+  return Address.isPayToPublicKeyHash(type) ||
+    Address.isPayToScriptHash(type);
+};
+
+Address.AllTypes = Object.keys(Address.TypesMap);
 
 /**
  * @param {Buffer} hash - An instance of a hash Buffer

--- a/packages/bitcore-lib-doge/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-doge/lib/transaction/transaction.js
@@ -808,7 +808,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
-  amount = parseFloat(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -825,7 +825,7 @@ Transaction.prototype.feePerKb = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerByte = function(amount) {
-  amount = parseInt(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();

--- a/packages/bitcore-lib-doge/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-doge/lib/transaction/transaction.js
@@ -792,6 +792,7 @@ Transaction.prototype.hasAllUtxoInfo = function() {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.fee = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._fee = amount;
   this._updateChangeOutput();
@@ -807,6 +808,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
+  amount = parseFloat(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -822,7 +824,8 @@ Transaction.prototype.feePerKb = function(amount) {
  * @param {number} amount satoshis per Byte to be sent
  * @return {Transaction} this, for chaining
  */
-Transaction.prototype.feePerByte = function (amount) {
+Transaction.prototype.feePerByte = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();
@@ -882,10 +885,8 @@ Transaction.prototype.to = function(address, amount) {
     return this;
   }
 
-  $.checkArgument(
-    JSUtil.isNaturalNumber(amount),
-    'Amount is expected to be a positive integer'
-  );
+  amount = parseInt(amount);
+  $.checkArgument(JSUtil.isNaturalNumber(amount), 'Amount is expected to be a positive integer');
   this.addOutput(new Output({
     script: Script(new Address(address)),
     satoshis: amount

--- a/packages/bitcore-lib-doge/test/address.js
+++ b/packages/bitcore-lib-doge/test/address.js
@@ -35,7 +35,7 @@ describe('Address', function() {
   it('should throw an error because of bad type param', function() {
     (function() {
       return new Address(PKHLivenet[0], 'livenet', 'pubkey');
-    }).should.throw('Third argument must be "pubkeyhash" or "scripthash"');
+    }).should.throw('Third argument must be one of: "pubkeyhash", "p2pkh", "scripthash", "p2sh".');
   });
 
   describe('bitcoind compliance', function() {

--- a/packages/bitcore-lib-ltc/lib/address.js
+++ b/packages/bitcore-lib-ltc/lib/address.js
@@ -129,7 +129,7 @@ Address.PayToPublicKeyHashAlt = 'p2pkh';
 Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
 Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
 Address.isPayToPublicKeyHash = function(type) {
-  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type.toLowerCase());
 };
 /** @static */
 Address.PayToScriptHash = 'scripthash';
@@ -137,7 +137,7 @@ Address.PayToScriptHashAlt = 'p2sh';
 Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
 Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
 Address.isPayToScriptHash = function(type) {
-  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type.toLowerCase());
 };
 /** @static */
 Address.PayToWitnessPublicKeyHash = 'witnesspubkeyhash';
@@ -145,7 +145,7 @@ Address.PayToWitnessPublicKeyHashAlt = 'p2wpkh';
 Address.TypesMap[Address.PayToWitnessPublicKeyHash] = Address.PayToWitnessPublicKeyHash;
 Address.TypesMap[Address.PayToWitnessPublicKeyHashAlt] = Address.PayToWitnessPublicKeyHash;
 Address.isPayToWitnessPublicKeyHash = function(type) {
-  return [Address.PayToWitnessPublicKeyHash, Address.PayToWitnessPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToWitnessPublicKeyHash, Address.PayToWitnessPublicKeyHashAlt].includes(type.toLowerCase());
 };
 /** @static */
 Address.PayToWitnessScriptHash = 'witnessscripthash';
@@ -153,7 +153,7 @@ Address.PayToWitnessScriptHashAlt = 'p2wsh';
 Address.TypesMap[Address.PayToWitnessScriptHash] = Address.PayToWitnessScriptHash;
 Address.TypesMap[Address.PayToWitnessScriptHashAlt] = Address.PayToWitnessScriptHash;
 Address.isPayToWitnessScriptHash = function(type) {
-  return [Address.PayToWitnessScriptHash, Address.PayToWitnessScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToWitnessScriptHash, Address.PayToWitnessScriptHashAlt].includes(type.toLowerCase());
 };
 
 Address.isValidType = function(type) {
@@ -349,7 +349,7 @@ Address._transformScript = function(script, network) {
  */
 Address.createMultisig = function(publicKeys, threshold, network, nestedWitness, type) {
   network = network || publicKeys[0].network || Networks.defaultNetwork;
-  if (type && !Address.PayToScriptHash(type) && !Address.PayToWitnessScriptHash(type)) {
+  if (type && !Address.isPayToScriptHash(type) && !Address.isPayToWitnessScriptHash(type)) {
     throw new TypeError('Type must be either scripthash or witnessscripthash to create multisig.');
   }
   if (nestedWitness || Address.isPayToWitnessScriptHash(type)) {

--- a/packages/bitcore-lib-ltc/lib/publickey.js
+++ b/packages/bitcore-lib-ltc/lib/publickey.js
@@ -363,11 +363,12 @@ PublicKey.prototype._getID = function _getID() {
  * Will return an address for the public key
  *
  * @param {String|Network=} network - Which network should the address be for
+ * @param {string} type - Either 'pubkeyhash', 'witnesspubkeyhash', or 'scripthash'
  * @returns {Address} An address generated from the public key
  */
-PublicKey.prototype.toAddress = function(network) {
+PublicKey.prototype.toAddress = function(network, type) {
   var Address = require('./address');
-  return Address.fromPublicKey(this, network || this.network);
+  return Address.fromPublicKey(this, network || this.network, type);
 };
 
 /**

--- a/packages/bitcore-lib-ltc/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/transaction.js
@@ -743,7 +743,8 @@ Transaction.prototype.addInput = function(input, outputScript, satoshis) {
   }
   if (!input.output && outputScript && satoshis != null) {
     outputScript = outputScript instanceof Script ? outputScript : new Script(outputScript);
-    $.checkArgumentType(satoshis, 'number', 'satoshis');
+    satoshis = parseInt(satoshis);
+    $.checkArgument(JSUtil.isNaturalNumber(satoshis), 'satoshis must be a natural number');
     input.output = new Output({
       script: outputScript,
       satoshis: satoshis
@@ -787,6 +788,7 @@ Transaction.prototype.hasAllUtxoInfo = function() {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.fee = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._fee = amount;
   this._updateChangeOutput();
@@ -802,6 +804,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
+  amount = parseFloat(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -817,7 +820,8 @@ Transaction.prototype.feePerKb = function(amount) {
  * @param {number} amount satoshis per Byte to be sent
  * @return {Transaction} this, for chaining
  */
-Transaction.prototype.feePerByte = function (amount) {
+Transaction.prototype.feePerByte = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();
@@ -877,10 +881,8 @@ Transaction.prototype.to = function(address, amount) {
     return this;
   }
 
-  $.checkArgument(
-    JSUtil.isNaturalNumber(amount),
-    'Amount is expected to be a positive integer'
-  );
+  amount = parseInt(amount);
+  $.checkArgument(JSUtil.isNaturalNumber(amount), 'Amount is expected to be a positive integer');
   this.addOutput(new Output({
     script: Script(new Address(address)),
     satoshis: amount

--- a/packages/bitcore-lib-ltc/lib/transaction/transaction.js
+++ b/packages/bitcore-lib-ltc/lib/transaction/transaction.js
@@ -804,7 +804,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
-  amount = parseFloat(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -821,7 +821,7 @@ Transaction.prototype.feePerKb = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerByte = function(amount) {
-  amount = parseInt(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();

--- a/packages/bitcore-lib-ltc/test/address.js
+++ b/packages/bitcore-lib-ltc/test/address.js
@@ -36,7 +36,7 @@ describe('Address', function() {
   it('should throw an error because of bad type param', function() {
     (function() {
       return new Address(PKHLivenet[0], 'livenet', 'pubkey');
-    }).should.throw('Third argument must be "pubkeyhash", "scripthash", "witnesspubkeyhash", or "witnessscripthash".');
+    }).should.throw('Third argument must be one of: "pubkeyhash", "p2pkh", "scripthash", "p2sh", "witnesspubkeyhash", "p2wpkh", "witnessscripthash", "p2wsh".');
   });
 
   describe('bitcoind compliance', function() {

--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -128,7 +128,7 @@ Address.PayToPublicKeyHashAlt = 'p2pkh';
 Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
 Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
 Address.isPayToPublicKeyHash = function(type) {
-  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToScriptHash = 'scripthash';
@@ -136,7 +136,7 @@ Address.PayToScriptHashAlt = 'p2sh';
 Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
 Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
 Address.isPayToScriptHash = function(type) {
-  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToWitnessPublicKeyHash = 'witnesspubkeyhash';
@@ -144,7 +144,7 @@ Address.PayToWitnessPublicKeyHashAlt = 'p2wpkh';
 Address.TypesMap[Address.PayToWitnessPublicKeyHash] = Address.PayToWitnessPublicKeyHash;
 Address.TypesMap[Address.PayToWitnessPublicKeyHashAlt] = Address.PayToWitnessPublicKeyHash;
 Address.isPayToWitnessPublicKeyHash = function(type) {
-  return [Address.PayToWitnessPublicKeyHash, Address.PayToWitnessPublicKeyHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToWitnessPublicKeyHash, Address.PayToWitnessPublicKeyHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToWitnessScriptHash = 'witnessscripthash';
@@ -152,7 +152,7 @@ Address.PayToWitnessScriptHashAlt = 'p2wsh';
 Address.TypesMap[Address.PayToWitnessScriptHash] = Address.PayToWitnessScriptHash;
 Address.TypesMap[Address.PayToWitnessScriptHashAlt] = Address.PayToWitnessScriptHash;
 Address.isPayToWitnessScriptHash = function(type) {
-  return [Address.PayToWitnessScriptHash, Address.PayToWitnessScriptHashAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToWitnessScriptHash, Address.PayToWitnessScriptHashAlt].includes(type.toLowerCase());
 };
 
 Address.PayToTaproot = 'taproot';
@@ -160,7 +160,7 @@ Address.PayToTaprootAlt = 'p2tr';
 Address.TypesMap[Address.PayToTaproot] = Address.PayToTaproot;
 Address.TypesMap[Address.PayToTaprootAlt] = Address.PayToTaproot;
 Address.isPayToTaproot = function(type) {
-  return [Address.PayToTaproot, Address.PayToTaprootAlt].includes(type?.toLowerCase?.());
+  return typeof type === 'string' && [Address.PayToTaproot, Address.PayToTaprootAlt].includes(type.toLowerCase());
 };
 
 Address.isValidType = function(type) {
@@ -421,7 +421,7 @@ Address._transformString = function(data, network, type) {
     var info = Address._transformBuffer(Buffer.from(data, 'utf8'), network, type);
     return info;
   } catch (e) {
-    if (Address.PayToWitnessPublicKeyHash(type) || Address.isPayToWitnessScriptHash(type) || Address.isPayToTaproot(type)) {
+    if (Address.isPayToWitnessPublicKeyHash(type) || Address.isPayToWitnessScriptHash(type) || Address.isPayToTaproot(type)) {
       throw e;
     }
   }

--- a/packages/bitcore-lib/lib/address.js
+++ b/packages/bitcore-lib/lib/address.js
@@ -72,13 +72,11 @@ function Address(data, network, type, multisigType) {
     throw new TypeError('Second argument must be "livenet" or "testnet".');
   }
 
-  if (type && (
-    type !== Address.PayToPublicKeyHash
-    && type !== Address.PayToScriptHash
-    && type !== Address.PayToWitnessPublicKeyHash
-    && type !== Address.PayToWitnessScriptHash
-    && type !== Address.PayToTaproot)) {
-    throw new TypeError('Third argument must be "pubkeyhash", "scripthash", "witnesspubkeyhash", "witnessscripthash", or "taproot".');
+  if (type) {
+    if (!Address.isValidType(type)) {
+      throw new TypeError('Third argument must be one of: "' + Address.AllTypes.join('", "') + '".');
+    }
+    type = Address.TypesMap[type.toLowerCase()];
   }
 
   var info = this._classifyArguments(data, network, type);
@@ -123,16 +121,63 @@ Address.prototype._classifyArguments = function(data, network, type) {
   }
 };
 
-/** @static */
+Address.TypesMap = {};
+
 Address.PayToPublicKeyHash = 'pubkeyhash';
-/** @static */
+Address.PayToPublicKeyHashAlt = 'p2pkh';
+Address.TypesMap[Address.PayToPublicKeyHash] = Address.PayToPublicKeyHash;
+Address.TypesMap[Address.PayToPublicKeyHashAlt] = Address.PayToPublicKeyHash;
+Address.isPayToPublicKeyHash = function(type) {
+  return [Address.PayToPublicKeyHash, Address.PayToPublicKeyHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToScriptHash = 'scripthash';
-/** @static */
+Address.PayToScriptHashAlt = 'p2sh';
+Address.TypesMap[Address.PayToScriptHash] = Address.PayToScriptHash;
+Address.TypesMap[Address.PayToScriptHashAlt] = Address.PayToScriptHash;
+Address.isPayToScriptHash = function(type) {
+  return [Address.PayToScriptHash, Address.PayToScriptHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToWitnessPublicKeyHash = 'witnesspubkeyhash';
-/** @static */
+Address.PayToWitnessPublicKeyHashAlt = 'p2wpkh';
+Address.TypesMap[Address.PayToWitnessPublicKeyHash] = Address.PayToWitnessPublicKeyHash;
+Address.TypesMap[Address.PayToWitnessPublicKeyHashAlt] = Address.PayToWitnessPublicKeyHash;
+Address.isPayToWitnessPublicKeyHash = function(type) {
+  return [Address.PayToWitnessPublicKeyHash, Address.PayToWitnessPublicKeyHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToWitnessScriptHash = 'witnessscripthash';
-/** @static */
+Address.PayToWitnessScriptHashAlt = 'p2wsh';
+Address.TypesMap[Address.PayToWitnessScriptHash] = Address.PayToWitnessScriptHash;
+Address.TypesMap[Address.PayToWitnessScriptHashAlt] = Address.PayToWitnessScriptHash;
+Address.isPayToWitnessScriptHash = function(type) {
+  return [Address.PayToWitnessScriptHash, Address.PayToWitnessScriptHashAlt].includes(type?.toLowerCase?.());
+};
+
 Address.PayToTaproot = 'taproot';
+Address.PayToTaprootAlt = 'p2tr';
+Address.TypesMap[Address.PayToTaproot] = Address.PayToTaproot;
+Address.TypesMap[Address.PayToTaprootAlt] = Address.PayToTaproot;
+Address.isPayToTaproot = function(type) {
+  return [Address.PayToTaproot, Address.PayToTaprootAlt].includes(type?.toLowerCase?.());
+};
+
+Address.isValidType = function(type) {
+  return Address.isPayToPublicKeyHash(type) ||
+    Address.isPayToScriptHash(type) ||
+    Address.isPayToWitnessPublicKeyHash(type) ||
+    Address.isPayToWitnessScriptHash(type) ||
+    Address.isPayToTaproot(type);
+};
+
+Address.isValidMultisigType = function(type) {
+  return Address.isPayToScriptHash(type) ||
+    Address.isPayToWitnessScriptHash(type);
+};
+
+Address.AllTypes = Object.keys(Address.TypesMap);
+
 
 /**
  * @param {Buffer} hash - An instance of a hash Buffer
@@ -281,15 +326,15 @@ Address._transformPublicKey = function(pubkey, network, type) {
   if (!(pubkey instanceof PublicKey)) {
     throw new TypeError('Address must be an instance of PublicKey.');
   }
-  if (type && type !== Address.PayToScriptHash && type !== Address.PayToWitnessPublicKeyHash && type !== Address.PayToPublicKeyHash && type !== Address.PayToTaproot) {
+  if (type && !Address.isPayToScriptHash(type) && !Address.isPayToWitnessPublicKeyHash(type) && !Address.isPayToPublicKeyHash(type) && !Address.isPayToTaproot(type)) {
     throw new TypeError('Type must be either pubkeyhash, witnesspubkeyhash, scripthash, or taproot to transform public key.');
   }
-  if (!pubkey.compressed && (type === Address.PayToScriptHash || type === Address.PayToWitnessPublicKeyHash)) {
+  if (!pubkey.compressed && (Address.isPayToScriptHash(type) || Address.isPayToWitnessPublicKeyHash(type))) {
     throw new TypeError('Witness addresses must use compressed public keys.');
   }
-  if (type === Address.PayToScriptHash) {
+  if (Address.isPayToScriptHash(type)) {
     info.hashBuffer = Hash.sha256ripemd160(Script.buildWitnessV0Out(pubkey).toBuffer());
-  } else if (type === Address.PayToTaproot) {
+  } else if (Address.isPayToTaproot(type)) {
     info.hashBuffer = pubkey.createTapTweak().tweakedPubKey;
   } else {
     info.hashBuffer = Hash.sha256ripemd160(pubkey.toBuffer());
@@ -330,10 +375,10 @@ Address._transformScript = function(script, network) {
  */
 Address.createMultisig = function(publicKeys, threshold, network, nestedWitness, type) {
   network = network || publicKeys[0].network || Networks.defaultNetwork;
-  if (type && type !== Address.PayToScriptHash && type !== Address.PayToWitnessScriptHash) {
+  if (type && !Address.isPayToScriptHash(type) && !Address.isPayToWitnessScriptHash(type)) {
     throw new TypeError('Type must be either scripthash or witnessscripthash to create multisig.');
   }
-  if (nestedWitness || type === Address.PayToWitnessScriptHash) {
+  if (nestedWitness || Address.isPayToWitnessScriptHash(type)) {
     publicKeys = _.map(publicKeys, PublicKey);
     for (var i = 0; i < publicKeys.length; i++) {
       if (!publicKeys[i].compressed) {
@@ -376,7 +421,7 @@ Address._transformString = function(data, network, type) {
     var info = Address._transformBuffer(Buffer.from(data, 'utf8'), network, type);
     return info;
   } catch (e) {
-    if (type === Address.PayToWitnessPublicKeyHash || type === Address.PayToWitnessScriptHash || type === Address.PayToTaproot) {
+    if (Address.PayToWitnessPublicKeyHash(type) || Address.isPayToWitnessScriptHash(type) || Address.isPayToTaproot(type)) {
       throw e;
     }
   }
@@ -423,7 +468,7 @@ Address.fromPublicKeyHash = function(hash, network) {
 Address.fromScriptHash = function(hash, network, type) {
   $.checkArgument(hash, 'hash parameter is required');
   var info = Address._transformHash(hash);
-  if (type === Address.PayToWitnessScriptHash && hash.length !== 32) {
+  if (Address.isPayToWitnessScriptHash(type) && hash.length !== 32) {
       throw new TypeError('Address hashbuffer must be exactly 32 bytes for v0 witness script hash.');
   }
   var type = type || Address.PayToScriptHash;
@@ -445,7 +490,7 @@ Address.payingTo = function(script, network, type) {
   $.checkArgument(script, 'script is required');
   $.checkArgument(script instanceof Script, 'script must be instance of Script');
   var hash;
-  if (type === Address.PayToWitnessScriptHash) {
+  if (Address.isPayToWitnessScriptHash(type)) {
     hash = Hash.sha256(script.toBuffer());
   } else {
     hash = Hash.sha256ripemd160(script.toBuffer());

--- a/packages/bitcore-lib/lib/transaction/transaction.js
+++ b/packages/bitcore-lib/lib/transaction/transaction.js
@@ -810,7 +810,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
-  amount = parseFloat(amount);
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -827,7 +827,7 @@ Transaction.prototype.feePerKb = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerByte = function(amount) {
-  amount = parseInt(amount)
+  amount = parseFloat(amount); // fee rate can be a fractional number (float)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();

--- a/packages/bitcore-lib/lib/transaction/transaction.js
+++ b/packages/bitcore-lib/lib/transaction/transaction.js
@@ -749,7 +749,8 @@ Transaction.prototype.addInput = function(input, outputScript, satoshis) {
   }
   if (!input.output && outputScript && satoshis != null) {
     outputScript = outputScript instanceof Script ? outputScript : new Script(outputScript);
-    $.checkArgumentType(satoshis, 'number', 'satoshis');
+    satoshis = parseInt(satoshis);
+    $.checkArgument(JSUtil.isNaturalNumber(satoshis), 'satoshis must be a natural number');
     input.output = new Output({
       script: outputScript,
       satoshis: satoshis
@@ -793,6 +794,7 @@ Transaction.prototype.hasAllUtxoInfo = function() {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.fee = function(amount) {
+  amount = parseInt(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._fee = amount;
   this._updateChangeOutput();
@@ -808,6 +810,7 @@ Transaction.prototype.fee = function(amount) {
  * @return {Transaction} this, for chaining
  */
 Transaction.prototype.feePerKb = function(amount) {
+  amount = parseFloat(amount);
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerKb = amount;
   this._updateChangeOutput();
@@ -823,7 +826,8 @@ Transaction.prototype.feePerKb = function(amount) {
  * @param {number} amount satoshis per Byte to be sent
  * @return {Transaction} this, for chaining
  */
-Transaction.prototype.feePerByte = function (amount) {
+Transaction.prototype.feePerByte = function(amount) {
+  amount = parseInt(amount)
   $.checkArgument(!isNaN(amount), 'amount must be a number');
   this._feePerByte = amount;
   this._updateChangeOutput();
@@ -883,10 +887,8 @@ Transaction.prototype.to = function(address, amount) {
     return this;
   }
 
-  $.checkArgument(
-    JSUtil.isNaturalNumber(amount),
-    'Amount is expected to be a positive integer'
-  );
+  amount = parseInt(amount);
+  $.checkArgument(JSUtil.isNaturalNumber(amount), 'Amount is expected to be a positive integer');
   this.addOutput(new Output({
     script: Script(new Address(address)),
     satoshis: amount

--- a/packages/bitcore-lib/test/address.js
+++ b/packages/bitcore-lib/test/address.js
@@ -36,7 +36,7 @@ describe('Address', function() {
   it('should throw an error because of bad type param', function() {
     (function() {
       return new Address(PKHLivenet[0], 'livenet', 'pubkey');
-    }).should.throw('Third argument must be "pubkeyhash", "scripthash", "witnesspubkeyhash", "witnessscripthash", or "taproot".');
+    }).should.throw('Third argument must be one of: "pubkeyhash", "p2pkh", "scripthash", "p2sh", "witnesspubkeyhash", "p2wpkh", "witnessscripthash", "p2wsh", "taproot", "p2tr".');
   });
 
   describe('bitcoind compliance', function() {

--- a/packages/bitcore-lib/test/address_witness.js
+++ b/packages/bitcore-lib/test/address_witness.js
@@ -30,7 +30,7 @@ describe('Witness Address', function() {
   it('should throw an error because of bad type param', function() {
     (function() {
       return new Address(P2WPKHLivenet[0], 'livenet', 'pubkey');
-    }).should.throw('Third argument must be "pubkeyhash", "scripthash", "witnesspubkeyhash", "witnessscripthash", or "taproot".');
+    }).should.throw('Third argument must be one of: "pubkeyhash", "p2pkh", "scripthash", "p2sh", "witnesspubkeyhash", "p2wpkh", "witnessscripthash", "p2wsh", "taproot", "p2tr".');
   });
 
   // livenet valid


### PR DESCRIPTION
This PR:

* Adds non-breaking support for common address type strings (e.g. "p2sh", "p2pkh") - case insensitive 
* Add better input checks for amounts (to support string or bigint amounts)
* Adds type to LTC public key `toAddress()` method


Example:
```
const lib = require('bitcore-lib');
const pk1 = new lib.PrivateKey('c56f1e5775c6b74771167f3100c415465b1d4a2dc7f1c09583d7ffd4e4bbcdd5');

pk1.publicKey.toAddress('mainnet', 'scripthash');
pk1.publicKey.toAddress('mainnet', 'P2SH');
// 3DLsJvY9hxn4xEL68WmYHAT9PtyR1swRJo

pk1.publicKey.toAddress('mainnet', 'pubkeyhash');
pk1.publicKey.toAddress('mainnet', 'p2pkh');
// 1Jbc5ngop22vnKQKX6FnYBxsdoCbX8M5ji

pk1.publicKey.toAddress('mainnet', 'witnesspubkeyhash');
pk1.publicKey.toAddress('mainnet', 'p2WpKh');
// bc1qcyzezquxscm4xj7l3gwwttudrynk6hs7gzgcr0

pk1.publicKey.toAddress('mainnet', 'taproot');
pk1.publicKey.toAddress('mainnet', 'p2tr');
// bc1p7zrgt6r79zr4xkf05udqlxm339kz4z4esmy8u6utxkyyw24dfhwqn399l7
```