### PR TITLE
Add copayers to tss txps

### DIFF
--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -529,7 +529,7 @@ export class Wallet implements IWallet {
         messageHash: Buffer.from(messageHash, 'hex'),
         derivationPath,
         password,
-        id: `${txp.id}:${derivationPath.replace(/\//g, '-')}`,
+        id: `${txp.id}:input${i}`,
         logMessageWaiting: `Signing tx input ${i} (${i + 1}/${inputPaths.length}). Waiting for all parties to join...`,
         logMessageCompleted: `Tx input ${i} complete (${i + 1}/${inputPaths.length})`
       });

--- a/packages/bitcore-wallet-service/src/bws.ts
+++ b/packages/bitcore-wallet-service/src/bws.ts
@@ -34,6 +34,8 @@ if (config.https) {
       fs.readFileSync(config.CAinter2),
       fs.readFileSync(config.CAroot)
     ];
+  } else if (config.certificateAuthorities) {
+    serverOpts.ca = config.certificateAuthorities.map(caPath => fs.readFileSync(caPath));
   }
 }
 

--- a/packages/bitcore-wallet-service/src/lib/common/utils.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/utils.ts
@@ -365,6 +365,12 @@ export const Utils = {
     return 'testnet';
   },
 
+  getAddressNetworkForDbLookup(address, network) {
+    const generic = Utils.getGenericName(network);
+    if (generic === 'livenet') return address;
+    return `${address}:${generic}`;
+  },
+
   castToBool(input: any) {
     input = input?.toString();
     if (input?.toLowerCase() === 'true' || input == '1') {

--- a/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/txproposal.ts
@@ -424,16 +424,20 @@ export class TxProposal implements ITxProposal {
   }
 
   getCurrentSignatures() {
-    const acceptedActions = _.filter(this.actions, a => {
-      return a.type == 'accept';
-    });
+    const acceptedActions = this.actions.filter(a => a.type == 'accept');
 
-    return _.map(acceptedActions, x => {
-      return {
-        signatures: x.signatures,
-        xpub: x.xpub
-      };
-    });
+    const uniqueXpubs = new Set();
+    const signatures = [];
+    for (const a of acceptedActions) {
+      // TSS will have multiple accept actions with the same xpub/signature (different copayerIds)
+      if (uniqueXpubs.has(a.xpub)) continue;
+      uniqueXpubs.add(a.xpub);
+      signatures.push({
+        signatures: a.signatures,
+        xpub: a.xpub
+      });
+    }
+    return signatures;
   }
 
   getRawTx() {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1,4 +1,3 @@
-import util from 'util';
 import {
   BitcoreLib as Bitcore,
   BitcoreLibCash as BitcoreCash,
@@ -3361,13 +3360,15 @@ export class WalletService implements IWalletService {
           if (wallet.tssKeyId) {
             try {
               // Add the other copayers to the txp.copayers array
-              // so the client can see who participated in the signing.
-              const addrDbString = Utils.getAddressNetworkForDbLookup(txp.from || txp.inputs[0]?.address, wallet.network);
-              const address = await util.promisify(storage.fetchAddressByWalletId).call(storage, wallet.id, addrDbString);
-              const tssSigSeshId = `${txp.id}:${address.path.replace(/\//g, '-')}`;
+              //  so the client can see who participated in the signing.
+              // Note we hardcode to input0 as that should always be present and should suffice for
+              //  gathering copayers. However, there is a possibility that input1 (or any input >0)
+              //  could contain a different set of copayers, depending on the client's implementation
+              //  of TSS. While technically possible, it's unlikely and the impact is mostly aesthetic.
+              const tssSigSeshId = `${txp.id}:input0`;
               const tssSigSession = await storage.fetchTssSigSession({ id: tssSigSeshId });
               if (!tssSigSession) {
-                throw new Error('TSS signature session not found');
+                throw new Error('TSS signature session not found: ' + tssSigSeshId);
               }
               const copayerIds = tssSigSession.participants.map(p => p.copayerId);
               for (const copayerId of copayerIds) {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1,3 +1,4 @@
+import util from 'util';
 import {
   BitcoreLib as Bitcore,
   BitcoreLibCash as BitcoreCash,
@@ -3340,9 +3341,9 @@ export class WalletService implements IWalletService {
           
 
           const copayer = wallet.getCopayer(this.copayerId);
+          const xPubKey = wallet.tssKeyId ? wallet.clientDerivedPublicKey : copayer.xPubKey;
 
           try {
-            const xPubKey = wallet.tssKeyId ? wallet.clientDerivedPublicKey : copayer.xPubKey;
             if (!txp.sign(this.copayerId, opts.signatures, xPubKey)) {
               this.logw('Error signing transaction (BAD_SIGNATURES)');
               this.logw('Client version:', this.clientVersion);
@@ -3355,6 +3356,27 @@ export class WalletService implements IWalletService {
           } catch (ex) {
             this.logw('Error signing transaction proposal:', ex);
             return cb(ex);
+          }
+
+          if (wallet.tssKeyId) {
+            try {
+              // Add the other copayers to the txp.copayers array
+              // so the client can see who participated in the signing.
+              const addrDbString = Utils.getAddressNetworkForDbLookup(txp.from || txp.inputs[0]?.address, wallet.network);
+              const address = await util.promisify(storage.fetchAddressByWalletId).call(storage, wallet.id, addrDbString);
+              const tssSigSeshId = `${txp.id}:${address.path.replace(/\//g, '-')}`;
+              const tssSigSession = await storage.fetchTssSigSession({ id: tssSigSeshId });
+              if (!tssSigSession) {
+                throw new Error('TSS signature session not found');
+              }
+              const copayerIds = tssSigSession.participants.map(p => p.copayerId);
+              for (const copayerId of copayerIds) {
+                if (copayerId === this.copayerId) continue;
+                txp.addAction(copayerId, 'accept', null, opts.signatures, xPubKey);
+              }
+            } catch (err) {
+              this.logw('Error finding accepting copayers for TSS txp: %o %o', txp.id, err);
+            }
           }
 
           this.storage.storeTx(this.walletId, txp, err => {

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -166,6 +166,9 @@ export class Storage {
     db.collection(collections.TSS_KEYGEN).createIndex({
       id: 1
     }, { unique: true });
+    db.collection(collections.TSS_SIGN).createIndex({
+      id: 1
+    }, { unique: true });
   }
 
   connect(opts, cb) {


### PR DESCRIPTION
### Description
Accepted/broadcasted tx proposals for TSS wallets currently only have 1 copayer. This PR adds the other TSS participants as copayers to the txp so the client can see who participated in the TSS signing session.

### Changelog

* On pushing the signature to the server, gets TSS signing session and attaches other participants as copayers to the txp.
* Easier local https with a CA

### Testing Notes
You should be able to sign a txp with a TSS wallet as usual and the txp should have all signers listed in the copayers array

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.