### PR TITLE
Fix address derive log & cleanup address import paging log for common case

### DIFF
--- a/packages/bitcore-client/bin/wallet-derive
+++ b/packages/bitcore-client/bin/wallet-derive
@@ -44,20 +44,19 @@ const main = async () => {
     }
 
     while (unusedAddressCounter < gap) {
-      const address = await wallet.generateAddressPair(index, !noChange);
+      const [address, changeAddress] = await wallet.generateAddressPair(index, !noChange);
 
       const transactions = await wallet.client.getAddressTxos({ address });
+      if (changeAddress) {
+        transactions.push(...await wallet.client.getAddressTxos({ address: changeAddress }));
+      }
 
       if (!transactions.length || !wallet.isUtxoChain()) {
         unusedAddressCounter++;
       } else {
         unusedAddressCounter = 0;
       }
-      if (!noChange) {
-        console.log(`Current change index: ${index}: ${address}`);
-      } else {
-        console.log(`Current address index: ${index}: ${address}`);
-      }
+      console.log(`Current address index: ${index}: ${address}${changeAddress ? ` (change: ${changeAddress})` : ''}`);
       index++;
     }
   } catch (e) {

--- a/packages/bitcore-client/bin/wallet-send
+++ b/packages/bitcore-client/bin/wallet-send
@@ -91,7 +91,8 @@ const main = async () => {
         const { data } = wallet.getLib().ethers.Transaction.from(tx);
         const gasLimit = await wallet.estimateGas({ to, from, data, value: BigInt(balance.confirmed).toString() });
         const l1FeeWei = await wallet.getL1Fee(tx); // OP-stack chains have a "hidden" layer-1 data fee (in wei). Returns 0 for non-OP-stack chains.
-        const amtToSend = (BigInt(balance.confirmed) - (BigInt(gasLimit) * BigInt(params.feeRate)) - BigInt(l1FeeWei)).toString();
+        const feeWei = (BigInt(gasLimit) * BigInt(params.feeRate)) - BigInt(l1FeeWei);
+        const amtToSend = (BigInt(balance.confirmed) - (tokenName ? 0n : feeWei)).toString();
         params.recipients.push({ address: to, amount: amtToSend });
         params.gasLimit = gasLimit;
       } else if (wallet.chain.toUpperCase() === 'XRP') {

--- a/packages/bitcore-client/bin/wallet-send
+++ b/packages/bitcore-client/bin/wallet-send
@@ -88,7 +88,7 @@ const main = async () => {
       } else if (wallet.isEvmChain()) {
         const balance = await wallet.getBalance({ tokenName, address: from, hex: true });
         const tx = await wallet.newTx({ ...params, recipients: [{ address: to, amount: 1 }] }); // create dummy tx to estimate gas
-        const { data } = wallet.getLib().ethers.utils.parseTransaction(tx);
+        const { data } = wallet.getLib().ethers.Transaction.from(tx);
         const gasLimit = await wallet.estimateGas({ to, from, data, value: BigInt(balance.confirmed).toString() });
         const l1FeeWei = await wallet.getL1Fee(tx); // OP-stack chains have a "hidden" layer-1 data fee (in wei). Returns 0 for non-OP-stack chains.
         const amtToSend = (BigInt(balance.confirmed) - (BigInt(gasLimit) * BigInt(params.feeRate)) - BigInt(l1FeeWei)).toString();

--- a/packages/bitcore-client/src/client.ts
+++ b/packages/bitcore-client/src/client.ts
@@ -194,11 +194,15 @@ export class Client {
   async importAddresses(params: { pubKey: string; payload: Array<{ address: string }> }): Promise<void> {
     const { payload, pubKey } = params;
     const url = `${this.apiUrl}/wallet/${pubKey}`;
+    const pageSize = 100;
 
-    for (let i = 0; i < payload.length; i += 100) {
-      const body = payload.slice(i, i + 100);
-      console.log(`Importing addresses ${i + 1}-${i + body.length} of ${payload.length}`);
-      if (i >= 100) {
+    for (let i = 0; i < payload.length; i += pageSize) {
+      const body = payload.slice(i, i + pageSize);
+      if (payload.length > pageSize) {
+        // If we're paginating through a long list of addresses, log progress so the user knows something is happening
+        console.log(`Importing addresses ${i + 1}-${i + body.length} of ${payload.length}`);
+      }
+      if (i >= pageSize) {
         await utils.sleep(1000); // cooldown
       }
       

--- a/packages/bitcore-client/src/storage.ts
+++ b/packages/bitcore-client/src/storage.ts
@@ -8,6 +8,14 @@ import { TextFile } from './storage/textFile';
 import { StorageType } from './types/storage';
 import { IWallet, KeyImport } from './types/wallet';
 
+function tryParse(json: string) {
+  try {
+    return JSON.parse(json);
+  } catch {
+    return json;
+  }
+}
+
 export class Storage {
   path: string;
   db: Array<Mongo | Level | TextFile>;
@@ -229,7 +237,11 @@ export class Storage {
           open: i === 0, // open on first
           keepAlive: i < addresses.length - 1, // close on last
         });
-        keys.push(key);
+        if (key) {
+          keys.push(key);
+        } else {
+          console.warn(`Key not found for address ${address}`);
+        }
       } catch (err) {
         // don't continue from catch - i must be incremented
         console.error(err);
@@ -247,8 +259,9 @@ export class Storage {
   }): Promise<any> {
     const { address, name, keepAlive, open } = params;
     const payload = await this.storageType.getKey({ name, address, keepAlive, open });
-    const json = JSON.parse(payload) || payload;
-    const { key } = json; // pubKey available - not needed
+    // Note: payload could be undefined if the server has an address that local storage did not save
+    const json = tryParse(payload) || payload;
+    const { key } = json || {}; // pubKey available - not needed
     if (key) {
       return JSON.parse(key);
     } else {

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -37,6 +37,21 @@ const chainLibs = {
   SOL: { SolKit, SolanaProgram }
 };
 
+const baseUrls = {
+  BTC: 'https://api.bitcore.io/api',
+  BCH: 'https://api.bitcore.io/api',
+  DOGE: 'https://api.bitcore.io/api',
+  LTC: 'https://api.bitcore.io/api',
+  ETH: 'https://api-eth.bitcore.io/api',
+  MATIC: 'https://api-matic.bitcore.io/api',
+  ARB: 'https://api-eth.bitcore.io/api',
+  OP: 'https://api-eth.bitcore.io/api',
+  BASE: 'https://api-eth.bitcore.io/api',
+  ARC: 'https://api-eth.bitcore.io/api',
+  XRP: 'https://api-xrp.bitcore.io/api',
+  SOL: 'https://api-sol.bitcore.io/api'
+};
+
 export interface IWalletExt extends IWallet {
   storage?: Storage;
 }
@@ -70,7 +85,7 @@ export class Wallet {
   constructor(params: Wallet | IWalletExt) {
     Object.assign(this, params);
     if (!this.baseUrl) {
-      this.baseUrl = 'https://api.bitcore.io/api';
+      this.baseUrl = baseUrls[this.chain.toUpperCase()] || 'https://api.bitcore.io/api';
     }
     this.client = new Client({
       apiUrl: this.getApiUrl(),
@@ -827,7 +842,7 @@ export class Wallet {
     let existingTx;
     if (rawTx) {
       if (lib.ethers) {
-        existingTx = lib.ethers.utils.parseTransaction(rawTx);
+        existingTx = lib.ethers.Transaction.from(rawTx);
       } else {
         const tx = new lib.Transaction(rawTx);
         txid = tx.id;


### PR DESCRIPTION
### Description
Currently, the output log when deriving an address is a bit confusing/ambiguous for UTXO wallets.

e.g.
```sh
$ bin/wallet derive --storageType Level --name testy --gap 1
Wallet Password: 
using wallets at /home/kjoseph/.bitcore/bitcoreWallet
Current change index: 4: tb1qj6azkf2tw3h4w4k302e63xr8czm0yauc228ydt, tb1qcluqkwj3wdz96fjaskcudth6vf2rv2jqjjxdkl
```

Notice it says `Current change index` ("change"?) and then prints 2 addresses, leaving it ambiguous as to which one is change (spoiler alert, it's the 2nd one).

Furthermore, the log `Importing address 1-1 of 1` is overly verbose in the common case of creating an address. This log was intended to show pagination progress when importing a large amount of addresses.

### Changelog

* Fixed the address derivation output to be clearer: `Current address index: 4: tb1qj6azkf2tw3h4w4k302e63xr8czm0yauc228ydt (change: tb1qcluqkwj3wdz96fjaskcudth6vf2rv2jqjjxdkl)`
* Silences the address pagination progress log unless there is >100 addresses being imported
* Fixed ethers tx parsing
* Fixed default baseUrl for non-UTXO chains
* Fixed subtracting fee from token amount when using max send
* Cleaned up messy, scary-looking error logs when there local address keys are not found

### Testing Notes
Add any helpful notes for reviewers to test your code here.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.