### PR TITLE
[BWS] feat(templates): removes horizontal rule from email

### DIFF
--- a/packages/bitcore-wallet-service/templates/en/new_outgoing_tx.html
+++ b/packages/bitcore-wallet-service/templates/en/new_outgoing_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     A Payment of {{amount}} has been sent from your wallet.
-</div> 
+</div>


### PR DESCRIPTION
## Changes

- Removes the line between the header copy and description copy
- formats to add a newline to the eof

<img width="665" height="630" alt="image" src="https://github.com/user-attachments/assets/3489297a-d292-4dbb-b4b1-f92ab254ff73" />

## Testing notes for reviewer

1. Ensure dependencies are up to date in bitcore repo: `npm install`
2. run Bitcore Wallet Service locally in `/packages/bitcore-wallet-service`
```sh
npm start && tail -f logs/bws.log
```
3. Navigate to `bitcore/packages/bitcore-wallet-service/src/scripts` in a new tab
4. Run the following script with your email:
```sh
node preview-email.js new_outgoing_tx en send <your_email>@bitpay.com
```
5. A new browser window will open with the preview.
6. The `<hr/>` should be removed