### PR TITLE
Updated Dockerfile with Current Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ WORKDIR /bitcore
 COPY lerna.json ./
 COPY package*.json ./
 
+COPY  ./packages/bitcore-cli/package.json ./packages/bitcore-cli/package.json
+COPY  ./packages/bitcore-cli/package-lock.json ./packages/bitcore-cli/package-lock.json
+
 COPY  ./packages/bitcore-client/package.json ./packages/bitcore-client/package.json
 COPY  ./packages/bitcore-client/package-lock.json ./packages/bitcore-client/package-lock.json
 


### PR DESCRIPTION
Updated Dockerfile for current packages. Removed bitcore-wallet and added bitcore-cli. This fixes an error when I run ```docker compose build```:
```
 => ERROR [30/43] COPY  ./packages/bitcore-wallet/package.json ./packages/bitcore-wallet/package.json                                                                                                          0.0s
 => ERROR [31/43] COPY  ./packages/bitcore-wallet/package-lock.json ./packages/bitcore-wallet/package-lock.json                                                                                                0.0s
------
 > [30/43] COPY  ./packages/bitcore-wallet/package.json ./packages/bitcore-wallet/package.json:
------
------
 > [31/43] COPY  ./packages/bitcore-wallet/package-lock.json ./packages/bitcore-wallet/package-lock.json:
------
[+] build 0/1
 ⠙ Image bitcore-node Building                                                                                                                                                                                 1.6s
Dockerfile:63

--------------------

  61 |

  62 |     COPY  ./packages/bitcore-wallet/package.json ./packages/bitcore-wallet/package.json

  63 | >>> COPY  ./packages/bitcore-wallet/package-lock.json ./packages/bitcore-wallet/package-lock.json

  64 |

  65 |     COPY  ./packages/crypto-wallet-core/package.json ./packages/crypto-wallet-core/package.json

--------------------

failed to solve: failed to compute cache key: failed to calculate checksum of ref wa816kh8496s16x9aweaqhn6k::z7jibi1eb0uy3iz2ydn888ozj: "/packages/bitcore-wallet/package-lock.json": not found
```