### PR TITLE
[BWS] Environmental variable option for bws.config path 

### DIFF
--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -478,7 +478,11 @@ const Config = (): any => {
   };
 
   // Override default values with bws.config.js' values, if present
-  const { BITCORE_CONFIG_PATH = '../../../../', BWS_CONFIG_PATH = '../../' } = process.env;
+  const {
+    BITCORE_CONFIG_PATH = path.join(__dirname, '../../../../'),
+    BWS_CONFIG_PATH = path.join(__dirname, '../../')
+  } = process.env;
+  
   let bwsConfig;
 
   try {


### PR DESCRIPTION
Instead of just checkout bitcore-wallet-service/bws.config.js,

- First look in BWS_CONFIG_PATH or BWS_CONFIG_PATH/bws.config.js. Throws errors on failure.
- Second look in BITCORE_CONFIG_PATH or BWS_CONFIG_PATH/bitcore.config.json. Does not throw errors on failure, just uses default paths.
- If there are no environmental variables, try bitcore/bitcore.config.json and lastly bitcore-wallet-service/bws.config.js