### PR TITLE
[BWS] Fix: remove variant prop from Ramp signedUrl generation

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/ramp.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/ramp.ts
@@ -152,7 +152,6 @@ export class RampService {
     if (req.body.useSendCryptoCallback) qs.push('useSendCryptoCallback=' + encodeURIComponent(req.body.useSendCryptoCallback));
     if (req.body.paymentMethodType) qs.push('paymentMethodType=' + encodeURIComponent(req.body.paymentMethodType));
     if (req.body.hideExitButton) qs.push('hideExitButton=' + encodeURIComponent(req.body.hideExitButton));
-    if (req.body.variant) qs.push('variant=' + encodeURIComponent(req.body.variant));
     if (req.body.useSendCryptoCallbackVersion) qs.push('useSendCryptoCallbackVersion=' + encodeURIComponent(req.body.useSendCryptoCallbackVersion));
 
     const queryString = qs.join('&');

--- a/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
@@ -310,7 +310,6 @@ describe('Ramp integration', () => {
         defaultFlow: 'OFFRAMP',
         selectedCountryCode: 'US',
         defaultAsset: 'BTC_BTC',
-        variant: 'webview-mobile',
         useSendCryptoCallback: true,
         useSendCryptoCallbackVersion: 1,
         hideExitButton: false,
@@ -329,7 +328,6 @@ describe('Ramp integration', () => {
       params.swapAmount.should.equal('1000000');
       params.defaultAsset.should.equal('BTC_BTC');
       params.useSendCryptoCallback.should.equal('true');
-      params.variant.should.equal('webview-mobile');
       params.useSendCryptoCallbackVersion.should.equal('1');
 
       // timestamp must exist and be numeric
@@ -350,7 +348,6 @@ describe('Ramp integration', () => {
         defaultFlow: 'OFFRAMP',
         selectedCountryCode: 'US',
         defaultAsset: 'BTC_BTC',
-        variant: 'webview-mobile',
         useSendCryptoCallback: true,
         useSendCryptoCallbackVersion: 1,
         hideExitButton: false,
@@ -369,7 +366,6 @@ describe('Ramp integration', () => {
       params.swapAmount.should.equal('1000000');
       params.defaultAsset.should.equal('BTC_BTC');
       params.useSendCryptoCallback.should.equal('true');
-      params.variant.should.equal('webview-mobile');
       params.useSendCryptoCallbackVersion.should.equal('1');
 
       // timestamp must exist and be numeric


### PR DESCRIPTION
### Description
Users attempting to sell crypto from the app via Ramp Network are receiving an "Integration issue detected" message when opening the signedUrl in our webview.
I contacted their team, and they indicated that the error is due to a variable they recently removed: `variant`


### Changelog

* I removed the variable from the signed URL generation and the respective tests