### PR TITLE
[BCN] Add balance at time method for EVM

### DIFF
--- a/packages/bitcore-node/src/models/cache.ts
+++ b/packages/bitcore-node/src/models/cache.ts
@@ -60,7 +60,7 @@ export class CacheModel extends BaseModel<ICache<any>> {
       return found.value as T;
     } else {
       // cache miss
-      this.collection.remove({ _id: found._id });
+      this.collection.deleteOne({ _id: found._id });
       return null;
     }
   }
@@ -75,7 +75,7 @@ export class CacheModel extends BaseModel<ICache<any>> {
       return found.value as T;
     } else {
       // cache miss
-      this.collection.remove({ _id: found._id });
+      this.collection.deleteOne({ _id: found._id });
       return null;
     }
   }

--- a/packages/bitcore-node/test/integration/ethereum/csp.spec.ts
+++ b/packages/bitcore-node/test/integration/ethereum/csp.spec.ts
@@ -134,7 +134,7 @@ describe('Ethereum API', function() {
         gasPrice: 10 * 1e9
       } as IEVMTransactionInProcess;
     });
-    await CacheStorage.collection.remove({});
+    await CacheStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.insertMany(txs);
     const estimates = await Promise.all([1, 2, 3, 4].map(target => ETH.getFee({ network, target })));
@@ -155,7 +155,7 @@ describe('Ethereum API', function() {
         gasPrice: 10 * 1e9
       } as IEVMTransactionInProcess;
     });
-    await CacheStorage.collection.remove({})
+    await CacheStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.insertMany(txs);
     let estimates = await Promise.all([1, 2, 3, 4].map(target => ETH.getFee({ network, target })));

--- a/packages/bitcore-node/test/integration/matic/csp.spec.ts
+++ b/packages/bitcore-node/test/integration/matic/csp.spec.ts
@@ -99,7 +99,7 @@ describe('Polygon/MATIC API', function() {
         gasPrice: 10 * 1e9
       } as IEVMTransactionInProcess;
     });
-    await CacheStorage.collection.remove({});
+    await CacheStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.insertMany(txs);
     const estimates = await Promise.all([1, 2, 3, 4].map(target => MATIC.getFee({ network, target })));
@@ -120,7 +120,7 @@ describe('Polygon/MATIC API', function() {
         gasPrice: 10 * 1e9
       } as IEVMTransactionInProcess;
     });
-    await CacheStorage.collection.remove({})
+    await CacheStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.deleteMany({});
     await EVMTransactionStorage.collection.insertMany(txs);
     let estimates = await Promise.all([1, 2, 3, 4].map(target => MATIC.getFee({ network, target })));


### PR DESCRIPTION
This PR:

* Adds a `getWalletBalanceAtTime()` method to the EVM CSP
* Updates deprecated mongodb `remove()` method to `deleteOne`/`deleteMany`