### PR TITLE
[BWS, BWC] JIT Nonce XRP support

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -4208,6 +4208,7 @@ export interface Txp {
   encryptedMessage?: string; // is set equal to `message` before decryption in processTxps()
   network: string;
   nonce?: number;
+  deferNonce?: boolean;
   note?: Note;
   outputOrder: Array<number>;
   outputs?: Array<{

--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -161,7 +161,7 @@ export class XrpChain implements IChain {
         ...txp,
         tag: _tag ? Number(_tag) : undefined,
         chain,
-        nonce: Number(txp.nonce) + Number(index),
+        nonce: (txp.nonce != null ? Number(txp.nonce) : 0) + Number(index),
         recipients: [recepient]
       });
       unsignedTxs.push(rawTx);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3412,7 +3412,7 @@ export class WalletService implements IWalletService {
             return cb(null, txp);
           }
 
-          if (!Constants.EVM_CHAINS[wallet.chain.toUpperCase()]) {
+          if (!Constants.EVM_CHAINS[wallet.chain.toUpperCase()] && wallet.chain.toUpperCase() !== 'XRP') {
             return cb(null, txp);
           }
 

--- a/packages/bitcore-wallet-service/test/integration/helpers.ts
+++ b/packages/bitcore-wallet-service/test/integration/helpers.ts
@@ -559,6 +559,7 @@ class Helpers {
         // For eth => account, 0, change = 0
         const priv = xpriv.derive('m/0/0').privateKey;
         const privKey = priv.toString('hex');
+        const pubKey = priv.publicKey.toString('hex');
         let tx = ChainService.getBitcoreTx(txp).uncheckedSerialize();
         const isERC20 = txp.tokenAddress && !txp.payProUrl;
         const chain = isERC20 ? Utils.getChain(txp.coin) + 'ERC20' : Utils.getChain(txp.coin);
@@ -568,7 +569,7 @@ class Helpers {
           const signed = Transactions.getSignature({
             chain: chain.toUpperCase(),
             tx: rawTx,
-            key: { privKey: privKey.toString('hex') },
+            key: { privKey: privKey.toString('hex'), pubKey },
           });
           signatures.push(signed);
         }

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -8134,6 +8134,97 @@ describe('Wallet service', function() {
     });
   });
 
+  describe('#prepareTx XRP (deferred nonce)', function() {
+    const XRP_ADDR = 'rDzTZxa7NwD9vmNf5dvTbW4FQDNSRsfPv6';
+    let server, wallet, fromAddr;
+
+    beforeEach(async function() {
+      ({ server, wallet } = await helpers.createAndJoinWallet(1, 1, { coin: 'xrp' }));
+      const address = await util.promisify(server.createAddress).call(server, {});
+      fromAddr = address.address;
+      await helpers.stubUtxos(server, wallet, [1, 2], { coin: 'xrp' });
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '5');
+    });
+
+    it('should create XRP txp with nonce=null when deferNonce is true', async function() {
+      const txp = await util.promisify(server.createTx).call(server, {
+        outputs: [{ toAddress: XRP_ADDR, amount: 8000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      });
+      should.exist(txp);
+      txp.deferNonce.should.be.true;
+      should.not.exist(txp.nonce);
+    });
+
+    it('should assign nonce to a deferred XRP txp via prepareTx', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const txp = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: XRP_ADDR, amount: 8000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+
+      should.not.exist(txp.nonce);
+
+      const result = await util.promisify(server.prepareTx).call(server, {
+        txProposalId: txp.id
+      });
+      result.nonce.should.equal(10);
+    });
+
+    it('should calculate gap-free nonce for XRP skipping pending nonces', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '5');
+
+      const normalTxp = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: XRP_ADDR, amount: 1000 }],
+        feePerKb: 123e2,
+        from: fromAddr
+      }, TestData.copayers[0].privKey_1H_0);
+      normalTxp.nonce.should.equal('5');
+
+      const deferred = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: XRP_ADDR, amount: 2000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+
+      const result = await util.promisify(server.prepareTx).call(server, {
+        txProposalId: deferred.id
+      });
+      result.nonce.should.equal(6);
+    });
+
+    it('should sign XRP txp after prepareTx assigns nonce', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '7');
+      helpers.stubBroadcast('txid123');
+
+      const txp = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: XRP_ADDR, amount: 8000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+
+      const withNonce = await util.promisify(server.prepareTx).call(server, {
+        txProposalId: txp.id
+      });
+      withNonce.nonce.should.equal(7);
+
+      const fetched = await util.promisify(server.getTx).call(server, { txProposalId: txp.id });
+      const signatures = helpers.clientSign(fetched, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      const signed = await util.promisify(server.signTx).call(server, {
+        txProposalId: txp.id,
+        signatures
+      });
+      signed.status.should.equal('accepted');
+    });
+  });
+
   describe('#signTx nonce override', function() {
     const ETH_ADDR = '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A';
     let server, wallet, fromAddr;


### PR DESCRIPTION
### Description
Extends the deferred nonce / `prepareTx` flow to XRP. Previously only EVM chains could use `deferNonce` to skip nonce assignment at create time and assign a fresh sequence number right before signing. XRP uses the same nonce-based signing model (the `Sequence` field is part of the signed payload), so it benefits from the same JIT assignment.

Also adds `deferNonce` to the BWC `Txp` interface so downstream consumers (like the app) can check it without type errors.

### Changelog

* `prepareTx` chain gate now allows XRP alongside EVM chains
* Null nonce guard in XRP `getBitcoreTx` to prevent NaN when building unsigned txs with deferred nonce (matches existing EVM pattern)
* Added `deferNonce?: boolean` to the BWC `Txp` type interface
* Integration tests for the XRP deferred nonce flow (create, prepareTx, gap-free nonce, sign)

### Testing Notes
Run BWS integration tests:
```bash
cd packages/bitcore-wallet-service && npm run test:integration
```
New tests are in the `#prepareTx XRP (deferred nonce)` describe block.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
