### PR TITLE
[BWS] Fix package version import

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -57,6 +57,7 @@ import {
   Wallet
 } from './model';
 import { Storage } from './storage';
+import { version } from '../../package.json';
 
 let request = _request;
 const $ = singleton();
@@ -196,7 +197,7 @@ export class WalletService implements IWalletService {
    */
   static getServiceVersion() {
     if (!serviceVersion) {
-      serviceVersion = 'bws-' + require('../../package').version;
+      serviceVersion = 'bws-' + version;
     }
 
     return serviceVersion;


### PR DESCRIPTION
This PR:

* Fixes the package version import. Previously, you could start the server, but if you called any API endpoint it would throw an error (e.g. `http://localhost:3232/bws/api/v1/stats`)