### PR TITLE
Remove lodash from BWS express app route modules

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/routes/blockchain.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/blockchain.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import * as _ from 'lodash';
 import type * as Types from '../../types/expressapp';
 import type { WalletService } from '../server';
 
@@ -74,10 +73,10 @@ export function registerBlockchainRoutes(router: express.Router, context: RouteC
         if (req.query.network) opts.network = req.query.network as string;
         server.getFeeLevels(opts, resolve);
       }).then((feeLevels: any[]) => {
-        _.each(feeLevels, feeLevel => {
+        for (const feeLevel of feeLevels) {
           feeLevel.feePerKB = feeLevel.feePerKb;
           delete feeLevel.feePerKb;
-        });
+        }
         return feeLevels;
       })
     );

--- a/packages/bitcore-wallet-service/src/lib/routes/maintenance.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/maintenance.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import * as _ from 'lodash';
 import { WalletService } from '../server';
 import { Stats } from '../stats';
 import type * as Types from '../../types/expressapp';
@@ -84,8 +83,9 @@ export function registerMaintenanceRoutes(router: express.Router, context: Route
   router.get('/v1/txnotes/', (req, res) => {
     getServerWithAuth(req, res, server => {
       const opts: { minTs?: number } = {};
-      if (req.query.minTs && _.isNumber(+req.query.minTs)) {
-        opts.minTs = +req.query.minTs;
+      const minTs = +req.query.minTs;
+      if (req.query.minTs && typeof minTs === 'number') {
+        opts.minTs = minTs;
       }
       server.getTxNotes(opts, (err, notes) => {
         if (err) return returnError(err, res, req);

--- a/packages/bitcore-wallet-service/src/lib/routes/maintenance.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/maintenance.ts
@@ -83,9 +83,12 @@ export function registerMaintenanceRoutes(router: express.Router, context: Route
   router.get('/v1/txnotes/', (req, res) => {
     getServerWithAuth(req, res, server => {
       const opts: { minTs?: number } = {};
-      const minTs = +req.query.minTs;
-      if (req.query.minTs && typeof minTs === 'number') {
-        opts.minTs = minTs;
+      const rawMinTs = req.query.minTs;
+      if (typeof rawMinTs === 'string' && rawMinTs.trim() !== '') {
+        const minTs = Number(rawMinTs);
+        if (Number.isFinite(minTs)) {
+          opts.minTs = minTs;
+        }
       }
       server.getTxNotes(opts, (err, notes) => {
         if (err) return returnError(err, res, req);

--- a/packages/bitcore-wallet-service/src/lib/routes/walletdata.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/walletdata.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import * as _ from 'lodash';
 import { Common } from '../common';
 import type * as Types from '../../types/expressapp';
 import type { GetAddressesOpts } from '../../types/server';
@@ -133,7 +132,7 @@ export function registerWalletDataRoutes(router: express.Router, context: RouteC
   router.get('/v1/utxos/', (req, res) => {
     const opts: { addresses?: string[] } = {};
     const addresses = req.query.addresses;
-    if (addresses && _.isString(addresses)) {
+    if (addresses && typeof addresses === 'string') {
       opts.addresses = (req.query.addresses as string).split(',');
     }
 

--- a/packages/bitcore-wallet-service/src/lib/routes/wallets.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/wallets.ts
@@ -1,6 +1,5 @@
 import * as async from 'async';
 import express from 'express';
-import * as _ from 'lodash';
 import { Common } from '../common';
 import { ClientError } from '../errors/clienterror';
 import logger from '../logger';
@@ -212,7 +211,7 @@ export function registerWalletRoutes(router: express.Router, context: RouteConte
     if (res.headersSent) {
       return;
     }
-    return res.json(_.flatten(responses));
+    return res.json(responses.reduce((all, response) => all.concat(response), []));
   });
 
   router.post('/v1/wallets/exist', async (req, res) => {

--- a/packages/bitcore-wallet-service/src/lib/routes/wallets.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/wallets.ts
@@ -211,7 +211,7 @@ export function registerWalletRoutes(router: express.Router, context: RouteConte
     if (res.headersSent) {
       return;
     }
-    return res.json(responses.reduce((all, response) => all.concat(response), []));
+    return res.json(responses.flat());
   });
 
   router.post('/v1/wallets/exist', async (req, res) => {


### PR DESCRIPTION
### Description
Removes the remaining lodash usage from the BWS express app route modules. This keeps the extracted route code behavior-equivalent while reducing lodash dependency surface in the `expressapp.ts` route area.

### Changelog

* Replace lodash `each`, `isNumber`, `isString`, and `flatten` usage in BWS route modules with native equivalents.
* Remove lodash imports from the blockchain, maintenance, walletdata, and wallets route modules.

### Testing Notes

* Ran direct lodash-vs-native replacement checks.
* Ran BWS lint and production build.
* Ran focused ExpressApp route tests.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
