### PR TITLE
[BWS, BWC] Support oldest-first txhistory paging via reverse param

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -2576,6 +2576,8 @@ export class API extends EventEmitter {
       skip?: number;
       /** Limit the number of transactions */
       limit?: number;
+      /** Return oldest transactions first. */
+      reverse?: boolean;
       /** ERC20 token contract address */
       tokenAddress?: string;
       /** MULTISIG ETH Contract Address */
@@ -2595,6 +2597,7 @@ export class API extends EventEmitter {
       if (opts) {
         if (opts.skip) args.push('skip=' + opts.skip);
         if (opts.limit) args.push('limit=' + opts.limit);
+        if (opts.reverse) args.push('reverse=1');
         if (opts.tokenAddress) args.push('tokenAddress=' + opts.tokenAddress);
         if (opts.multisigContractAddress)
           args.push('multisigContractAddress=' + opts.multisigContractAddress);

--- a/packages/bitcore-wallet-client/test/api.test.ts
+++ b/packages/bitcore-wallet-client/test/api.test.ts
@@ -5898,6 +5898,19 @@ describe('client API', function() {
         },
         {
           opts: {
+            reverse: true
+          },
+          expected: [10, 20]
+        },
+        {
+          opts: {
+            skip: 1,
+            reverse: true
+          },
+          expected: [20]
+        },
+        {
+          opts: {
             skip: 3
           },
           expected: []

--- a/packages/bitcore-wallet-service/README.md
+++ b/packages/bitcore-wallet-service/README.md
@@ -231,6 +231,7 @@ Optional Arguments:
 
 - skip: Records to skip from the result (defaults to 0)
 - limit: Total number of records to return (return all available records if not specified).
+- reverse: Return oldest transactions first.
 
 Returns:
 

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -1180,12 +1180,14 @@ export class ExpressApp {
         const opts: {
           skip?: number;
           limit?: number;
+          reverse?: boolean;
           includeExtendedInfo?: boolean;
           tokenAddress?: string;
           multisigContractAddress?: string;
         } = {};
         if (req.query.skip) opts.skip = +req.query.skip;
         if (req.query.limit) opts.limit = +req.query.limit;
+        if (req.query.reverse == '1') opts.reverse = true;
         if (req.query.tokenAddress) opts.tokenAddress = req.query.tokenAddress as string;
         if (req.query.multisigContractAddress)
           opts.multisigContractAddress = req.query.multisigContractAddress as string;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -4487,6 +4487,13 @@ export class WalletService implements IWalletService {
         next => {
           if (streamData) {
             lastTxs = streamData;
+            if (cacheStatus.tipTxId) {
+              // Stream data can outlive cache promotion, so trim any entries that
+              // are now part of the durable cache before paging.
+              lastTxs = _.takeWhile(lastTxs, (tx: any) => {
+                return tx.txid != cacheStatus.tipTxId;
+              });
+            }
             return next();
           }
 
@@ -4519,6 +4526,24 @@ export class WalletService implements IWalletService {
           });
         },
         next => {
+          if (opts.reverse) {
+            const cachedTxs = _.isNumber(cacheStatus.tipIndex) ? cacheStatus.tipIndex + 1 : 0;
+            const totalTxs = cachedTxs + lastTxs.length;
+            const oldestFirstSkip = skip;
+
+            // Keep the existing newest-first cache math by translating the requested
+            // oldest-first cursor into the equivalent newest-first slice.
+            limit = Math.max(0, Math.min(limit, totalTxs - oldestFirstSkip));
+            skip = Math.max(0, totalTxs - oldestFirstSkip - limit);
+          }
+
+          if (limit === 0) {
+            resultTxs = [];
+            fromCache = false;
+            fromBc = false;
+            return next();
+          }
+
           // Case 1.
           //            t -->
           //  | Old TXS    | ======= LAST TXS ========== \
@@ -4603,6 +4628,9 @@ export class WalletService implements IWalletService {
       ],
       err => {
         if (err) return cb(err);
+        if (opts.reverse) {
+          resultTxs.reverse();
+        }
         return cb(null, {
           items: resultTxs,
           fromCache,
@@ -4620,10 +4648,11 @@ export class WalletService implements IWalletService {
    * @param {Object} opts
    * @param {Number} opts.skip (defaults to 0)
    * @param {Number} opts.limit
+   * @param {Boolean} opts.reverse[=false] - Return oldest transactions first.
    * @param {String} opts.tokenAddress ERC20 Token Contract Address
    * @param {String} opts.multisigContractAddress MULTISIG ETH Contract Address
    * @param {Number} opts.includeExtendedInfo[=false] - Include all inputs/outputs for every tx.
-   * @returns {TxProposal[]} Transaction proposals, first newer
+   * @returns {TxProposal[]} Transaction proposals, newer first unless opts.reverse is set
    */
   getTxHistory(opts, cb) {
     opts = opts || {};

--- a/packages/bitcore-wallet-service/test/integration/history.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/history.test.ts
@@ -85,6 +85,158 @@ describe('History', function() {
       });
     });
 
+    it('should page from oldest first with reverse and keep skip stable if new txs arrive', async function() {
+      const _cache = Defaults.CONFIRMATIONS_TO_START_CACHING;
+      (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = 1;
+
+      try {
+        const baseTxs = helpers.createTxsV8(5, BCHEIGHT);
+        helpers.stubHistory(null, null, baseTxs);
+
+        const firstPage = await new Promise<any[]>((resolve, reject) => {
+          server.getTxHistory({ limit: 2, reverse: true }, function(err, txs) {
+            if (err) return reject(err);
+            resolve(txs);
+          });
+        });
+
+        firstPage.map(tx => tx.id).should.deep.equal(['id4', 'id3']);
+
+        const txTemplate = baseTxs[0];
+        const updatedTxs = [
+          {
+            ...txTemplate,
+            id: 'newid0',
+            txid: 'newtxid0',
+            height: -1,
+            blockTime: '2018-09-21T18:08:33.000Z'
+          },
+          {
+            ...txTemplate,
+            id: 'newid1',
+            txid: 'newtxid1',
+            height: -1,
+            blockTime: '2018-09-21T18:08:32.000Z'
+          },
+          ...baseTxs
+        ];
+        helpers.stubHistory(null, null, updatedTxs);
+
+        const secondPage = await new Promise<any[]>((resolve, reject) => {
+          server.getTxHistory({ skip: 2, limit: 2, reverse: true }, function(err, txs) {
+            if (err) return reject(err);
+            resolve(txs);
+          });
+        });
+
+        secondPage.map(tx => tx.id).should.deep.equal(['id2', 'id1']);
+      } finally {
+        (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = _cache;
+      }
+    });
+
+    it('should trim reused stream data against the current cache tip in reverse mode', async function() {
+      const _cache = Defaults.CONFIRMATIONS_TO_START_CACHING;
+      (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = 1;
+
+      try {
+        const baseTxs = helpers.createTxsV8(4, BCHEIGHT);
+        helpers.stubHistory(null, null, baseTxs);
+
+        await new Promise<void>((resolve, reject) => {
+          server.storage.storeTxHistoryCacheV8(
+            wallet.id,
+            null,
+            [
+              {
+                id: baseTxs[3].id,
+                txid: baseTxs[3].txid,
+                blockheight: baseTxs[3].height
+              }
+            ],
+            0,
+            err => {
+              if (err) return reject(err);
+              resolve();
+            }
+          );
+        });
+
+        const firstPage = await new Promise<{ txs: any[]; useStream: boolean }>((resolve, reject) => {
+          server.getTxHistory({ limit: 2, reverse: true }, function(err, txs, _fromCache, useStream) {
+            if (err) return reject(err);
+            resolve({ txs, useStream });
+          });
+        });
+
+        firstPage.useStream.should.equal(false);
+        firstPage.txs.map(tx => tx.id).should.deep.equal(['id3', 'id2']);
+
+        const secondPage = await new Promise<{ txs: any[]; useStream: boolean }>((resolve, reject) => {
+          server.getTxHistory({ skip: 2, limit: 2, reverse: true }, function(err, txs, _fromCache, useStream) {
+            if (err) return reject(err);
+            resolve({ txs, useStream });
+          });
+        });
+
+        secondPage.useStream.should.equal(true);
+        secondPage.txs.map(tx => tx.id).should.deep.equal(['id1', 'id0']);
+      } finally {
+        (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = _cache;
+      }
+    });
+
+    it('should trim reused stream data against the current cache tip in newest-first mode', async function() {
+      const _cache = Defaults.CONFIRMATIONS_TO_START_CACHING;
+      (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = 1;
+
+      try {
+        const baseTxs = helpers.createTxsV8(4, BCHEIGHT);
+        helpers.stubHistory(null, null, baseTxs);
+
+        await new Promise<void>((resolve, reject) => {
+          server.storage.storeTxHistoryCacheV8(
+            wallet.id,
+            null,
+            [
+              {
+                id: baseTxs[3].id,
+                txid: baseTxs[3].txid,
+                blockheight: baseTxs[3].height
+              }
+            ],
+            0,
+            err => {
+              if (err) return reject(err);
+              resolve();
+            }
+          );
+        });
+
+        const firstPage = await new Promise<{ txs: any[]; useStream: boolean }>((resolve, reject) => {
+          server.getTxHistory({ limit: 2 }, function(err, txs, _fromCache, useStream) {
+            if (err) return reject(err);
+            resolve({ txs, useStream });
+          });
+        });
+
+        firstPage.useStream.should.equal(false);
+        firstPage.txs.map(tx => tx.id).should.deep.equal(['id0', 'id1']);
+
+        const secondPage = await new Promise<{ txs: any[]; useStream: boolean }>((resolve, reject) => {
+          server.getTxHistory({ skip: 2, limit: 2 }, function(err, txs, _fromCache, useStream) {
+            if (err) return reject(err);
+            resolve({ txs, useStream });
+          });
+        });
+
+        secondPage.useStream.should.equal(true);
+        secondPage.txs.map(tx => tx.id).should.deep.equal(['id2', 'id3']);
+      } finally {
+        (Defaults.CONFIRMATIONS_TO_START_CACHING as any) = _cache;
+      }
+    });
+
     it('should filter out DUST amount', function(done) {
       const txs= helpers.createTxsV8(50, BCHEIGHT);
       txs[5].satoshis=100;
@@ -1139,4 +1291,3 @@ describe('History', function() {
     });
   });
 });
-

--- a/packages/bitcore-wallet-service/test/txhistory.paging.test.ts
+++ b/packages/bitcore-wallet-service/test/txhistory.paging.test.ts
@@ -1,0 +1,166 @@
+'use strict';
+
+import * as chai from 'chai';
+import 'chai/register-should';
+import { WalletService } from '../src/lib/server';
+
+chai.should();
+
+type TxItem = {
+  id: string;
+  txid: string;
+  confirmations: number;
+  blockheight: number;
+};
+
+function makeTx(id: number): TxItem {
+  return {
+    id: `id${id}`,
+    txid: `txid${id}`,
+    confirmations: 100 - id,
+    blockheight: 1000 - id
+  };
+}
+
+function callGetTxHistoryV8(service: WalletService, bc, wallet, opts, skip: number, limit: number) {
+  return new Promise<any>((resolve, reject) => {
+    service.getTxHistoryV8(bc, wallet, opts, skip, limit, (err, res) => {
+      if (err) return reject(err);
+      resolve(res);
+    });
+  });
+}
+
+describe('TxHistory Paging', function() {
+  function buildService(initialCacheNewest: TxItem[], getBcNewest: () => TxItem[]) {
+    let cacheNewest = initialCacheNewest.slice();
+    let streamKey: string | null = null;
+    let streamItems: TxItem[] | null = null;
+
+    const service = Object.create(WalletService.prototype) as WalletService & {
+      storage: any;
+      syncWallet: any;
+      _getBlockchainHeight: any;
+      _normalizeTxHistory: any;
+      userAgent: string;
+    };
+
+    service.userAgent = 'txhistory-test-agent';
+    service.syncWallet = (_wallet, next) => next();
+    service._getBlockchainHeight = (_chain, _network, cb) => cb(null, 1000, 'test-hash');
+    service._normalizeTxHistory = (_walletCacheKey, _txs, _dustThreshold, _bcHeight, cb) => cb(null, getBcNewest());
+    service.storage = {
+      getTxHistoryCacheStatusV8: (_walletCacheKey, cb) =>
+        cb(null, {
+          updatedHeight: 0,
+          tipIndex: cacheNewest.length ? cacheNewest.length - 1 : null,
+          tipTxId: cacheNewest.length ? cacheNewest[0].txid : null,
+          tipHeight: cacheNewest.length ? cacheNewest[0].blockheight : null
+        }),
+      getTxHistoryStreamV8: (_walletCacheKey, cb) =>
+        cb(null, streamKey && streamItems ? { streamKey, items: streamItems.slice() } : null),
+      clearTxHistoryStreamV8: (_walletCacheKey, cb) => {
+        streamKey = null;
+        streamItems = null;
+        cb();
+      },
+      storeTxHistoryStreamV8: (_walletCacheKey, inStreamKey, items, cb) => {
+        streamKey = inStreamKey;
+        streamItems = items.slice();
+        cb();
+      },
+      getTxHistoryCacheV8: (_walletCacheKey, skip, limit, cb) => cb(null, cacheNewest.slice(skip, skip + limit)),
+      storeTxHistoryCacheV8: (_walletCacheKey, _tipIndex, items, _updateHeight, cb) => {
+        cacheNewest = items.concat(cacheNewest);
+        cb();
+      }
+    };
+
+    const bc = {
+      getTransactions: (_wallet, _startBlock, cb) => cb(null, [])
+    };
+    const wallet = {
+      id: 'wallet1',
+      chain: 'btc',
+      network: 'livenet'
+    };
+
+    return { service, bc, wallet };
+  }
+
+  it('should preserve newest-first skip behavior by default', async function() {
+    const cacheNewest = [makeTx(5), makeTx(6), makeTx(7)];
+    const bcNewest = [makeTx(0), makeTx(1), makeTx(2), makeTx(3), makeTx(4)];
+    const { service, bc, wallet } = buildService(cacheNewest, () => bcNewest);
+
+    const result = await callGetTxHistoryV8(service, bc, wallet, {}, 2, 2);
+
+    result.items.map(tx => tx.id).should.deep.equal(['id2', 'id3']);
+  });
+
+  it('should return oldest-first pages when reverse is set', async function() {
+    const cacheNewest = [makeTx(5), makeTx(6), makeTx(7)];
+    const bcNewest = [makeTx(0), makeTx(1), makeTx(2), makeTx(3), makeTx(4)];
+    const { service, bc, wallet } = buildService(cacheNewest, () => bcNewest);
+
+    const result = await callGetTxHistoryV8(service, bc, wallet, { reverse: true }, 0, 2);
+
+    result.items.map(tx => tx.id).should.deep.equal(['id7', 'id6']);
+  });
+
+  it('should keep reverse skip stable when new transactions arrive at the tip', async function() {
+    const cacheNewest = [makeTx(5), makeTx(6), makeTx(7)];
+    let bcNewest = [makeTx(0), makeTx(1), makeTx(2), makeTx(3), makeTx(4)];
+    const { service, bc, wallet } = buildService(cacheNewest, () => bcNewest);
+
+    const firstPage = await callGetTxHistoryV8(service, bc, wallet, { reverse: true }, 0, 2);
+    firstPage.items.map(tx => tx.id).should.deep.equal(['id7', 'id6']);
+
+    bcNewest = [
+      {
+        id: 'newid0',
+        txid: 'newtxid0',
+        confirmations: 0,
+        blockheight: -1
+      },
+      {
+        id: 'newid1',
+        txid: 'newtxid1',
+        confirmations: 0,
+        blockheight: -1
+      },
+      ...bcNewest
+    ];
+
+    const secondPage = await callGetTxHistoryV8(service, bc, wallet, { reverse: true }, 2, 2);
+    secondPage.items.map(tx => tx.id).should.deep.equal(['id5', 'id4']);
+  });
+
+  it('should trim streamed txs that were promoted into cache before reverse paging', async function() {
+    const cacheNewest = [makeTx(3)];
+    const bcNewest = [makeTx(0), makeTx(1), makeTx(2), makeTx(3)];
+    const { service, bc, wallet } = buildService(cacheNewest, () => bcNewest);
+
+    const firstPage = await callGetTxHistoryV8(service, bc, wallet, { reverse: true }, 0, 2);
+    firstPage.useStream.should.equal(false);
+    firstPage.items.map(tx => tx.id).should.deep.equal(['id3', 'id2']);
+
+    const secondPage = await callGetTxHistoryV8(service, bc, wallet, { reverse: true }, 2, 2);
+    secondPage.useStream.should.equal(true);
+    secondPage.items.map(tx => tx.id).should.deep.equal(['id1', 'id0']);
+  });
+
+  it('should trim streamed txs that were promoted into cache before newest-first paging', async function() {
+    const cacheNewest = [makeTx(3)];
+    const bcNewest = [makeTx(0), makeTx(1), makeTx(2), makeTx(3)];
+    const { service, bc, wallet } = buildService(cacheNewest, () => bcNewest);
+
+    const firstPage = await callGetTxHistoryV8(service, bc, wallet, {}, 0, 2);
+    firstPage.useStream.should.equal(false);
+    firstPage.items.map(tx => tx.id).should.deep.equal(['id0', 'id1']);
+
+    const secondPage = await callGetTxHistoryV8(service, bc, wallet, {}, 2, 2);
+    secondPage.useStream.should.equal(true);
+    secondPage.items.map(tx => tx.id).should.deep.equal(['id2', 'id3']);
+  });
+});


### PR DESCRIPTION
### Description
Adds oldest-first `txhistory` paging via `reverse=1`, following the same reverse convention already used by `GET /v2/addresses/`, with stable skip behavior for paging from start to finish. Also trims reused `txhistory` stream data against the current cache tip so pages do not duplicate or skip txs when cached txs advance between requests.

### Changelog
- Add `reverse` support to `txhistory` in BWS and BWC.
- Make `skip` act as an oldest-first cursor when `reverse=1`, while preserving newest-first behavior by default.
- Trim reused txhistory stream data against the current cache tip before paging.
- Add unit/integration coverage for reverse paging and stream overlap in both paging modes.
- Document the new `reverse` behavior.

### Testing Notes
- `cd packages/bitcore-wallet-service && npm test -- --grep "should page from oldest first with reverse and keep skip stable if new txs arrive|should trim reused stream data against the current cache tip in reverse mode|should trim reused stream data against the current cache tip in newest-first mode"`
- `cd packages/bitcore-wallet-client && npm test -- --grep "should get paginated transaction history"`

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.