### PR TITLE
[BWS] Add feePerKb to Solana getFee

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
@@ -90,7 +90,7 @@ export class SolChain implements IChain {
   getFee(server, wallet, opts) {
     return new Promise(resolve => {
       const numSignatures = opts.numSignatures || 1;
-      const feePerKb = 5000; // Fee per signature in lamports
+      const feePerKb = Defaults.SOL_BASE_FEE; // Fee per signature in lamports
       const fee = feePerKb * numSignatures;
       return resolve({ fee, feePerKb });
     });
@@ -179,7 +179,7 @@ export class SolChain implements IChain {
       if (err) return cb(err);
       const { availableAmount } = balance;
       const sigs = opts.numSignatures || 1;
-      let fee = sigs * 5000
+      const fee = sigs * Defaults.SOL_BASE_FEE
       return cb(null, {
         utxosBelowFee: 0,
         amountBelowFee: 0,

--- a/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/sol/index.ts
@@ -89,8 +89,10 @@ export class SolChain implements IChain {
 
   getFee(server, wallet, opts) {
     return new Promise(resolve => {
-      const numSignatures = opts.signatures || 1;
-      return resolve({ fee: 5000 * numSignatures });
+      const numSignatures = opts.numSignatures || 1;
+      const feePerKb = 5000; // Fee per signature in lamports
+      const fee = feePerKb * numSignatures;
+      return resolve({ fee, feePerKb });
     });
   }
 
@@ -176,7 +178,7 @@ export class SolChain implements IChain {
     server.getBalance({}, (err, balance) => {
       if (err) return cb(err);
       const { availableAmount } = balance;
-      const sigs = opts.signatures || 1;
+      const sigs = opts.numSignatures || 1;
       let fee = sigs * 5000
       return cb(null, {
         utxosBelowFee: 0,

--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -412,6 +412,8 @@ export const Defaults = {
   // SOL has a non-refundable rent fee / balance
   MIN_SOL_BALANCE: 1002240,
 
+  SOL_BASE_FEE: 5000,
+
   // Time to get the latest push notification subscriptions. In ms.
   PUSH_NOTIFICATION_SUBS_TIME: 10 * 60 * 1000, // 10 min.
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -2575,7 +2575,7 @@ export class WalletService implements IWalletService {
    * @param {string} opts.memo - Optional. Solana transaction memo
    * @param {number} opts.decimals - Optional. Numbet of decimal of a desited token
    * @param {string} opts.fromAta - Optional. ATA addres of the sender (Solana)
-   * * @param {number} opts.numSignatures - Optional. Number of signatures required for the transation. For Solana fee calculation.
+   * @param {number} opts.numSignatures - Optional. Number of signatures required for the transation. For Solana fee calculation.
    * @param {Boolean} opts.refreshOnPublish - Optional. Allows publish function to refresh txp data
    * @returns {TxProposal} Transaction proposal. outputs address format will use the same format as inpunt.
    */

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -2355,7 +2355,8 @@ export class WalletService implements IWalletService {
             {
               feePerKb: opts.feePerKb,
               excludeUnconfirmedUtxos: !!opts.excludeUnconfirmedUtxos,
-              returnInputs: true
+              returnInputs: true,
+              numSignatures: opts.numSignatures
             },
             (err, info) => {
               if (err) return next(err);
@@ -2574,6 +2575,7 @@ export class WalletService implements IWalletService {
    * @param {string} opts.memo - Optional. Solana transaction memo
    * @param {number} opts.decimals - Optional. Numbet of decimal of a desited token
    * @param {string} opts.fromAta - Optional. ATA addres of the sender (Solana)
+   * * @param {number} opts.numSignatures - Optional. Number of signatures required for the transation. For Solana fee calculation.
    * @param {Boolean} opts.refreshOnPublish - Optional. Allows publish function to refresh txp data
    * @returns {TxProposal} Transaction proposal. outputs address format will use the same format as inpunt.
    */


### PR DESCRIPTION
This PR sets Solana's base fee as the feePerKb for the chain. This value does not change. Solana's fee structure charges a base fee per signature as opposed to transaction size used in UTXO and computation needs (e.g gas used) EVM chains. 

There is only one `Fee Level` implemented for Solana. There are no benefits for increasing the fee (e.g speeding up a transaction) therefore no additional fee levels are needed. Faster transactions are achieved through the priority fee  which is an optional params on for Solana BWS transactions proposals. You can get a priority fee based on percentile relative to all other priority fees using the Bitcore Node api endpoint `/api/SOL/:network/priorityFee/:percentile`

