### PR TITLE
[BWS] Ignore tx receipt logs

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3691,7 +3691,7 @@ export class WalletService implements IWalletService {
           priorityGasFee: tx.priorityGasFee,
           txType: tx.txType,
           gasLimit: tx.gasLimit,
-          receipt: tx.receipt,
+          receipt: tx.receipt ? { ...tx.receipt, logs: undefined } : undefined,
           nonce: tx.nonce,
           effects: tx.effects
         };


### PR DESCRIPTION
This PR:

* Ignores tx receipt logs for wallet transactions which can be very plentiful and create very large cache documents.