### PR TITLE
Remove bitcore-wallet test script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,6 @@
     "ci:bitcore-wallet-service": "./ci.sh 'npm run test:bitcore-wallet-service'",
     "test:bitcore-wallet-client": "cd ./packages/bitcore-wallet-client && npm run test",
     "ci:bitcore-wallet-client": "./ci.sh 'npm run test:bitcore-wallet-client'",
-    "test:bitcore-wallet": "cd ./packages/bitcore-wallet && npm run test",
-    "ci:bitcore-wallet": "./ci.sh 'npm run test:bitcore-wallet'",
     "test:crypto-wallet-core": "cd ./packages/crypto-wallet-core && npm run test",
     "ci:crypto-wallet-core": "./ci.sh 'npm run test:crypto-wallet-core'",
     "test:bitcore-node": "cd ./packages/bitcore-node && npm run test",


### PR DESCRIPTION
### Summary
Removes vestigial bitcore-wallet script from package.json. 

bitcore-wallet is no longer in bitcore, so it's test script should be removed from package.json to prevent confusion and promote consistency.