### PR TITLE
README Fixes: Contributors link, replaced Bitcore Wallet -> Bitcore CLI, moved Bitpay Wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <img alt="npm" src="https://img.shields.io/npm/v/bitcore-lib">
   <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/bitpay/bitcore">
   <a href="https://opensource.org/licenses/MIT/" target="_blank"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-blue.svg" style="display: inherit;"/></a>
+  <a href="https://github.com/bitpay/bitcore/graphs/contributors"> 
   <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bitpay/bitcore">
   <br>
  <img src="https://circleci.com/gh/bitpay/bitcore.svg?style=shield" alt="master build">

--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@
 ## Applications
 
 - [Bitcore Node](packages/bitcore-node) - A standardized API to interact with multiple blockchain networks
-- [Bitcore Wallet](packages/bitcore-wallet) - **DEPRECATED** A command-line based wallet client
 - [Bitcore Wallet Client](packages/bitcore-wallet-client) - A client for the wallet service
 - [Bitcore Wallet Service](packages/bitcore-wallet-service) - A multisig HD service for wallets
-- [Bitpay Wallet](https://github.com/bitpay/bitpay-app) - An easy-to-use, multiplatform, multisignature, secure wallet for bitcoin, ethereum, and more
+- [Bitcore CLI](packages/bitcore-cli) - A command line interface for using BWS and BWC
 - [Insight](packages/insight) - A blockchain explorer web user interface
 
 ## Libraries
@@ -38,6 +37,7 @@
 
 - [Bitcore Build](packages/bitcore-build) - A helper to add tasks to gulp
 - [Bitcore Client](packages/bitcore-client) - A helper to create a wallet using the bitcore-node infrastructure
+- [Bitpay/Bitpay App](https://github.com/bitpay/bitpay-app) - An easy-to-use, multiplatform, multisignature, secure wallet for bitcoin, ethereum, and more
 
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
   <img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/bitpay/bitcore">
   <a href="https://opensource.org/licenses/MIT/" target="_blank"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-blue.svg" style="display: inherit;"/></a>
   <a href="https://github.com/bitpay/bitcore/graphs/contributors"> 
-  <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bitpay/bitcore">
+    <img alt="GitHub contributors" src="https://img.shields.io/github/contributors/bitpay/bitcore">
+  </a>
   <br>
  <img src="https://circleci.com/gh/bitpay/bitcore.svg?style=shield" alt="master build">
 </p>


### PR DESCRIPTION
- Fixed contributors link
- Replaced ```Bitcore Wallet``` with ```Bitcore CLI```
- Moved ```Bitpay Wallet``` to extras and renamed it ```Bitpay/Bitpay App``` to indicate the repo location is not in bitcore