### PR TITLE
Fix SOL rent fallback

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
+++ b/packages/bitcore-wallet-service/src/lib/blockchainexplorers/v8.ts
@@ -695,7 +695,7 @@ export class V8 {
           return cb(null, ret || Defaults.MIN_SOL_BALANCE);
         } catch (err) {
           logger.error('[v8.js] Error getting rentMinimum: %o', err);
-          return cb(null, Defaults.MIN_XRP_BALANCE);
+          return cb(null, Defaults.MIN_SOL_BALANCE);
         }
       })
       .catch(cb);


### PR DESCRIPTION
### Description
The SOL rent falls back to the XRP constant.

### Changelog

* Fix the fallback const to SOL's default rent.

### Testing Notes
n/a

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.