### PR TITLE
Fix various small bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "lerna": "^5.6.2",
-        "typescript": "4.9.4"
+        "typescript": "5.7.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.37.0",
@@ -9553,6 +9553,19 @@
         "node": "^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/lerna/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -14126,15 +14139,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "lerna": "^5.6.2",
-    "typescript": "4.9.4"
+    "typescript": "5.7.3"
   },
   "husky": {
     "hooks": {

--- a/packages/bitcore-cli/src/commands/export.ts
+++ b/packages/bitcore-cli/src/commands/export.ts
@@ -13,6 +13,7 @@ export function command(args: CommonArgs) {
     .usage('<walletName> --command export [options]')
     .optionsGroup('Export Options')
     .option('--filename <filename>', 'Filename to export to', `~/${wallet.name}-export.json`)
+    .option('--readonly', 'Export as read-only (cannot send funds)')
     .parse(process.argv);
   
   const opts = program.opts();
@@ -22,16 +23,24 @@ export function command(args: CommonArgs) {
   return opts;
 }
 
-export async function exportWallet(args: CommonArgs<{ filename?: string }>) {
+export async function exportWallet(args: CommonArgs<{ filename?: string; readonly?: boolean }>) {
   const { wallet, opts } = args;
   if (opts.command) {
     Object.assign(opts, command(args));
   }
   const replaceTilde = str => str.startsWith('~') ? str.replace('~', os.homedir()) : str;
 
+  const readOnly = !!opts.readonly || wallet.isReadOnly() || await prompt.confirm({
+    message: 'Export as read-only (cannot send funds)?',
+    initialValue: false
+  });
+  if (prompt.isCancel(readOnly)) {
+    throw new UserCancelled();
+  }
+
   const filename = opts.filename || await prompt.text({
     message: 'Enter filename to export to:',
-    initialValue: `~/${wallet.name}-export.json`,
+    initialValue: `~/${wallet.name}${readOnly ? '-nokey' : ''}-export.json`,
     validate: (value) => {
       value = value.trim();
       if (!value) return 'Filename is required';
@@ -61,7 +70,8 @@ export async function exportWallet(args: CommonArgs<{ filename?: string }>) {
 
   await wallet.export({
     filename: replaceTilde(filename),
-    exportPassword
+    exportPassword,
+    readOnly
   });
   
   prompt.log.success('Exported to ' + filename);

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -301,17 +301,18 @@ export class Wallet implements IWallet {
       throw new Error('No wallet data to save. Wallet not created or loaded');
     }
     
-    let key;
+    let key: TssKey.TssKey | KeyType | undefined;
     if (!readOnly) {
       if (this.#walletData.key instanceof TssKey.TssKey) {
         key = new TssKey.TssKey(this.#walletData.key.toObj());
       } else {
         key = new Key({ seedType: 'object', seedData: this.#walletData.key.toObj() });
       }
-    }
-    if (key && (key.isPrivKeyEncrypted() || key.isKeyChainEncrypted?.())) {
-      const walletPassword = await getPassword('Wallet password:');
-      key.decrypt(walletPassword);
+
+      if (key.isPrivKeyEncrypted() || (key as TssKey.TssKey).isKeyChainEncrypted?.()) {
+        const walletPassword = await getPassword('Wallet password:');
+        key.decrypt(walletPassword);
+      }
     }
     
     let data: any = { key: key?.toObj(), credentials: this.#walletData.credentials.toObj() };

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -302,10 +302,12 @@ export class Wallet implements IWallet {
     }
     
     let key;
-    if (this.#walletData.key instanceof TssKey.TssKey) {
-      key = new TssKey.TssKey(this.#walletData.key.toObj());
-    } else if (!readOnly) {
-      key = new Key({ seedType: 'object', seedData: this.#walletData.key.toObj() });
+    if (!readOnly) {
+      if (this.#walletData.key instanceof TssKey.TssKey) {
+        key = new TssKey.TssKey(this.#walletData.key.toObj());
+      } else {
+        key = new Key({ seedType: 'object', seedData: this.#walletData.key.toObj() });
+      }
     }
     if (key && (key.isPrivKeyEncrypted() || key.isKeyChainEncrypted?.())) {
       const walletPassword = await getPassword('Wallet password:');

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -222,7 +222,7 @@ export class Wallet implements IWallet {
     walletData = (walletData as WalletData);
     
 
-    const instantiateKey = () => {
+    const instantiateKey = (walletData: WalletData) => {
       if (!walletData.key) {
         return undefined; // read-only wallet
       }
@@ -240,11 +240,11 @@ export class Wallet implements IWallet {
       const imported = Client.upgradeCredentialsV1(walletData);
       this.client.fromString(JSON.stringify(imported.credentials));
 
-      key = instantiateKey();
+      key = instantiateKey(walletData);
     } catch {
       try {
         this.client.fromObj(walletData.credentials);
-        key = instantiateKey();
+        key = instantiateKey(walletData);
       } catch (e) {
         Utils.die('Corrupt wallet file:' + (_verbose && e.stack ? e.stack : e));
       }
@@ -273,7 +273,7 @@ export class Wallet implements IWallet {
       if (!this.#walletData) {
         throw new Error('No wallet data to save. Wallet not created or loaded');
       }
-      let data: WalletData | EncryptionTypes.IEncrypted = { key: this.#walletData.key.toObj(), credentials: this.#walletData.credentials.toObj() };
+      let data: WalletData | EncryptionTypes.IEncrypted = { key: this.#walletData.key?.toObj(), credentials: this.#walletData.credentials.toObj() };
       if (encryptAll) {
         const password = await getPassword('Enter password to encrypt:', { minLength: 6 });
         await prompt.password({
@@ -331,13 +331,15 @@ export class Wallet implements IWallet {
     let data: any = await fs.promises.readFile(filename, 'utf8');
     data = Encryption.decryptWithPassword(data, importPassword);
     data = Utils.jsonParseWithBuffer(data);
-    if (data.key.keychain) {
-      data.key = new TssKey.TssKey(data.key);
-    } else {
-      data.key = new Key({ seedType: 'object', seedData: data.key });
+    if (data.key) { // no data.key means it's a readonly wallet
+      if (data.key.keychain) {
+        data.key = new TssKey.TssKey(data.key);
+      } else {
+        data.key = new Key({ seedType: 'object', seedData: data.key });
+      }
+      const walletPassword = await getPassword('Set a wallet password:', { minLength: 6, hidden: false });
+      data.key.encrypt(walletPassword);
     }
-    const walletPassword = await getPassword('Wallet password:', { minLength: 6, hidden: false });
-    data.key.encrypt(walletPassword);
     this.#walletData = {
       key: data.key,
       credentials: Credentials.fromObj(data.credentials)

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -294,8 +294,9 @@ export class Wallet implements IWallet {
   async export(args: {
     filename: string;
     exportPassword?: string;
+    readOnly?: boolean;
   }) {
-    const { filename, exportPassword } = args;
+    const { filename, exportPassword, readOnly } = args;
     if (!this.#walletData) {
       throw new Error('No wallet data to save. Wallet not created or loaded');
     }
@@ -303,15 +304,15 @@ export class Wallet implements IWallet {
     let key;
     if (this.#walletData.key instanceof TssKey.TssKey) {
       key = new TssKey.TssKey(this.#walletData.key.toObj());
-    } else {
+    } else if (!readOnly) {
       key = new Key({ seedType: 'object', seedData: this.#walletData.key.toObj() });
     }
-    if (key.isPrivKeyEncrypted() || key.isKeyChainEncrypted?.()) {
+    if (key && (key.isPrivKeyEncrypted() || key.isKeyChainEncrypted?.())) {
       const walletPassword = await getPassword('Wallet password:');
       key.decrypt(walletPassword);
     }
     
-    let data: any = { key: key.toObj(), credentials: this.#walletData.credentials.toObj() };
+    let data: any = { key: key?.toObj(), credentials: this.#walletData.credentials.toObj() };
     if (exportPassword != null) {
       data = Encryption.encryptWithPassword(data, exportPassword, WALLET_ENCRYPTION_OPTS);
     }

--- a/packages/bitcore-cli/types/wallet.d.ts
+++ b/packages/bitcore-cli/types/wallet.d.ts
@@ -62,6 +62,7 @@ export interface IWallet {
   export(args: {
     filename: string;
     exportPassword?: string;
+    readOnly?: boolean;
   }): Promise<void>;
   import(args: {
     filename: string;

--- a/packages/insight/package-lock.json
+++ b/packages/insight/package-lock.json
@@ -9,13 +9,13 @@
       "version": "10.0.11",
       "license": "MIT",
       "dependencies": {
+        "@bitpay-labs/bitcore-lib": "^11.8.1",
+        "@bitpay-labs/bitcore-lib-cash": "^11.8.1",
+        "@bitpay-labs/bitcore-lib-doge": "^11.8.1",
+        "@bitpay-labs/bitcore-lib-ltc": "^11.8.1",
         "@reduxjs/toolkit": "2.3.0",
         "assert": "2.1.0",
         "axios": "1.7.9",
-        "bitcore-lib": "^10.0.23",
-        "bitcore-lib-cash": "^10.0.23",
-        "bitcore-lib-doge": "^10.0.21",
-        "bitcore-lib-ltc": "^10.0.21",
         "buffer": "6.0.3",
         "chart.js": "4.4.6",
         "crypto-browserify": "3.12.1",
@@ -2041,6 +2041,90 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@bitpay-labs/bitcore-lib": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@bitpay-labs/bitcore-lib/-/bitcore-lib-11.8.1.tgz",
+      "integrity": "sha512-uw/zb/BHIBEWcOAVGo5XPYldl24Km96krafHOrlg/05DYuqJaJG5zGL86Mgb6C9FJ0/tPIuCda7Y8FokqbmDTw==",
+      "license": "MIT",
+      "dependencies": {
+        "bech32": "=2.0.0",
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "^6.5.3",
+        "inherits": "=2.0.1",
+        "lodash": "^4.17.20"
+      }
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-cash": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@bitpay-labs/bitcore-lib-cash/-/bitcore-lib-cash-11.8.1.tgz",
+      "integrity": "sha512-G4AJp3RkTAkFVOoaF2jjdtsrIQ4EHcrViIPAbRy666MJoTHdGbLoRUS7qP9x+AgYKlOUr69JYLEiqceDgYwY8w==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "^6.5.3",
+        "inherits": "=2.0.1",
+        "lodash": "^4.17.20"
+      }
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-cash/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "license": "ISC"
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-doge": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@bitpay-labs/bitcore-lib-doge/-/bitcore-lib-doge-11.8.1.tgz",
+      "integrity": "sha512-U0P+RDPuxO3Qu9rZ0AMuJE+4NG51xPviADxLq3v9rEt0KkEYb+mMlb8qQoM1FCBXqsH1l2DsbwoVAa+aKTfV1A==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "^6.5.3",
+        "inherits": "=2.0.1",
+        "lodash": "^4.17.20",
+        "scryptsy": "2.1.0"
+      }
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-doge/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "license": "ISC"
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-ltc": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@bitpay-labs/bitcore-lib-ltc/-/bitcore-lib-ltc-11.8.1.tgz",
+      "integrity": "sha512-fXuQEBu4lG4E6KmkuS+aW7X+2RYuYOtRVLKgnNYWpNppZJ+GLF1hY8COI0rvjdg6DH3phm4PeQgJX7sO+MRchg==",
+      "license": "MIT",
+      "dependencies": {
+        "bech32": "=2.0.0",
+        "bn.js": "=4.11.8",
+        "bs58": "^4.0.1",
+        "buffer-compare": "=1.1.1",
+        "elliptic": "^6.5.3",
+        "inherits": "=2.0.1",
+        "lodash": "^4.17.20",
+        "scryptsy": "2.1.0"
+      }
+    },
+    "node_modules/@bitpay-labs/bitcore-lib-ltc/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "license": "ISC"
+    },
+    "node_modules/@bitpay-labs/bitcore-lib/node_modules/inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==",
+      "license": "ISC"
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
@@ -5767,82 +5851,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bitcore-lib": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-10.5.3.tgz",
-      "integrity": "sha512-QTeKpe5Md8x4njp6PsBCek+kZ0AA21RfBZi8HmTo+16laRxqyHz+pcn2pxDJgq6ZLmVLfU+AykKgHGqPt1KAYg==",
-      "dependencies": {
-        "bech32": "=2.0.0",
-        "bn.js": "=4.11.8",
-        "bs58": "^4.0.1",
-        "buffer-compare": "=1.1.1",
-        "elliptic": "^6.5.3",
-        "inherits": "=2.0.1",
-        "lodash": "^4.17.20"
-      }
-    },
-    "node_modules/bitcore-lib-cash": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/bitcore-lib-cash/-/bitcore-lib-cash-10.5.3.tgz",
-      "integrity": "sha512-CVcxGKYIslwj/1XQgbfWA1i4jLQSQQtJsyL5i4o6JIP7UkNIcmL0gujh65q2FJApwON8DihREMJMF2ryi5fpdg==",
-      "dependencies": {
-        "bn.js": "=4.11.8",
-        "bs58": "^4.0.1",
-        "buffer-compare": "=1.1.1",
-        "elliptic": "^6.5.3",
-        "inherits": "=2.0.1",
-        "lodash": "^4.17.20"
-      }
-    },
-    "node_modules/bitcore-lib-cash/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
-    },
-    "node_modules/bitcore-lib-doge": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/bitcore-lib-doge/-/bitcore-lib-doge-10.5.3.tgz",
-      "integrity": "sha512-JduFfTVKxdn8bWGsnxZhWt9zJgA46fNgBG26zuJ6KtBZum4mQw88aP/6dYMSiS/oCZOvY0knAJfA8EQjqGG+qA==",
-      "dependencies": {
-        "bn.js": "=4.11.8",
-        "bs58": "^4.0.1",
-        "buffer-compare": "=1.1.1",
-        "elliptic": "^6.5.3",
-        "inherits": "=2.0.1",
-        "lodash": "^4.17.20",
-        "scryptsy": "2.1.0"
-      }
-    },
-    "node_modules/bitcore-lib-doge/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
-    },
-    "node_modules/bitcore-lib-ltc": {
-      "version": "10.5.3",
-      "resolved": "https://registry.npmjs.org/bitcore-lib-ltc/-/bitcore-lib-ltc-10.5.3.tgz",
-      "integrity": "sha512-hVIH5WTED1RInshZ00knBnXaWCbo7tZwrWBax2z2ZcVF7OCC52Ae5v8t1CWWKGRDtWq7panIGe3uuZsmTMmdpA==",
-      "dependencies": {
-        "bech32": "=2.0.0",
-        "bn.js": "=4.11.8",
-        "bs58": "^4.0.1",
-        "buffer-compare": "=1.1.1",
-        "elliptic": "^6.5.3",
-        "inherits": "=2.0.1",
-        "lodash": "^4.17.20",
-        "scryptsy": "2.1.0"
-      }
-    },
-    "node_modules/bitcore-lib-ltc/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
-    },
-    "node_modules/bitcore-lib/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA=="
     },
     "node_modules/bluebird": {
       "version": "3.7.2",

--- a/packages/insight/package.json
+++ b/packages/insight/package.json
@@ -25,10 +25,10 @@
     "postbuild": "./postbuild.sh"
   },
   "dependencies": {
-    "@bitpay-labs/bitcore-lib": "^10.0.23",
-    "@bitpay-labs/bitcore-lib-cash": "^10.0.23",
-    "@bitpay-labs/bitcore-lib-doge": "^10.0.21",
-    "@bitpay-labs/bitcore-lib-ltc": "^10.0.21",
+    "@bitpay-labs/bitcore-lib": "^11.8.1",
+    "@bitpay-labs/bitcore-lib-cash": "^11.8.1",
+    "@bitpay-labs/bitcore-lib-doge": "^11.8.1",
+    "@bitpay-labs/bitcore-lib-ltc": "^11.8.1",
     "@reduxjs/toolkit": "2.3.0",
     "assert": "2.1.0",
     "axios": "1.7.9",

--- a/packages/insight/src/components/block-details.tsx
+++ b/packages/insight/src/components/block-details.tsx
@@ -193,7 +193,7 @@ const BlockDetails: FC<BlockDetailsProps> = ({currency, network, block}) => {
 
               <SecondaryTitle>Transactions</SecondaryTitle>
 
-              {transactionList.length ? (
+              {transactionList?.length ? (
                 <InfiniteScroll
                   next={() => loadMore()}
                   hasMore={hasMore}


### PR DESCRIPTION
### Description
This fixes various small bugs I found while digging into various issues recently

### Changelog

* bitcore-cli: Fixes read-only wallet imports
* bitcore-cli: Adds read-only export functionality (to support exporting RO wallets)
* root: Fixes vscode debugger crashing - bump root typescript version to 5.7
* insight: Fixes bitcore libs version mismatch with `@bitpay-labs` depdendencies
* insight: Fixes block page crashing to a white page when the block tx call fails

### Testing Notes
* bitcore-cli: Export any read-only wallet from the app and import into bitcore-cli
* bitcore-cli: Export a wallet as read-only
* bitcore-cli: Export a read-only wallet -- it should not error and not ask if you want to export read-only.
* root: The vscode debugger should work
* insight: it should run + going to block page where txs API call returns empty should not crash to a white page

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.