### PR TITLE
[BWC] Fix Type Errors in Tests

### DIFF
--- a/packages/bitcore-wallet-client/test/api.test.ts
+++ b/packages/bitcore-wallet-client/test/api.test.ts
@@ -4649,7 +4649,7 @@ describe('client API', function() {
             }
           };
         }
-      };
+      } as any;
     };
     beforeEach(() => {
       oldreq = Client.PayProV2.request;

--- a/packages/bitcore-wallet-client/test/paypro.test.ts
+++ b/packages/bitcore-wallet-client/test/paypro.test.ts
@@ -39,7 +39,7 @@ function mockRequest(bodyBuf, headers) {
         }
       };
     }
-  };
+  } as any;
 
 };
 
@@ -99,7 +99,7 @@ describe('PayPro', function() {
         };
       },
       'post': () => { }
-    };
+    } as any;
     PayPro.get({
       url: 'https://test.bitpay.com/paypro',
       network: 'testnet',
@@ -220,7 +220,7 @@ describe('PayPro', function() {
           }
         };
       }
-    };
+    } as any;
     PayPro.send(opts, function (err, data, memo) {
       should.exist(err);
       done();

--- a/packages/bitcore-wallet-client/test/payproV2.test.ts
+++ b/packages/bitcore-wallet-client/test/payproV2.test.ts
@@ -52,7 +52,7 @@ describe('PayProV2', () => {
           }
         };
       }
-    };
+    } as any;
   };
   beforeEach(() => {
     oldreq = PayProV2.request;
@@ -93,7 +93,7 @@ describe('PayProV2', () => {
             }
           };
         }
-      };
+      } as any;
       PayProV2._asyncRequest({
         url: 'https://bitpay.com/i/LanynqCPoL2JQb8z8s5Z3X',
         method: 'post',
@@ -144,7 +144,7 @@ describe('PayProV2', () => {
             }
           };
         }
-      };
+      } as any;
       PayProV2._asyncRequest({
         url: 'https://bitpay.com/i/LanynqCPoL2JQb8z8s5Z3X',
         method: 'post',
@@ -195,7 +195,7 @@ describe('PayProV2', () => {
             }
           };
         }
-      };
+      } as any;
       PayProV2._asyncRequest({
         url: 'https://bitpay.com/i/LanynqCPoL2JQb8z8s5Z3X',
         method: 'post',


### PR DESCRIPTION
Fixes type errors in bitcore-wallet-client tests. I added 8 as any statements. I was getting this error after running ```npm run compile``` in bitcore-wallet-client (last 13 lines): 
```
test/payproV2.test.ts:189:17 - error TS2353: Object literal may only specify known properties, and 'statusMessage' does not exist in type 'Response'.

189                 statusMessage: 'Not Found',
                    ~~~~~~~~~~~~~


Found 28 errors in 3 files.

Errors  Files
     5  test/api.test.ts:4609
     9  test/paypro.test.ts:14
    14  test/payproV2.test.ts:12
```