### PR TITLE
[BWS] Fix: delete banxa payment_method_id for old app requests only

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/banxa.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/banxa.ts
@@ -190,6 +190,12 @@ export class BanxaService {
         return reject(new ClientError("Banxa's request missing arguments"));
       }
 
+      if (!req.body.payment_method || req.body.payment_method === 'other') {
+        // Workaround to allow older versions of the app to freely choose the payment method on the checkout page when they select "other".
+        delete req.body.payment_method_id;
+      }
+      delete req.body.payment_method;
+
       const UriPath = '/orders';
       const URL: string = API + UriPath;
       const auth = this.getBanxaSignature('post', UriPath, API_KEY, SECRET_KEY, req.body);


### PR DESCRIPTION
Description
The Banxa team reported that older versions of the app that select "Other" as the payment method are incorrectly sending a payment_method_id.

Changelog
I added a workaround ensures that the payment_method_id is removed for older versions, and newer versions that now send the payment_method attribute can avoid sending it for "Other" and retain it only for specific payment methods, thus enabling "KYC Free" for the Apple Pay option.