### PR TITLE
[BWS] feat(templates): removes horizontal rule from emails

### DIFF
--- a/packages/bitcore-wallet-service/templates/en/new_incoming_tx.html
+++ b/packages/bitcore-wallet-service/templates/en/new_incoming_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     You have received a payment of {{amount}}{{networkStr}}. The transaction is still unconfirmed.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/en/new_outgoing_tx.html
+++ b/packages/bitcore-wallet-service/templates/en/new_outgoing_tx.html
@@ -10,4 +10,4 @@
 
 <div class="content-text">
     A Payment of {{amount}} has been sent from your wallet.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/es/new_incoming_tx.html
+++ b/packages/bitcore-wallet-service/templates/es/new_incoming_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     Recibió un pago de {{amount}}{{networkStr}}. La transacción aún no está confirmada.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/es/new_outgoing_tx.html
+++ b/packages/bitcore-wallet-service/templates/es/new_outgoing_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     Un pago de {{amount}} ha sido enviado de su billetera.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/fr/new_incoming_tx.html
+++ b/packages/bitcore-wallet-service/templates/fr/new_incoming_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     Vous avez reçu un paiement de {{amount}}{{networkStr}}. La transaction n'est toujours pas confirmée.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/fr/new_outgoing_tx.html
+++ b/packages/bitcore-wallet-service/templates/fr/new_outgoing_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     Un paiement de {{amount}} a été envoyé de votre portefeuille.
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/ja/new_incoming_tx.html
+++ b/packages/bitcore-wallet-service/templates/ja/new_incoming_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     {{amount}}{{networkStr}}の支払いを受け取りました。 トランザクションはまだ確認されていません。
-</div> 
+</div>

--- a/packages/bitcore-wallet-service/templates/ja/new_outgoing_tx.html
+++ b/packages/bitcore-wallet-service/templates/ja/new_outgoing_tx.html
@@ -6,8 +6,6 @@
     {{title}}
 </h1>
 
-<div class="divider"></div>
-
 <div class="content-text">
     {{amount}}のビットコインがウォレットから送金されました。
-</div> 
+</div>


### PR DESCRIPTION
## Changes

- Removes the line between the header copy and description copy
- formats to add a newline to the eof

## Testing notes for reviewer

1. Ensure dependencies are up to date in bitcore repo: `npm install`
2. run Bitcore Wallet Service locally in `/packages/bitcore-wallet-service`
```sh
npm start && tail -f logs/bws.log
```
3. Navigate to `bitcore/packages/bitcore-wallet-service/src/scripts` in a new tab
4. Run the following script with your email:
```sh
node preview-email.js new_outgoing_tx en send <your_email>@bitpay.com
```
5. A new browser window will open with the preview.
6. The `<hr/>` should be removed