### PR TITLE
[BCN] Optional Auth and Protocol for RPC

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
+++ b/packages/bitcore-node/src/providers/chain-state/internal/internal.ts
@@ -56,8 +56,8 @@ export class InternalStateProvider implements IChainStateService {
     if (!RPC_PEER) {
       throw new Error(`RPC not configured for ${chain} ${network}`);
     }
-    const { username, password, host, port } = RPC_PEER;
-    return new RPC(username, password, host, port);
+    const { username, password, host, port, protocol } = RPC_PEER;
+    return new RPC(username, password, host, port, protocol);
   }
 
   private getAddressQuery(params: StreamAddressUtxosParams) {

--- a/packages/bitcore-node/src/rpc.ts
+++ b/packages/bitcore-node/src/rpc.ts
@@ -9,14 +9,17 @@ export class RPC {
     private username: string,
     private password: string,
     private host: string,
-    private port: number | string
+    private port: number | string,
+    private protocol: string = 'http'
   ) {}
 
   public callMethod(method: string, params: any, callback: CallbackType, walletName?: string) {
+    const authString = this.username ? `${this.username}:${this.password}@` : '';
+    const walletString = walletName ? '/wallet/' + walletName : '';
     request(
       {
         method: 'POST',
-        url: `http://${this.username}:${this.password}@${this.host}:${this.port}${walletName ? '/wallet/' + walletName : ''}`,
+        url: `${this.protocol}://${authString}${this.host}:${this.port}${walletString}`,
         body: {
           jsonrpc: '1.0',
           id: Date.now(),
@@ -122,8 +125,8 @@ export class AsyncRPC {
   private rpc: RPC;
   private walletName: string | undefined;
 
-  constructor(username: string, password: string, host: string, port: number | string) {
-    this.rpc = new RPC(username, password, host, port);
+  constructor(username: string, password: string, host: string, port: number | string, protocol?: string) {
+    this.rpc = new RPC(username, password, host, port, protocol);
     this.walletName = process.env.LOADED_MOCHA_OPTS === 'true' ? 'MOCHA_BITCORE_WALLET' : undefined;
   }
 

--- a/packages/bitcore-node/src/types/Config.ts
+++ b/packages/bitcore-node/src/types/Config.ts
@@ -23,6 +23,7 @@ export interface IUtxoNetworkConfig extends INetworkConfig {
     port: number | string;
     username: string;
     password: string;
+    protocol?: string;
   };
   defaultFeeMode?: FeeMode;
   syncStartHash?: string; // Start syncing from this block


### PR DESCRIPTION
Made the RPC url more flexible so I could use getblock.io. This allows me to use https and connect to the getblock.io RPC without authentication (as none was provided).
- Added protocol option for rpc URL with http as default
- Made authentication string optional