### PR TITLE
[BWS] Fix paths after tests typscripting; fix SOL republish sig

### DIFF
--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -477,7 +477,7 @@ const Config = (): any => {
 
   // Override default values with bws.config.js' values, if present
   try {
-    const bwsConfig = require('../bws.config');
+    const bwsConfig = require('../../bws.config');
     defaultConfig = _.merge(defaultConfig, bwsConfig);
   } catch {
     logger.info('bws.config.js not found, using default configuration values');

--- a/packages/bitcore-wallet-service/src/lib/model/copayer.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/copayer.ts
@@ -24,7 +24,7 @@ export interface ICopayer {
     key: string;
     signature: string;
   }>;
-  customData: any;
+  customData?: any;
   walletId: string;
   isSupportStaff?: boolean;
   isMarketingStaff?: boolean;
@@ -47,7 +47,7 @@ export class Copayer {
     key: string;
     signature: string;
   }>;
-  customData: any;
+  customData?: any;
   addressManager: AddressManager;
   walletId: string;
   isSupportStaff?: boolean;

--- a/packages/bitcore-wallet-service/src/lib/model/wallet.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/wallet.ts
@@ -51,7 +51,7 @@ export interface IWallet<isSharedT = boolean | (() => boolean)> {
   derivationStrategy: string;
   addressType: string;
   addressManager: IAddressManager;
-  scanStatus?: 'error' | 'success';
+  scanStatus?: 'error' | 'success' | 'running';
   beRegistered: boolean; // Block explorer registered
   beAuthPrivateKey2?: string;
   beAuthPublicKey2?: string;
@@ -84,7 +84,7 @@ export class Wallet implements IWallet<() => boolean> {
   derivationStrategy: string;
   addressType: string;
   addressManager: AddressManager;
-  scanStatus?: 'error' | 'success';
+  scanStatus?: 'error' | 'success' | 'running';
   beRegistered: boolean; // Block explorer registered
   beAuthPrivateKey2?: string;
   beAuthPublicKey2?: string;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -473,9 +473,9 @@ export class WalletService implements IWalletService {
 
   _runLocked(cb, task, waitTime?: number) {
     $.checkState(this.walletId, 'Failed state: this.walletId undefined at <_runLocked()>');
-
     this.lock.runLocked(this.walletId, { waitTime }, cb, task);
   }
+
   logi(message, ...args) {
     if (typeof message === 'string' && args.length > 0 && !message.endsWith('%o')) {
       for (let i = 0; i < args.length; i++) {
@@ -735,7 +735,7 @@ export class WalletService implements IWalletService {
    * @param {Object} opts
    * @returns {Object} wallet
    */
-  getWallet(opts, cb) {
+  getWallet(opts, cb: (err: Error, wallet?: Wallet) => void) {
     this.storage.fetchWallet(this.walletId, (err, wallet) => {
       if (err) return cb(err);
       if (!wallet) return cb(Errors.WALLET_NOT_FOUND);
@@ -829,7 +829,7 @@ export class WalletService implements IWalletService {
     opts = opts || {};
 
     const status: {
-      wallet?: IWallet;
+      wallet?: Partial<IWallet>;
       serverMessage?: {
         title: string;
         body: string;
@@ -856,7 +856,7 @@ export class WalletService implements IWalletService {
     async.parallel(
       [
         next => {
-          this.getWallet({}, (err, wallet) => {
+          this.getWallet({}, (err, wallet: Partial<Wallet>) => {
             if (err) return next(err);
             if (this._upgradeNeeded(UPGRADES.SOL_bwc_$lt_10_10_12, wallet)) {
               return next(Errors.UPGRADE_NEEDED);
@@ -873,7 +873,7 @@ export class WalletService implements IWalletService {
               wallet = _.omit(wallet, walletExtendedKeys);
               wallet.copayers = (wallet.copayers || []).map(copayer => {
                 return _.omit(copayer, copayerExtendedKeys);
-              });
+              }) as Copayer[];
             }
             status.wallet = wallet;
 
@@ -2907,15 +2907,18 @@ export class WalletService implements IWalletService {
               raw = txp.prePublishRaw;
               signingKey = this._getSigningKey(raw, opts.proposalSignature, copayer.requestPubKeys);
             }
-            if (!signingKey) {
-              return cb(new ClientError('Invalid proposal signature'));
-            }
           }
+          if (!signingKey) {
+            return cb(new ClientError('Invalid proposal signature'));
+          }
+
           // Save signature info for other copayers to check
-          txp.proposalSignature = opts.proposalSignature;
-          if (signingKey.selfSigned) {
-            txp.proposalSignaturePubKey = signingKey.key;
-            txp.proposalSignaturePubKeySig = signingKey.signature;
+          if (!txp.proposalSignature) { // May already be set if republishing
+            txp.proposalSignature = opts.proposalSignature;
+            if (signingKey.selfSigned) {
+              txp.proposalSignaturePubKey = signingKey.key;
+              txp.proposalSignaturePubKeySig = signingKey.signature;
+            }
           }
 
           ChainService.checkTxUTXOs(this, txp, opts, err => {

--- a/packages/bitcore-wallet-service/start-docker.sh
+++ b/packages/bitcore-wallet-service/start-docker.sh
@@ -4,12 +4,12 @@
 mkdir -p logs
 
 # Run each service and redirect output to log files
-node ./ts_build/messagebroker/messagebroker.js > logs/messagebroker.log 2>&1 &
-node ./ts_build/bcmonitor/bcmonitor.js > logs/bcmonitor.log 2>&1 &
-node ./ts_build/emailservice/emailservice.js > logs/emailservice.log 2>&1 &
-node ./ts_build/pushnotificationsservice/pushnotificationsservice.js > logs/pushnotificationsservice.log 2>&1 &
-node ./ts_build/fiatrateservice/fiatrateservice.js > logs/fiatrateservice.log 2>&1 &
-node ./ts_build/bws.js > logs/bws.log 2>&1 &
+node ./ts_build/src/messagebroker/messagebroker.js > logs/messagebroker.log 2>&1 &
+node ./ts_build/src/bcmonitor/bcmonitor.js > logs/bcmonitor.log 2>&1 &
+node ./ts_build/src/emailservice/emailservice.js > logs/emailservice.log 2>&1 &
+node ./ts_build/src/pushnotificationsservice/pushnotificationsservice.js > logs/pushnotificationsservice.log 2>&1 &
+node ./ts_build/src/fiatrateservice/fiatrateservice.js > logs/fiatrateservice.log 2>&1 &
+node ./ts_build/src/bws.js > logs/bws.log 2>&1 &
 
 echo "All services started"
 

--- a/packages/bitcore-wallet-service/start.sh
+++ b/packages/bitcore-wallet-service/start.sh
@@ -29,10 +29,10 @@ run_program ()
   fi
 }
 
-run_program ./ts_build/messagebroker/messagebroker.js pids/messagebroker.pid logs/messagebroker.log
-run_program ./ts_build/bcmonitor/bcmonitor.js pids/bcmonitor.pid logs/bcmonitor.log
-run_program ./ts_build/emailservice/emailservice.js pids/emailservice.pid logs/emailservice.log
-run_program ./ts_build/pushnotificationsservice/pushnotificationsservice.js pids/pushnotificationsservice.pid logs/pushnotificationsservice.log
-run_program ./ts_build/fiatrateservice/fiatrateservice.js pids/fiatrateservice.pid logs/fiatrateservice.log
-run_program ./ts_build/bws.js pids/bws.pid logs/bws.log
+run_program ./ts_build/src/messagebroker/messagebroker.js pids/messagebroker.pid logs/messagebroker.log
+run_program ./ts_build/src/bcmonitor/bcmonitor.js pids/bcmonitor.pid logs/bcmonitor.log
+run_program ./ts_build/src/emailservice/emailservice.js pids/emailservice.pid logs/emailservice.log
+run_program ./ts_build/src/pushnotificationsservice/pushnotificationsservice.js pids/pushnotificationsservice.pid logs/pushnotificationsservice.log
+run_program ./ts_build/src/fiatrateservice/fiatrateservice.js pids/fiatrateservice.pid logs/fiatrateservice.log
+run_program ./ts_build/src/bws.js pids/bws.pid logs/bws.log
 


### PR DESCRIPTION
This PR:

* Fixes paths for start script and config file (it changed after tests became typescript which added `src` and `tests` folders to `ts_build`)
* Fixes resetting proposalSignature on republish for SOL txps
* Adds/improves some typing for Wallet