### PR TITLE
add fiatrates v4 endpoint

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -1398,6 +1398,23 @@ export class ExpressApp {
       });
     });
 
+    router.get('/v4/fiatrates/:code/', (req, res) => {
+      SetPublicCache(res, 5 * ONE_MINUTE);
+      let server: WalletService;
+      try {
+        server = getServer(req, res);
+      } catch (ex) {
+        return returnError(ex, res, req);
+      }
+      server.externalServices.coinGecko.coinGeckoGetFiatRates(req)
+        .then(response => {
+          res.json(response);
+        })
+        .catch(err => {
+          return returnError(err ?? 'unknown', res, req);
+        });
+    });
+
     // DEPRECATED
     router.post('/v1/pushnotifications/subscriptions/', (req, res) => {
       getServerWithAuth(req, res, server => {


### PR DESCRIPTION
## Description
This PR adds a new `/v4/fiatrates/:code` endpoint backed by CoinGecko to return historical fiat rates for 7 different timeframes (1 day, 7 days, 30 days, 90 days, 1 year, 5 years, and all time) for supported coins.

To ensure caching requirements remain manageable, this PR:
- Validates fiat `:code` against `Defaults.FIAT_CURRENCIES`.
- Validates `coin` values (rejects coins not explicitly enumerated in `resolveCoinGeckoId`).
- Restricts `days` to `1, 7, 30, 90, 365, 1825` (defaults to all time when no days param is provided).
- Appends `interval=daily` to CoinGecko market chart requests when `days >= 90` to limit response sizes at the larger intervals.

## Testing Notes
- `npm test`
Manual:
- `GET /bws/api/v4/fiatrates/USD`
- `GET /bws/api/v4/fiatrates/USD?days=7`
- `GET /bws/api/v4/fiatrates/USD?coin=BTC&days=90` (should use daily interval)
- `GET /bws/api/v4/fiatrates/USD?days=2` (should return error: invalid days)
- `GET /bws/api/v4/fiatrates/USDX` (should return error: unsupported fiat currency code)
- `GET /bws/api/v4/fiatrates/USD?coin=BADCOIN` (should return error: unsupported coin)