### PR TITLE
Fix bitcore-lib brittle point handling

### DIFF
--- a/packages/bitcore-lib/lib/crypto/schnorr.js
+++ b/packages/bitcore-lib/lib/crypto/schnorr.js
@@ -114,9 +114,9 @@ Schnorr.verify = function(publicKey, message, signature) {
     const p = Point.getP();
     const n = Point.getN();
 
-    const P = Point.fromX(false, publicKey).liftX();
-    const r = new BN(signature.slice(0, 32));
-    const s = new BN(signature.slice(32, 64));
+    const P = Point.fromX(false, BN.fromBuffer(publicKey)).liftX();
+    const r = BN.fromBuffer(signature.slice(0, 32));
+    const s = BN.fromBuffer(signature.slice(32, 64));
     if (r.gte(p) || s.gte(n)) {
       return false;
     }

--- a/packages/bitcore-lib/lib/publickey.js
+++ b/packages/bitcore-lib/lib/publickey.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var BN = require('./crypto/bn');
-var Point = require('./crypto/point');
-var Hash = require('./crypto/hash');
-var JSUtil = require('./util/js');
-var Network = require('./networks');
-var _ = require('lodash');
-var $ = require('./util/preconditions');
+const _ = require('lodash');
+const BN = require('./crypto/bn');
+const Hash = require('./crypto/hash');
+const Point = require('./crypto/point');
 const TaggedHash = require('./crypto/taggedhash');
+const Network = require('./networks');
+const JSUtil = require('./util/js');
+const $ = require('./util/preconditions');
 
 /**
  * Instantiate a PublicKey from a {@link PrivateKey}, {@link Point}, `string`, or `Buffer`.
@@ -18,13 +18,13 @@ const TaggedHash = require('./crypto/taggedhash');
  * @example
  * ```javascript
  * // instantiate from a private key
- * var key = PublicKey(privateKey, true);
+ * let key = PublicKey(privateKey, true);
  *
  * // export to as a DER hex encoded string
- * var exported = key.toString();
+ * let exported = key.toString();
  *
  * // import the public key
- * var imported = PublicKey.fromString(exported);
+ * let imported = PublicKey.fromString(exported);
  * ```
  *
  * @param {string|PrivateKey} [data] - The encoded data in various formats
@@ -48,7 +48,7 @@ function PublicKey(data, extra) {
   }
   extra = extra || {};
 
-  var info = this._classifyArgs(data, extra);
+  const info = this._classifyArgs(data, extra);
 
   // validation
   info.point.validate();
@@ -69,7 +69,7 @@ function PublicKey(data, extra) {
  */
 PublicKey.prototype._classifyArgs = function(data, extra) {
   /* jshint maxcomplexity: 10 */
-  var info = {
+  let info = {
     compressed: _.isUndefined(extra.compressed) || extra.compressed
   };
 
@@ -101,7 +101,7 @@ PublicKey.prototype._classifyArgs = function(data, extra) {
  * @private
  */
 PublicKey._isPrivateKey = function(param) {
-  var PrivateKey = require('./privatekey');
+  const PrivateKey = require('./privatekey');
   return param instanceof PrivateKey;
 };
 
@@ -125,7 +125,7 @@ PublicKey._isBuffer = function(param) {
  */
 PublicKey._transformPrivateKey = function(privkey) {
   $.checkArgument(PublicKey._isPrivateKey(privkey), 'Must be an instance of PrivateKey');
-  var info = {};
+  const info = {};
   info.point = Point.getG().mul(privkey.bn);
   info.compressed = privkey.compressed;
   info.network = privkey.network;
@@ -144,14 +144,14 @@ PublicKey._transformDER = function(buf, strict) {
   /* jshint maxstatements: 30 */
   /* jshint maxcomplexity: 12 */
   $.checkArgument(PublicKey._isBuffer(buf), 'Must be a hex buffer of DER encoded public key');
-  var info = {};
+  let info = {};
 
   strict = _.isUndefined(strict) ? true : strict;
 
-  var x;
-  var y;
-  var xbuf;
-  var ybuf;
+  let x;
+  let y;
+  let xbuf;
+  let ybuf;
 
   if (buf[0] === 0x04 || (!strict && (buf[0] === 0x06 || buf[0] === 0x07))) {
     xbuf = buf.slice(1, 33);
@@ -192,7 +192,7 @@ PublicKey._transformX = function(odd, x) {
   if (Buffer.isBuffer(x)) {
     x = BN.fromBuffer(x);
   }
-  var info = {};
+  const info = {};
   info.point = Point.fromX(odd, x);
   return info;
 };
@@ -205,9 +205,9 @@ PublicKey._transformX = function(odd, x) {
  * @private
  */
 PublicKey._transformObject = function(json) {
-  var x = new BN(json.x, 'hex');
-  var y = new BN(json.y, 'hex');
-  var point = new Point(x, y);
+  const x = new BN(json.x, 'hex');
+  const y = new BN(json.y, 'hex');
+  const point = new Point(x, y);
   return new PublicKey(point, {
     compressed: json.compressed
   });
@@ -221,7 +221,7 @@ PublicKey._transformObject = function(json) {
  */
 PublicKey.fromPrivateKey = function(privkey) {
   $.checkArgument(PublicKey._isPrivateKey(privkey), 'Must be an instance of PrivateKey');
-  var info = PublicKey._transformPrivateKey(privkey);
+  const info = PublicKey._transformPrivateKey(privkey);
   return new PublicKey(info.point, {
     compressed: info.compressed,
     network: info.network
@@ -240,7 +240,7 @@ PublicKey.fromBuffer = function(buf, strict) {
     return PublicKey.fromX(false, buf);
   }
   return PublicKey.fromDER(buf, strict);
-}
+};
 
 /**
  * Instantiate a PublicKey from a DER buffer
@@ -250,7 +250,7 @@ PublicKey.fromBuffer = function(buf, strict) {
  */
 PublicKey.fromDER = function(buf, strict) {
   $.checkArgument(PublicKey._isBuffer(buf), 'Must be a hex buffer of DER encoded public key');
-  var info = PublicKey._transformDER(buf, strict);
+  const info = PublicKey._transformDER(buf, strict);
   return new PublicKey(info.point, {
     compressed: info.compressed
   });
@@ -278,8 +278,8 @@ PublicKey.fromPoint = function(point, compressed) {
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromString = function(str, encoding) {
-  var buf = Buffer.from(str, encoding || 'hex');
-  var info = PublicKey._transformDER(buf);
+  const buf = Buffer.from(str, encoding || 'hex');
+  const info = PublicKey._transformDER(buf);
   return new PublicKey(info.point, {
     compressed: info.compressed
   });
@@ -293,7 +293,7 @@ PublicKey.fromString = function(str, encoding) {
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromX = function(odd, x) {
-  var info = PublicKey._transformX(odd, x);
+  const info = PublicKey._transformX(odd, x);
   return new PublicKey(info.point, {
     compressed: info.compressed
   });
@@ -311,7 +311,7 @@ PublicKey.fromTaproot = function(hexBuf) {
   $.checkArgument(Buffer.isBuffer(hexBuf), 'hexBuf must be a hex string or buffer');
   $.checkArgument(hexBuf.length === 32, 'Taproot public keys must be 32 bytes');
   return new PublicKey.fromX(false, hexBuf);
-}
+};
 
 /**
  * Verifies if the input is a valid Taproot public key
@@ -396,7 +396,7 @@ PublicKey.prototype.createTapTweak = function(merkleRoot) {
  * @returns {null|Error} An error if exists
  */
 PublicKey.getValidationError = function(data) {
-  var error;
+  let error;
   try {
     /* jshint nonew: false */
     new PublicKey(data);
@@ -433,22 +433,22 @@ PublicKey.prototype.toObject = PublicKey.prototype.toJSON = function toObject() 
  * @returns {Buffer} A DER hex encoded buffer
  */
 PublicKey.prototype.toBuffer = PublicKey.prototype.toDER = function() {
-  var x = this.point.getX();
-  var y = this.point.getY();
+  const x = this.point.getX();
+  const y = this.point.getY();
 
-  var xbuf = x.toBuffer({
+  const xbuf = x.toBuffer({
     size: 32
   });
-  var ybuf = y.toBuffer({
+  const ybuf = y.toBuffer({
     size: 32
   });
 
-  var prefix;
+  let prefix;
   if (!this.compressed) {
     prefix = Buffer.from([0x04]);
     return Buffer.concat([prefix, xbuf, ybuf]);
   } else {
-    var odd = ybuf[ybuf.length - 1] % 2;
+    const odd = ybuf[ybuf.length - 1] % 2;
     if (odd) {
       prefix = Buffer.from([0x03]);
     } else {
@@ -475,7 +475,7 @@ PublicKey.prototype._getID = function _getID() {
  * @returns {Address} An address generated from the public key
  */
 PublicKey.prototype.toAddress = function(network, type) {
-  var Address = require('./address');
+  const Address = require('./address');
   return Address.fromPublicKey(this, network || this.network, type);
 };
 

--- a/packages/bitcore-lib/lib/publickey.js
+++ b/packages/bitcore-lib/lib/publickey.js
@@ -189,6 +189,9 @@ PublicKey._transformDER = function(buf, strict) {
  */
 PublicKey._transformX = function(odd, x) {
   $.checkArgument(typeof odd === 'boolean', 'Must specify whether y is odd or not (true or false)');
+  if (Buffer.isBuffer(x)) {
+    x = BN.fromBuffer(x);
+  }
   var info = {};
   info.point = Point.fromX(odd, x);
   return info;

--- a/packages/bitcore-lib/lib/publickey.js
+++ b/packages/bitcore-lib/lib/publickey.js
@@ -180,18 +180,16 @@ PublicKey._transformDER = function(buf, strict) {
 };
 
 /**
- * Internal function to transform X into a public key point
+ * Internal function to transform an X coordinate into a public key point
  *
  * @param {Boolean} odd - If the point is above or below the x axis
- * @param {Point} x - The x point
+ * @param {BN} x - The x coordinate as a BN
  * @returns {Object} An object with keys: point and compressed
  * @private
  */
 PublicKey._transformX = function(odd, x) {
   $.checkArgument(typeof odd === 'boolean', 'Must specify whether y is odd or not (true or false)');
-  if (Buffer.isBuffer(x)) {
-    x = BN.fromBuffer(x);
-  }
+  $.checkArgument(x instanceof BN, 'x must be an instance of BN');
   const info = {};
   info.point = Point.fromX(odd, x);
   return info;
@@ -237,7 +235,7 @@ PublicKey.fromPrivateKey = function(privkey) {
 PublicKey.fromBuffer = function(buf, strict) {
   $.checkArgument(PublicKey._isBuffer(buf), 'Must be a hex buffer of DER encoded public key or 32 byte X coordinate (taproot)');
   if (buf.length === 32) {
-    return PublicKey.fromX(false, buf);
+    return PublicKey.fromX(false, BN.fromBuffer(buf));
   }
   return PublicKey.fromDER(buf, strict);
 };
@@ -286,13 +284,14 @@ PublicKey.fromString = function(str, encoding) {
 };
 
 /**
- * Instantiate a PublicKey from an X Point
+ * Instantiate a PublicKey from an X coordinate
  *
  * @param {Boolean} odd - If the point is above or below the x axis
- * @param {Point} x - The x point
+ * @param {BN} x - The x coordinate as a BN
  * @returns {PublicKey} A new valid instance of PublicKey
  */
 PublicKey.fromX = function(odd, x) {
+  $.checkArgument(x instanceof BN, 'x must be an instance of BN');
   const info = PublicKey._transformX(odd, x);
   return new PublicKey(info.point, {
     compressed: info.compressed
@@ -310,7 +309,7 @@ PublicKey.fromTaproot = function(hexBuf) {
   }
   $.checkArgument(Buffer.isBuffer(hexBuf), 'hexBuf must be a hex string or buffer');
   $.checkArgument(hexBuf.length === 32, 'Taproot public keys must be 32 bytes');
-  return new PublicKey.fromX(false, hexBuf);
+  return PublicKey.fromX(false, BN.fromBuffer(hexBuf));
 };
 
 /**

--- a/packages/bitcore-lib/lib/script/interpreter.js
+++ b/packages/bitcore-lib/lib/script/interpreter.js
@@ -1,18 +1,18 @@
+/* eslint-disable no-bitwise */
 'use strict';
 
 const _ = require('lodash');
-
-const Script = require('./script');
-const Opcode = require('../opcode');
 const BN = require('../crypto/bn');
 const Hash = require('../crypto/hash');
 const Signature = require('../crypto/signature');
-const PublicKey = require('../publickey');
-const $ = require('../util/preconditions');
-const SighashWitness = require('../transaction/sighashwitness');
-const SighashSchnorr = require('../transaction/sighashschnorr');
-const BufferWriter = require('../encoding/bufferwriter');
 const TaggedHash = require('../crypto/taggedhash');
+const BufferWriter = require('../encoding/bufferwriter');
+const Opcode = require('../opcode');
+const PublicKey = require('../publickey');
+const SighashSchnorr = require('../transaction/sighashschnorr');
+const SighashWitness = require('../transaction/sighashwitness');
+const $ = require('../util/preconditions');
+const Script = require('./script');
 
 /**
  * Bitcoin transactions contain scripts. Each input has a script called the
@@ -24,7 +24,7 @@ const TaggedHash = require('../crypto/taggedhash');
  * The primary way to use this class is via the verify function.
  * e.g., Interpreter().verify( ... );
  */
-var Interpreter = function Interpreter(obj) {
+const Interpreter = function Interpreter(obj) {
   if (!(this instanceof Interpreter)) {
     return new Interpreter(obj);
   }
@@ -39,8 +39,8 @@ var Interpreter = function Interpreter(obj) {
 
 Interpreter.prototype.verifyWitnessProgram = function(version, program, witness, satoshis, flags, isP2SH) {
 
-  var scriptPubKey = new Script();
-  var stack = [];
+  let scriptPubKey = new Script();
+  let stack = [];
 
   if (version === 0) {
     if (program.length === Interpreter.WITNESS_V0_SCRIPTHASH_SIZE) {
@@ -49,9 +49,9 @@ Interpreter.prototype.verifyWitnessProgram = function(version, program, witness,
         return false;
       }
 
-      var scriptPubKeyBuffer = witness[witness.length - 1];
+      const scriptPubKeyBuffer = witness[witness.length - 1];
       scriptPubKey = new Script(scriptPubKeyBuffer);
-      var hash = Hash.sha256(scriptPubKeyBuffer);
+      const hash = Hash.sha256(scriptPubKeyBuffer);
       if (hash.toString('hex') !== program.toString('hex')) {
         this.errstr = 'SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH';
         return false;
@@ -107,8 +107,8 @@ Interpreter.prototype.verifyWitnessProgram = function(version, program, witness,
       const scriptPubKeyBuf = stack.pop();
 
       if (
-        control.length < Interpreter.TAPROOT_CONTROL_BASE_SIZE  ||
-        control.length > Interpreter.TAPROOT_CONTROL_MAX_SIZE   ||
+        control.length < Interpreter.TAPROOT_CONTROL_BASE_SIZE ||
+        control.length > Interpreter.TAPROOT_CONTROL_MAX_SIZE ||
         ((control.length - Interpreter.TAPROOT_CONTROL_BASE_SIZE) % Interpreter.TAPROOT_CONTROL_NODE_SIZE) != 0
       ) {
         this.errstr = 'SCRIPT_ERR_TAPROOT_WRONG_CONTROL_SIZE';
@@ -126,7 +126,7 @@ Interpreter.prototype.verifyWitnessProgram = function(version, program, witness,
         {
           const bw = new BufferWriter();
           bw.writeVarintNum(witness.length);
-          for (let element of witness) {
+          for (const element of witness) {
             bw.writeVarintNum(element.length);
             bw.write(element);
           }
@@ -135,7 +135,7 @@ Interpreter.prototype.verifyWitnessProgram = function(version, program, witness,
 
         try {
           scriptPubKey = new Script(scriptPubKeyBuf);
-        } catch (err) {
+        } catch {
           // Note how this condition would not be reached if an unknown OP_SUCCESSx was found
           this.errstr = 'SCRIPT_ERR_BAD_OPCODE';
           return false;
@@ -164,7 +164,7 @@ Interpreter.prototype.verifyWitnessProgram = function(version, program, witness,
 
 Interpreter.prototype.executeWitnessScript = function(scriptPubKey, stack, sigversion, satoshis, flags, execdata) {
   if (sigversion === Signature.Version.TAPSCRIPT) {
-    for (let chunk of scriptPubKey.chunks) {
+    for (const chunk of scriptPubKey.chunks) {
       // New opcodes will be listed here. May use a different sigversion to modify existing opcodes.
       if (Opcode.isOpSuccess(chunk.opcodenum)) {
         if (flags & Interpreter.SCRIPT_VERIFY_DISCOURAGE_OP_SUCCESS) {
@@ -208,7 +208,7 @@ Interpreter.prototype.executeWitnessScript = function(scriptPubKey, stack, sigve
     return false;
   }
 
-  var buf = this.stack[this.stack.length - 1];
+  const buf = this.stack[this.stack.length - 1];
   if (!Interpreter.castToBool(buf)) {
     this.errstr = 'SCRIPT_ERR_EVAL_FALSE_IN_STACK';
     return false;
@@ -236,7 +236,7 @@ Interpreter.prototype.executeWitnessScript = function(scriptPubKey, stack, sigve
  */
 Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags, witness, satoshis) {
 
-  var Transaction = require('../transaction');
+  const Transaction = require('../transaction');
   if (_.isUndefined(tx)) {
     tx = new Transaction();
   }
@@ -261,7 +261,7 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
     satoshis: 0,
     flags: flags
   });
-  var stackCopy;
+  let stackCopy;
 
   if ((flags & Interpreter.SCRIPT_VERIFY_SIGPUSHONLY) !== 0 && !scriptSig.isPushOnly()) {
     this.errstr = 'SCRIPT_ERR_SIG_PUSHONLY';
@@ -277,7 +277,7 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
     stackCopy = this.stack.slice();
   }
 
-  var stack = this.stack;
+  let stack = this.stack;
   this.initialize();
   this.set({
     script: scriptPubkey,
@@ -297,15 +297,15 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
     return false;
   }
 
-  var buf = this.stack[this.stack.length - 1];
+  const buf = this.stack[this.stack.length - 1];
   if (!Interpreter.castToBool(buf)) {
     this.errstr = 'SCRIPT_ERR_EVAL_FALSE_IN_STACK';
     return false;
   }
 
-  var hadWitness = false;
+  let hadWitness = false;
   if ((flags & Interpreter.SCRIPT_VERIFY_WITNESS)) {
-    var witnessValues = {};
+    const witnessValues = {};
     if (scriptPubkey.isWitnessProgram(witnessValues)) {
       hadWitness = true;
       if (scriptSig.toBuffer().length !== 0) {
@@ -333,8 +333,8 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
       throw new Error('internal error - stack copy empty');
     }
 
-    var redeemScriptSerialized = stackCopy[stackCopy.length - 1];
-    var redeemScript = Script.fromBuffer(redeemScriptSerialized);
+    const redeemScriptSerialized = stackCopy[stackCopy.length - 1];
+    const redeemScript = Script.fromBuffer(redeemScriptSerialized);
     stackCopy.pop();
 
     this.initialize();
@@ -361,10 +361,10 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
       return false;
     }
     if ((flags & Interpreter.SCRIPT_VERIFY_WITNESS)) {
-      var p2shWitnessValues = {};
+      const p2shWitnessValues = {};
       if (redeemScript.isWitnessProgram(p2shWitnessValues)) {
         hadWitness = true;
-        var redeemScriptPush = new Script();
+        const redeemScriptPush = new Script();
         redeemScriptPush.add(redeemScript.toBuffer());
         if (scriptSig.toHex() !== redeemScriptPush.toHex()) {
           this.errstr = 'SCRIPT_ERR_WITNESS_MALLEATED_P2SH';
@@ -386,20 +386,20 @@ Interpreter.prototype.verify = function(scriptSig, scriptPubkey, tx, nin, flags,
   // a clean stack (the P2SH inputs remain). The same holds for witness
   // evaluation.
   if ((this.flags & Interpreter.SCRIPT_VERIFY_CLEANSTACK) != 0) {
-      // Disallow CLEANSTACK without P2SH, as otherwise a switch
-      // CLEANSTACK->P2SH+CLEANSTACK would be possible, which is not a
-      // softfork (and P2SH should be one).
-      if (
-        (this.flags & Interpreter.SCRIPT_VERIFY_P2SH)    == 0 ||
+    // Disallow CLEANSTACK without P2SH, as otherwise a switch
+    // CLEANSTACK->P2SH+CLEANSTACK would be possible, which is not a
+    // softfork (and P2SH should be one).
+    if (
+      (this.flags & Interpreter.SCRIPT_VERIFY_P2SH) == 0 ||
         (this.flags & Interpreter.SCRIPT_VERIFY_WITNESS) == 0
-      ) {
-        throw 'flags & SCRIPT_VERIFY_P2SH';
-      }
+    ) {
+      throw 'flags & SCRIPT_VERIFY_P2SH';
+    }
 
-      if (stackCopy.length != 1) {
-        this.errstr = 'SCRIPT_ERR_CLEANSTACK';
-        return false;
-      }
+    if (stackCopy.length != 1) {
+      this.errstr = 'SCRIPT_ERR_CLEANSTACK';
+      return false;
+    }
   }
 
   if ((this.flags & Interpreter.SCRIPT_VERIFY_WITNESS)) {
@@ -605,7 +605,7 @@ Interpreter.TAPROOT_CONTROL_MAX_SIZE = Interpreter.TAPROOT_CONTROL_BASE_SIZE + I
 Interpreter.PROTOCOL_VERSION = 70016;
 
 Interpreter.castToBool = function(buf) {
-  for (var i = 0; i < buf.length; i++) {
+  for (let i = 0; i < buf.length; i++) {
     if (buf[i] !== 0) {
       // can be negative zero
       if (i === buf.length - 1 && buf[i] === 0x80) {
@@ -621,13 +621,13 @@ Interpreter.castToBool = function(buf) {
  * Translated from bitcoind's CheckSignatureEncoding
  */
 Interpreter.prototype.checkSignatureEncoding = function(buf) {
-  var sig;
+  let sig;
 
-    // Empty signature. Not strictly DER encoded, but allowed to provide a
-    // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
-    if (buf.length == 0) {
-        return true;
-    }
+  // Empty signature. Not strictly DER encoded, but allowed to provide a
+  // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
+  if (buf.length == 0) {
+    return true;
+  }
 
   if ((this.flags & (Interpreter.SCRIPT_VERIFY_DERSIG | Interpreter.SCRIPT_VERIFY_LOW_S | Interpreter.SCRIPT_VERIFY_STRICTENC)) !== 0 && !Signature.isTxDER(buf)) {
     this.errstr = 'SCRIPT_ERR_SIG_DER_INVALID_FORMAT';
@@ -678,15 +678,15 @@ Interpreter.prototype.checkPubkeyEncoding = function(buf) {
  * @returns {Boolean}
  */
 Interpreter.prototype.checkEcdsaSignature = function(sig, pubkey, nin, subscript, satoshis) {
-  var subscriptBuffer = subscript.toBuffer();
-  var scriptCodeWriter = new BufferWriter();
+  const subscriptBuffer = subscript.toBuffer();
+  const scriptCodeWriter = new BufferWriter();
   scriptCodeWriter.writeVarintNum(subscriptBuffer.length);
   scriptCodeWriter.write(subscriptBuffer);
 
   $.checkState(JSUtil.isNaturalNumber(satoshis));
-  var satoshisBuffer = new BufferWriter().writeUInt64LEBN(new BN(satoshis)).toBuffer();
+  const satoshisBuffer = new BufferWriter().writeUInt64LEBN(new BN(satoshis)).toBuffer();
 
-  var verified = SighashWitness.verify(
+  const verified = SighashWitness.verify(
     this,
     sig,
     pubkey,
@@ -779,8 +779,8 @@ Interpreter.prototype._evalChecksigPreTapscript = function(bufSig, bufPubkey) {
     const sig = Signature.fromTxFormat(bufSig);
     const pubkey = PublicKey.fromBuffer(bufPubkey, false);
     retVal.success = this.tx.verifySignature(sig, pubkey, this.nin, subscript, this.sigversion, this.satoshis);
-  } catch (e) {
-    //invalid sig or pubkey
+  } catch {
+    // invalid sig or pubkey
     retVal.success = false;
   }
 
@@ -814,7 +814,7 @@ Interpreter.prototype._evalChecksigTapscript = function(bufSig, bufPubkey) {
   const retVal = {
     success: bufSig.length > 0,
     result: false
-  }
+  };
   if (retVal.success) {
     // Implement the sigops/witnesssize ratio test.
     // Passing with an upgradable public key version is also counted.
@@ -848,7 +848,7 @@ Interpreter.prototype._evalChecksigTapscript = function(bufSig, bufPubkey) {
   // If it reaches here, then true
   retVal.result = true;
   return retVal;
-}
+};
 
 /**
  * Based on bitcoind's EvalChecksig function
@@ -856,7 +856,7 @@ Interpreter.prototype._evalChecksigTapscript = function(bufSig, bufPubkey) {
  * @returns {{ success: Boolean, verified: Boolean }}
  */
 Interpreter.prototype._evalCheckSig = function(bufSig, bufPubkey) {
-  switch(this.sigversion) {
+  switch (this.sigversion) {
     case Signature.Version.BASE:
     case Signature.Version.WITNESS_V0:
       // const verified = this._evalChecksigPreTapscript(bufSig, bufPubkey);
@@ -889,7 +889,7 @@ Interpreter.prototype.evaluate = function() {
 
   try {
     while (this.pc < this.script.chunks.length) {
-      var fSuccess = this.step();
+      const fSuccess = this.step();
       if (!fSuccess) {
         return false;
       }
@@ -925,7 +925,7 @@ Interpreter.prototype.checkLockTime = function(nLockTime) {
   // unless the type of nLockTime being tested is the same as
   // the nLockTime in the transaction.
   if (!(
-    (this.tx.nLockTime <  Interpreter.LOCKTIME_THRESHOLD && nLockTime.lt(Interpreter.LOCKTIME_THRESHOLD_BN)) ||
+    (this.tx.nLockTime < Interpreter.LOCKTIME_THRESHOLD && nLockTime.lt(Interpreter.LOCKTIME_THRESHOLD_BN)) ||
     (this.tx.nLockTime >= Interpreter.LOCKTIME_THRESHOLD && nLockTime.gte(Interpreter.LOCKTIME_THRESHOLD_BN))
   )) {
     return false;
@@ -952,7 +952,7 @@ Interpreter.prototype.checkLockTime = function(nLockTime) {
   }
 
   return true;
-}
+};
 
 
 /**
@@ -965,7 +965,7 @@ Interpreter.prototype.checkSequence = function(nSequence) {
 
   // Relative lock times are supported by comparing the passed in operand to
   // the sequence number of the input.
-  var txToSequence = this.tx.inputs[this.nin].sequenceNumber;
+  const txToSequence = this.tx.inputs[this.nin].sequenceNumber;
 
   // Fail if the transaction's version number is not set high enough to
   // trigger BIP 68 rules.
@@ -983,10 +983,10 @@ Interpreter.prototype.checkSequence = function(nSequence) {
 
   // Mask off any bits that do not have consensus-enforced meaning before
   // doing the integer comparisons
-  var nLockTimeMask =
-      Interpreter.SEQUENCE_LOCKTIME_TYPE_FLAG | Interpreter.SEQUENCE_LOCKTIME_MASK;
-  var txToSequenceMasked = new BN(txToSequence & nLockTimeMask);
-  var nSequenceMasked = nSequence.and(new BN(nLockTimeMask));
+  const nLockTimeMask =
+    Interpreter.SEQUENCE_LOCKTIME_TYPE_FLAG | Interpreter.SEQUENCE_LOCKTIME_MASK;
+  const txToSequenceMasked = new BN(txToSequence & nLockTimeMask);
+  const nSequenceMasked = nSequence.and(new BN(nLockTimeMask));
 
   // There are two kinds of nSequence: lock-by-blockheight and
   // lock-by-blocktime, distinguished by whether nSequenceMasked <
@@ -995,9 +995,9 @@ Interpreter.prototype.checkSequence = function(nSequence) {
   // We want to compare apples to apples, so fail the script unless the type
   // of nSequenceMasked being tested is the same as the nSequenceMasked in the
   // transaction.
-  var SEQUENCE_LOCKTIME_TYPE_FLAG_BN = new BN(Interpreter.SEQUENCE_LOCKTIME_TYPE_FLAG);
+  const SEQUENCE_LOCKTIME_TYPE_FLAG_BN = new BN(Interpreter.SEQUENCE_LOCKTIME_TYPE_FLAG);
 
-  if (!((txToSequenceMasked.lt(SEQUENCE_LOCKTIME_TYPE_FLAG_BN)  &&
+  if (!((txToSequenceMasked.lt(SEQUENCE_LOCKTIME_TYPE_FLAG_BN) &&
           nSequenceMasked.lt(SEQUENCE_LOCKTIME_TYPE_FLAG_BN)) ||
         (txToSequenceMasked.gte(SEQUENCE_LOCKTIME_TYPE_FLAG_BN) &&
           nSequenceMasked.gte(SEQUENCE_LOCKTIME_TYPE_FLAG_BN)))) {
@@ -1006,8 +1006,8 @@ Interpreter.prototype.checkSequence = function(nSequence) {
 
   // Now that we know we're comparing apples-to-apples, the comparison is a
   // simple numeric one.
-  return nSequenceMasked.lte(txToSequenceMasked)
-}
+  return nSequenceMasked.lte(txToSequenceMasked);
+};
 
 
 Interpreter.computeTapleafHash = function(leafVersion, scriptBuf) {
@@ -1044,15 +1044,15 @@ Interpreter.verifyTaprootCommitment = function(control, program, tapleafHash) {
   $.checkArgument(program.length >= 32, 'program is too short');
 
   try {
-    //! The internal pubkey (x-only, so no Y coordinate parity).
+    // ! The internal pubkey (x-only, so no Y coordinate parity).
     const p = PublicKey.fromX(false, control.slice(1, Interpreter.TAPROOT_CONTROL_BASE_SIZE));
-    //! The output pubkey (taken from the scriptPubKey).
+    // ! The output pubkey (taken from the scriptPubKey).
     const q = PublicKey.fromX(false, program);
     // Compute the Merkle root from the leaf and the provided path.
     const merkleRoot = Interpreter.computeTaprootMerkleRoot(control, tapleafHash);
     // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.
     return q.checkTapTweak(p, merkleRoot, control);
-  } catch (err) {
+  } catch {
     return false;
   }
 };
@@ -1063,13 +1063,13 @@ Interpreter.verifyTaprootCommitment = function(control, program, tapleafHash) {
  * bitcoind commit: b5d1b1092998bc95313856d535c632ea5a8f9104
  */
 Interpreter.prototype.step = function() {
-  var fRequireMinimal = (this.flags & Interpreter.SCRIPT_VERIFY_MINIMALDATA) !== 0;
+  const fRequireMinimal = (this.flags & Interpreter.SCRIPT_VERIFY_MINIMALDATA) !== 0;
 
-  //bool fExec = !count(vfExec.begin(), vfExec.end(), false);
-  var fExec = (this.vfExec.indexOf(false) === -1);
-  var buf, buf1, buf2, spliced, n, x1, x2, bn, bn1, bn2, bufSig, bufPubkey, subscript;
-  var sig, pubkey;
-  var fValue, fSuccess;
+  // bool fExec = !count(vfExec.begin(), vfExec.end(), false);
+  const fExec = (this.vfExec.indexOf(false) === -1);
+  let buf, buf1, buf2, spliced, n, x1, x2, bn, bn1, bn2, bufSig, bufPubkey, subscript;
+  let sig, pubkey;
+  let fValue, fSuccess;
   this.execdata = this.execdata || {};
   if (!this.execdata.codeseparatorPosInit) {
     this.execdata.codeseparatorPos = new BN(0xFFFFFFFF);
@@ -1077,9 +1077,9 @@ Interpreter.prototype.step = function() {
   }
 
   // Read instruction
-  var chunk = this.script.chunks[this.pc];
+  const chunk = this.script.chunks[this.pc];
   this.pc++;
-  var opcodenum = chunk.opcodenum;
+  const opcodenum = chunk.opcodenum;
   if (_.isUndefined(opcodenum)) {
     this.errstr = 'SCRIPT_ERR_UNDEFINED_OPCODE';
     return false;
@@ -1204,7 +1204,7 @@ Interpreter.prototype.step = function() {
         // Thus as a special case we tell CScriptNum to accept up
         // to 5-byte bignums, which are good until 2**39-1, well
         // beyond the 2**32-1 limit of the nLockTime field itself.
-        var nLockTime = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal, 5);
+        const nLockTime = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal, 5);
 
         // In the rare event that the argument may be < 0 due to
         // some arithmetic being done first, you can always use
@@ -1243,7 +1243,7 @@ Interpreter.prototype.step = function() {
         // integer field. See the comment in CHECKLOCKTIMEVERIFY
         // regarding 5-byte numeric operands.
 
-        var nSequence = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal, 5);
+        const nSequence = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal, 5);
 
 
         // In the rare event that the argument may be < 0 due to
@@ -1372,16 +1372,14 @@ Interpreter.prototype.step = function() {
         break;
 
       case Opcode.OP_RETURN:
-        {
-          this.errstr = 'SCRIPT_ERR_OP_RETURN';
-          return false;
-        }
-        break;
+      {
+        this.errstr = 'SCRIPT_ERR_OP_RETURN';
+        return false;
+      }
 
-
-        //
-        // Stack ops
-        //
+      //
+      // Stack ops
+      //
       case Opcode.OP_TOALTSTACK:
         {
           if (this.stack.length < 1) {
@@ -1437,7 +1435,7 @@ Interpreter.prototype.step = function() {
           }
           buf1 = this.stack[this.stack.length - 3];
           buf2 = this.stack[this.stack.length - 2];
-          var buf3 = this.stack[this.stack.length - 1];
+          const buf3 = this.stack[this.stack.length - 1];
           this.stack.push(buf1);
           this.stack.push(buf2);
           this.stack.push(buf3);
@@ -1587,7 +1585,7 @@ Interpreter.prototype.step = function() {
           }
           x1 = this.stack[this.stack.length - 3];
           x2 = this.stack[this.stack.length - 2];
-          var x3 = this.stack[this.stack.length - 1];
+          const x3 = this.stack[this.stack.length - 1];
           this.stack[this.stack.length - 3] = x2;
           this.stack[this.stack.length - 2] = x3;
           this.stack[this.stack.length - 1] = x1;
@@ -1638,7 +1636,7 @@ Interpreter.prototype.step = function() {
         //
       case Opcode.OP_EQUAL:
       case Opcode.OP_EQUALVERIFY:
-        //case Opcode.OP_NOTEQUAL: // use Opcode.OP_NUMNOTEQUAL
+        // case Opcode.OP_NOTEQUAL: // use Opcode.OP_NUMNOTEQUAL
         {
           // (x1 x2 - bool)
           if (this.stack.length < 2) {
@@ -1647,7 +1645,7 @@ Interpreter.prototype.step = function() {
           }
           buf1 = this.stack[this.stack.length - 2];
           buf2 = this.stack[this.stack.length - 1];
-          var fEqual = buf1.toString('hex') === buf2.toString('hex');
+          const fEqual = buf1.toString('hex') === buf2.toString('hex');
           this.stack.pop();
           this.stack.pop();
           this.stack.push(fEqual ? Interpreter.true : Interpreter.false);
@@ -1701,7 +1699,7 @@ Interpreter.prototype.step = function() {
             case Opcode.OP_0NOTEQUAL:
               bn = new BN((bn.cmp(BN.Zero) !== 0) + 0);
               break;
-              //default:      assert(!'invalid opcode'); break; // TODO: does this ever occur?
+              // default:      assert(!'invalid opcode'); break; // TODO: does this ever occur?
           }
           this.stack.pop();
           this.stack.push(bn.toScriptNumBuffer());
@@ -1809,8 +1807,8 @@ Interpreter.prototype.step = function() {
           }
           bn1 = BN.fromScriptNumBuffer(this.stack[this.stack.length - 3], fRequireMinimal);
           bn2 = BN.fromScriptNumBuffer(this.stack[this.stack.length - 2], fRequireMinimal);
-          var bn3 = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal);
-          //bool fValue = (bn2 <= bn1 && bn1 < bn3);
+          const bn3 = BN.fromScriptNumBuffer(this.stack[this.stack.length - 1], fRequireMinimal);
+          // bool fValue = (bn2 <= bn1 && bn1 < bn3);
           fValue = (bn2.cmp(bn1) <= 0) && (bn1.cmp(bn3) < 0);
           this.stack.pop();
           this.stack.pop();
@@ -1835,9 +1833,9 @@ Interpreter.prototype.step = function() {
             return false;
           }
           buf = this.stack[this.stack.length - 1];
-          //valtype vchHash((opcode == Opcode.OP_RIPEMD160 ||
+          // valtype vchHash((opcode == Opcode.OP_RIPEMD160 ||
           //                 opcode == Opcode.OP_SHA1 || opcode == Opcode.OP_HASH160) ? 20 : 32);
-          var bufHash;
+          let bufHash;
           if (opcodenum === Opcode.OP_RIPEMD160) {
             bufHash = Hash.ripemd160(buf);
           } else if (opcodenum === Opcode.OP_SHA1) {
@@ -1908,9 +1906,9 @@ Interpreter.prototype.step = function() {
             return false;
           }
 
-          let sig = this.stack[this.stack.length - 3];
+          const sig = this.stack[this.stack.length - 3];
           let num = this.stack[this.stack.length - 2];
-          let pubkey = this.stack[this.stack.length - 1];
+          const pubkey = this.stack[this.stack.length - 1];
 
           num = BN.fromScriptNumBuffer(num, fRequireMinimal);
 
@@ -1930,13 +1928,13 @@ Interpreter.prototype.step = function() {
         {
           // ([sig ...] num_of_signatures [pubkey ...] num_of_pubkeys -- bool)
 
-          var i = 1;
+          let i = 1;
           if (this.stack.length < i) {
             this.errstr = 'SCRIPT_ERR_INVALID_STACK_OPERATION';
             return false;
           }
 
-          var nKeysCount = BN.fromScriptNumBuffer(this.stack[this.stack.length - i], fRequireMinimal).toNumber();
+          let nKeysCount = BN.fromScriptNumBuffer(this.stack[this.stack.length - i], fRequireMinimal).toNumber();
           if (nKeysCount < 0 || nKeysCount > 20) {
             this.errstr = 'SCRIPT_ERR_PUBKEY_COUNT';
             return false;
@@ -1947,27 +1945,27 @@ Interpreter.prototype.step = function() {
             return false;
           }
           // int ikey = ++i;
-          var ikey = ++i;
+          let ikey = ++i;
           i += nKeysCount;
 
           // ikey2 is the position of last non-signature item in
           // the stack. Top stack item = 1. With
           // SCRIPT_VERIFY_NULLFAIL, this is used for cleanup if
           // operation fails.
-          var ikey2 = nKeysCount + 2;
+          let ikey2 = nKeysCount + 2;
 
           if (this.stack.length < i) {
             this.errstr = 'SCRIPT_ERR_INVALID_STACK_OPERATION';
             return false;
           }
 
-          var nSigsCount = BN.fromScriptNumBuffer(this.stack[this.stack.length - i], fRequireMinimal).toNumber();
+          let nSigsCount = BN.fromScriptNumBuffer(this.stack[this.stack.length - i], fRequireMinimal).toNumber();
           if (nSigsCount < 0 || nSigsCount > nKeysCount) {
             this.errstr = 'SCRIPT_ERR_SIG_COUNT';
             return false;
           }
           // int isig = ++i;
-          var isig = ++i;
+          let isig = ++i;
           i += nSigsCount;
           if (this.stack.length < i) {
             this.errstr = 'SCRIPT_ERR_INVALID_STACK_OPERATION';
@@ -1980,7 +1978,7 @@ Interpreter.prototype.step = function() {
           });
 
           // Drop the signatures, since there's no way for a signature to sign itself
-          for (var k = 0; k < nSigsCount; k++) {
+          for (let k = 0; k < nSigsCount; k++) {
             bufSig = this.stack[this.stack.length - isig - k];
             subscript.findAndDelete(new Script().add(bufSig));
           }
@@ -1996,13 +1994,13 @@ Interpreter.prototype.step = function() {
               return false;
             }
 
-            var fOk;
+            let fOk;
             try {
               sig = Signature.fromTxFormat(bufSig);
               pubkey = PublicKey.fromBuffer(bufPubkey, false);
               fOk = this.tx.verifySignature(sig, pubkey, this.nin, subscript, this.sigversion, this.satoshis, this.execdata);
-            } catch (e) {
-              //invalid sig or pubkey
+            } catch {
+              // invalid sig or pubkey
               fOk = false;
             }
 

--- a/packages/bitcore-lib/lib/script/interpreter.js
+++ b/packages/bitcore-lib/lib/script/interpreter.js
@@ -1045,9 +1045,9 @@ Interpreter.verifyTaprootCommitment = function(control, program, tapleafHash) {
 
   try {
     // ! The internal pubkey (x-only, so no Y coordinate parity).
-    const p = PublicKey.fromX(false, control.slice(1, Interpreter.TAPROOT_CONTROL_BASE_SIZE));
+    const p = PublicKey.fromX(false, BN.fromBuffer(control.slice(1, Interpreter.TAPROOT_CONTROL_BASE_SIZE)));
     // ! The output pubkey (taken from the scriptPubKey).
-    const q = PublicKey.fromX(false, program);
+    const q = PublicKey.fromX(false, BN.fromBuffer(program));
     // Compute the Merkle root from the leaf and the provided path.
     const merkleRoot = Interpreter.computeTaprootMerkleRoot(control, tapleafHash);
     // Verify that the output pubkey matches the tweaked internal pubkey, after correcting for parity.


### PR DESCRIPTION
### Description
Updating packages for bitcore-lib caused tests to fail which exposed a brittle point handling in PublicKey._transformX() and Schnorr.verify().

Utilizing the internal BN module mitigates this issue.

### Changelog

* In PublicKey._transformX(), if x is a buffer, convert it to BN
* In Schnorr.verify(), convert public key to BN

### Benchmarks (50,000 iterations)

#### PublicKey._transformX()

* Baseline: 244676.15 ns/op
* Inline fix: 249094.65 ns/op

#### Schnorr.verify()

* Baseline: 1820761.76 ns/op
* Inline fix: 1795178.86 ns/op

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.