### PR TITLE
fix(bitcore-lib): normalize elliptic BN in ECDSA.sign

### DIFF
--- a/packages/bitcore-lib/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib/lib/crypto/ecdsa.js
@@ -205,7 +205,10 @@ const sign = function(hashbuf, privkey, opts) {
     k = randomK ? getRandomK() : getDeterministicK(hashbuf, privkey, badrs);
     badrs++;
     Q = G.mul(k);
-    r = Q.x.umod(N);
+    // elliptic points may carry coordinates backed by a different bn.js instance
+    // than bitcore's BN wrapper when bundled by tools like webpack. Normalize
+    // through bytes before doing BN arithmetic to avoid cross-instance asserts.
+    r = BN.fromBuffer(Buffer.from(Q.getX().toArray('be', 32))).umod(N);
     s = k.invm(N).mul(e.add(d.mul(r))).umod(N);
   } while (r.cmp(BN.Zero) <= 0 || s.cmp(BN.Zero) <= 0);
 
@@ -299,4 +302,3 @@ module.exports.__testing__ = {
   getRandomK,
   toLowS,
 };
-

--- a/packages/bitcore-lib/lib/crypto/ecdsa.js
+++ b/packages/bitcore-lib/lib/crypto/ecdsa.js
@@ -205,7 +205,10 @@ const sign = function(hashbuf, privkey, opts) {
     k = randomK ? getRandomK() : getDeterministicK(hashbuf, privkey, badrs);
     badrs++;
     Q = G.mul(k);
-    r = Q.x.umod(N);
+    // elliptic point coordinates may come from a different bn.js instance in
+    // bundled runtimes. Point#getX() normalizes back into bitcore's BN type
+    // before modular arithmetic.
+    r = Q.getX().umod(N);
     s = k.invm(N).mul(e.add(d.mul(r))).umod(N);
   } while (r.cmp(BN.Zero) <= 0 || s.cmp(BN.Zero) <= 0);
 
@@ -299,4 +302,3 @@ module.exports.__testing__ = {
   getRandomK,
   toLowS,
 };
-

--- a/packages/bitcore-lib/test/crypto/ecdsa.js
+++ b/packages/bitcore-lib/test/crypto/ecdsa.js
@@ -191,6 +191,13 @@ describe('ECDSA', function() {
       ctrlSig.toString('hex').should.equal(testSig.toString('hex'));
     });
 
+    it('should normalize elliptic BN coordinates before modular arithmetic', function() {
+      const pk = PrivateKey.fromString('1471d2f131a665b24d419f0920e854993153391e64d1971704ded65ffc3d1f0c');
+      const hashbuf = Buffer.from('7afd0a663b64666242ef6edf3542bc18a6a4587b01249a1fd2d8164b0eedf8d6', 'hex');
+      const sig = ECDSA.sign(hashbuf, pk, { randomK: false });
+      ECDSA.verify(hashbuf, sig, pk.toPublicKey()).should.equal(true);
+    });
+
     it('should throw on improper input: Array', function() {
       const pk = PrivateKey.fromString('1471d2f131a665b24d419f0920e854993153391e64d1971704ded65ffc3d1f0c');
       const hashbuf = Buffer.from('7afd0a663b64666242ef6edf3542bc18a6a4587b01249a1fd2d8164b0eedf8d6', 'hex');

--- a/packages/bitcore-lib/test/crypto/point.js
+++ b/packages/bitcore-lib/test/crypto/point.js
@@ -42,6 +42,13 @@ describe('Point', function() {
       a.should.deep.equal( Buffer.from(valid.x, 'hex'));
     });
 
+    it('should return a bitcore BN instance', function() {
+      var p = Point.getG();
+      var x = p.getX();
+      x.should.be.instanceof(BN);
+      x.constructor.should.equal(BN);
+    });
+
   });
 
   describe('#getY', function() {


### PR DESCRIPTION
## Summary

This fixes an assertion failure in `bitcore-lib` `ECDSA.sign()` that can happen in bundled environments where `bitcore-lib` and `elliptic` end up using different `bn.js` instances.

## Root cause

`ECDSA.sign()` computes:

```js
Q = G.mul(k);
r = Q.x.umod(N);
```

In some bundled runtimes:

- `Q.x` comes from `elliptic`
- `N` comes from bitcore's BN wrapper

Even though both are BN-like values, they are not guaranteed to be compatible for direct arithmetic across instances, which can trigger internal assertions.

## Fix

Normalize the elliptic coordinate through bytes before modular arithmetic:

```js
r = BN.fromBuffer(Buffer.from(Q.getX().toArray('be', 32))).umod(N);
```

`Q.x` is produced by `elliptic`, while the subsequent arithmetic uses bitcore's BN wrapper. Normalizing through bytes preserves the math while avoiding cross-instance BN operations.

## Validation

- added a regression test in `test/crypto/ecdsa.js`
- verified `npx mocha test/crypto/ecdsa.js`
- verified `npx mocha test/message.js`
