### PR TITLE
[BCN] Add RPC overrides for MultiProvider EVM CSP + fixes

### DIFF
--- a/packages/bitcore-node/src/modules/multiProvider/api/csp.ts
+++ b/packages/bitcore-node/src/modules/multiProvider/api/csp.ts
@@ -345,22 +345,33 @@ export class MultiProviderEVMStateProvider extends BaseEVMStateProvider {
     const { walletAddresses } = streamParams;
     const chainId = await this.getChainId({ network });
     const providers = this.getProvidersForNetwork(network);
+    const tokenAddress = (args as any)?.tokenAddress;
 
     let activeProvider = providers.find(p => p.health.isAvailable());
     if (!activeProvider) {
       throw new AllProvidersUnavailableError('walletTransactions', this.chain, network);
     }
-    logger.debug(`MultiProvider: wallet stream using ${activeProvider.adapter.name} for ${this.chain}:${network} (${walletAddresses.length} addresses)`);
+    logger.debug(`MultiProvider: wallet stream using ${activeProvider.adapter.name} for ${this.chain}:${network} (${walletAddresses.length} addresses)${tokenAddress ? ` token=${tokenAddress}` : ''}`);
 
     for (const address of walletAddresses) {
       try {
-        const txStream = activeProvider.adapter.streamAddressTransactions({
-          chainId,
-          chain: this.chain,
-          network,
-          address,
-          args: { order: 'ASC', ...args } as any
-        });
+        const streamArgs = { order: 'ASC', ...args } as any;
+        const txStream = tokenAddress
+          ? activeProvider.adapter.streamERC20Transfers({
+            chainId,
+            chain: this.chain,
+            network,
+            address,
+            tokenAddress,
+            args: streamArgs
+          })
+          : activeProvider.adapter.streamAddressTransactions({
+            chainId,
+            chain: this.chain,
+            network,
+            address,
+            args: streamArgs
+          });
 
         transactionStream = txStream.eventPipe(transactionStream);
 

--- a/packages/bitcore-node/src/modules/multiProvider/api/csp.ts
+++ b/packages/bitcore-node/src/modules/multiProvider/api/csp.ts
@@ -1,6 +1,7 @@
 import { PassThrough, Readable } from 'stream';
 import { LRUCache } from 'lru-cache';
 import logger from '../../../logger';
+import { CacheStorage } from '../../../models/cache';
 import { WalletAddressStorage } from '../../../models/walletAddress';
 import { BaseEVMStateProvider } from '../../../providers/chain-state/evm/api/csp';
 import { EVMBlockStorage } from '../../../providers/chain-state/evm/models/block';
@@ -12,15 +13,19 @@ import { ExternalApiStream } from '../../../providers/chain-state/external/strea
 import { Config } from '../../../services/config';
 import {
   GetBlockBeforeTimeParams,
+  GetBlockParams,
   StreamAddressUtxosParams,
+  StreamBlocksParams,
   StreamTransactionParams,
   StreamWalletTransactionsParams
 } from '../../../types/namespaces/ChainStateProvider';
 import { normalizeChainNetwork } from '../../../utils';
+import { ReadableWithEventPipe } from '../../../utils/streamWithEventPipe';
+import type { MongoBound } from '../../../models/base';
 import type {
   BuildWalletTxsStreamParams
 } from '../../../providers/chain-state/evm/api/csp';
-import type { EVMTransactionJSON } from '../../../providers/chain-state/evm/types';
+import type { EVMTransactionJSON, IEVMBlock } from '../../../providers/chain-state/evm/types';
 import type { IIndexedAPIAdapter } from '../../../providers/chain-state/external/adapters/IIndexedAPIAdapter';
 import type { IBlock } from '../../../types/Block';
 import type { IMultiProviderConfig } from '../../../types/Config';
@@ -34,6 +39,8 @@ interface ProviderWithHealth {
 export class MultiProviderEVMStateProvider extends BaseEVMStateProvider {
   private providersByNetwork: Map<string, ProviderWithHealth[]> = new Map();
   blockAtTimeCache: { [key: string]: LRUCache<string, IBlock> } = {};
+  private localTipCache: Map<string, { tip: IBlock; fetchedAtMs: number }> = new Map();
+  private static readonly LOCAL_TIP_TTL_MS = 5_000;
 
   constructor(chain: string = 'ETH') {
     super(chain);
@@ -450,6 +457,110 @@ export class MultiProviderEVMStateProvider extends BaseEVMStateProvider {
       iterations++;
     }
     return low;
+  }
+
+  // @override
+  async getLocalTip({ chain, network }): Promise<IBlock> {
+    const key = normalizeChainNetwork(chain || this.chain, network);
+    const cached = this.localTipCache.get(key);
+    if (cached && Date.now() - cached.fetchedAtMs <= MultiProviderEVMStateProvider.LOCAL_TIP_TTL_MS) {
+      return cached.tip;
+    }
+    const { web3 } = await this.getWeb3(network, { type: 'realtime' });
+    const rawBlock = await web3.eth.getBlock('latest');
+    if (!rawBlock) {
+      throw new Error(`MultiProvider [${this.chain}:${network}]: realtime node returned no latest block`);
+    }
+    const tip = EVMBlockStorage.convertRawBlock(this.chain, network, rawBlock);
+    this.localTipCache.set(key, { tip, fetchedAtMs: Date.now() });
+    return tip;
+  }
+
+  // @override
+  async getFee(params) {
+    let { network } = params;
+    const { target = 4, txType } = params;
+    const chain = this.chain;
+    if (network === 'livenet') {
+      network = 'mainnet';
+    }
+    let cacheKey = `getFee-${chain}-${network}-${target}`;
+    if (txType) {
+      cacheKey += `-type${txType}`;
+    }
+
+    return CacheStorage.getGlobalOrRefresh(
+      cacheKey,
+      async () => {
+        const { rpc } = await this.getWeb3(network, { type: 'historical' });
+        const feerate = await rpc.estimateFee({ nBlocks: target, txType });
+        return { feerate: Number(feerate), blocks: target };
+      },
+      CacheStorage.Times.Minute
+    );
+  }
+
+  // @override
+  async streamBlocks(params: StreamBlocksParams) {
+    const { chain, network } = params;
+    const { web3 } = await this.getWeb3(network);
+    const chainId = await this.getChainId({ network });
+    const blockRange = await this.getBlocksRange({ ...params, chainId });
+    const tipHeight = Number(await web3.eth.getBlockNumber());
+    let isReading = false;
+
+    const stream = new ReadableWithEventPipe({
+      objectMode: true,
+      async read() {
+        if (isReading) {
+          return;
+        }
+        isReading = true;
+
+        let block;
+        let nextBlock;
+        try {
+          for (const blockNum of blockRange) {
+            // stage next block in new var so `nextBlock` doesn't get overwritten if needed for `block`
+            const thisNextBlock = parseInt(block?.number) === blockNum + 1 ? block : await web3.eth.getBlock(blockNum + 1);
+            block = parseInt(nextBlock?.number) === blockNum ? nextBlock : await web3.eth.getBlock(blockNum);
+            if (!block) {
+              continue;
+            }
+            nextBlock = thisNextBlock;
+            const convertedBlock = EVMBlockStorage.convertRawBlock(chain, network, block);
+            convertedBlock.nextBlockHash = nextBlock?.hash;
+            convertedBlock.confirmations = tipHeight - Number(block.number) + 1;
+            this.push(convertedBlock);
+          }
+        } catch (e) {
+          logger.error('Error streaming blocks: %o', e);
+        }
+        this.push(null);
+      }
+    });
+
+    return stream;
+  }
+
+  // @override
+  async _getBlocks(params: GetBlockParams) {
+    const { chain, network } = params;
+    const blocks: MongoBound<IEVMBlock>[] = [];
+    const { web3 } = await this.getWeb3(network);
+    const chainId = await this.getChainId({ network });
+    const blockRange = await this.getBlocksRange({ ...params, chainId });
+
+    for (const blockNum of blockRange) {
+      const block = await web3.eth.getBlock(blockNum);
+      const nextBlock = await web3.eth.getBlock(block.number + 1n);
+      const convertedBlock = EVMBlockStorage.convertRawBlock(chain, network, block);
+      convertedBlock.nextBlockHash = nextBlock?.hash!;
+      blocks.push(convertedBlock);
+    }
+
+    const tipHeight = Number(await web3.eth.getBlockNumber());
+    return { tipHeight, blocks };
   }
 
   // @override

--- a/packages/bitcore-node/src/providers/chain-state/external/adapters/alchemy.ts
+++ b/packages/bitcore-node/src/providers/chain-state/external/adapters/alchemy.ts
@@ -255,7 +255,10 @@ export class AlchemyAdapter implements IIndexedAPIAdapter {
       blockHash: '',
       blockTime: safeBlockTime,
       blockTimeNormalized: safeBlockTime,
-      value: transfer.value != null ? String(transfer.value) : 0,
+      // transfer.value is a decimal display value; rawContract.value is the
+      // canonical hex amount in wei (or smallest token unit) for both native
+      // and ERC20 categories.
+      value: BigInt(transfer.rawContract?.value || 0).toString(),
       gasLimit: 0,
       gasPrice: 0,
       fee: 0,

--- a/packages/bitcore-node/src/providers/chain-state/external/adapters/alchemy.ts
+++ b/packages/bitcore-node/src/providers/chain-state/external/adapters/alchemy.ts
@@ -255,9 +255,6 @@ export class AlchemyAdapter implements IIndexedAPIAdapter {
       blockHash: '',
       blockTime: safeBlockTime,
       blockTimeNormalized: safeBlockTime,
-      // transfer.value is a decimal display value; rawContract.value is the
-      // canonical hex amount in wei (or smallest token unit) for both native
-      // and ERC20 categories.
       value: BigInt(transfer.rawContract?.value || 0).toString(),
       gasLimit: 0,
       gasPrice: 0,

--- a/packages/bitcore-node/test/unit/adapters/alchemy.test.ts
+++ b/packages/bitcore-node/test/unit/adapters/alchemy.test.ts
@@ -195,7 +195,11 @@ describe('AlchemyAdapter', function() {
   // --- Asset transfer stream ---
   describe('AlchemyAssetTransferStream', function() {
     it('should query both fromAddress and toAddress and deduplicate', async function() {
-      const transfer1 = { hash: '0x1'.padEnd(66, '0'), blockNum: '0x1', from: VALID_FROM, to: VALID_ADDRESS, value: 1, category: 'external', uniqueId: 'u1', metadata: { blockTimestamp: '2023-01-01T00:00:00Z' } };
+      const transfer1 = {
+        hash: '0x1'.padEnd(66, '0'), blockNum: '0x1', from: VALID_FROM, to: VALID_ADDRESS,
+        value: 1, rawContract: { value: '0xde0b6b3a7640000' }, // 1 ETH in wei
+        category: 'external', uniqueId: 'u1', metadata: { blockTimestamp: '2023-01-01T00:00:00Z' }
+      };
       const transfer2 = { ...transfer1, uniqueId: 'u2', hash: '0x2'.padEnd(66, '0') };
       axiosPostStub.onCall(0).resolves({ status: 200, data: { result: { transfers: [transfer1], pageKey: null } } });
       axiosPostStub.onCall(1).resolves({ status: 200, data: { result: { transfers: [transfer1, transfer2], pageKey: null } } });
@@ -213,6 +217,31 @@ describe('AlchemyAdapter', function() {
       });
 
       expect(items).to.have.length(2);
+      // value comes from rawContract.value (wei), not the decimal display field
+      expect(items[0].value).to.equal('1000000000000000000');
+    });
+
+    it('should fall back to 0 when rawContract.value is missing', async function() {
+      const transfer = {
+        hash: '0xa'.padEnd(66, '0'), blockNum: '0x1', from: VALID_FROM, to: VALID_ADDRESS,
+        value: 1.2, // decimal display value, must be ignored
+        category: 'external', uniqueId: 'u3', metadata: { blockTimestamp: '2023-01-01T00:00:00Z' }
+      };
+      axiosPostStub.resolves({ status: 200, data: { result: { transfers: [transfer], pageKey: null } } });
+
+      const stream = adapter.streamAddressTransactions({
+        chain: 'ETH', network: 'mainnet', chainId: '1', address: VALID_ADDRESS,
+        args: { startBlock: 0, endBlock: 100 } as any
+      });
+
+      const items: any[] = [];
+      await new Promise<void>((resolve, reject) => {
+        stream.on('data', (d: any) => items.push(d));
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+
+      expect(items[0].value).to.equal('0');
     });
 
     it('should emit INVALID_REQUEST error for invalid address', function(done) {

--- a/packages/bitcore-node/test/unit/modules/base/csp.test.ts
+++ b/packages/bitcore-node/test/unit/modules/base/csp.test.ts
@@ -1,8 +1,11 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { CryptoRpc } from '@bitpay-labs/crypto-rpc';
+import { MultiProviderEVMStateProvider } from '../../../../src/modules/multiProvider/api/csp';
 import { MoralisStateProvider } from '../../../../src/modules/moralis/api/csp';
+import { CacheStorage } from '../../../../src/models/cache';
 import { BaseEVMStateProvider } from '../../../../src/providers/chain-state/evm/api/csp';
+import { EVMBlockStorage } from '../../../../src/providers/chain-state/evm/models/block';
 import { Config } from '../../../../src/services/config';
 
 
@@ -319,5 +322,164 @@ describe('BASE Chain State Provider', function() {
       ({ web3 } = await BASE.getWeb3(network, { type: 'realtime' }));
       expect(web3).to.equal(web3StubRealtime1); // index 0
     });
+  });
+});
+
+describe('MultiProviderEVMStateProvider: getLocalTip', function() {
+  let cfgStub: sinon.SinonStub;
+  let convertStub: sinon.SinonStub;
+
+  before(function() {
+    cfgStub = sinon.stub(Config, 'get').returns({ chains: { ETH: {} } } as any);
+    (BaseEVMStateProvider as any).rpcInitialized = { ETH: true };
+    // convertRawBlock writes Binary buffers; stub to return a height-only IBlock.
+    convertStub = sinon.stub(EVMBlockStorage, 'convertRawBlock').callsFake((chain: string, network: string, raw: any) => ({
+      chain, network, height: Number(raw.number), hash: raw.hash
+    }) as any);
+  });
+  after(function() {
+    cfgStub.restore();
+    convertStub.restore();
+  });
+
+  function buildProvider(latestBlocks: any[]) {
+    const provider = new MultiProviderEVMStateProvider('ETH');
+    let i = 0;
+    const getBlock = sinon.stub().callsFake(async (_tag: any) => latestBlocks[Math.min(i++, latestBlocks.length - 1)]);
+    (provider as any).getWeb3 = async () => ({ web3: { eth: { getBlock } } });
+    return { provider, getBlock };
+  }
+
+  it('returns tip from realtime RPC, not Mongo storage', async function() {
+    const raw = { number: 12345, hash: '0xabc', timestamp: 1700000000 };
+    const { provider, getBlock } = buildProvider([raw]);
+    const tip = await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+    expect(tip.height).to.equal(12345);
+    expect(getBlock.calledWith('latest')).to.equal(true);
+  });
+
+  it('caches tip across calls within TTL window', async function() {
+    const raw = { number: 100, hash: '0xa', timestamp: 1 };
+    const { provider, getBlock } = buildProvider([raw, raw]);
+    await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+    await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+    await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+    expect(getBlock.callCount).to.equal(1);
+  });
+
+  it('caches per chain:network independently', async function() {
+    const raw1 = { number: 100, hash: '0xa', timestamp: 1 };
+    const raw2 = { number: 200, hash: '0xb', timestamp: 2 };
+    const { provider, getBlock } = buildProvider([raw1, raw2]);
+    const tip1 = await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+    const tip2 = await provider.getLocalTip({ chain: 'ETH', network: 'sepolia' });
+    expect(tip1.height).to.equal(100);
+    expect(tip2.height).to.equal(200);
+    expect(getBlock.callCount).to.equal(2);
+  });
+
+  it('throws when realtime RPC returns no block', async function() {
+    const { provider } = buildProvider([null]);
+    try {
+      await provider.getLocalTip({ chain: 'ETH', network: 'mainnet' });
+      throw new Error('should have thrown');
+    } catch (e: any) {
+      expect(e.message).to.match(/no latest block/i);
+    }
+  });
+});
+
+describe('MultiProviderEVMStateProvider: getFee', function() {
+  let cfgStub: sinon.SinonStub;
+  let cacheStub: sinon.SinonStub;
+  before(function() {
+    cfgStub = sinon.stub(Config, 'get').returns({ chains: { ETH: {} } } as any);
+    (BaseEVMStateProvider as any).rpcInitialized = { ETH: true };
+    // Bypass Mongo-backed CacheStorage; just call through to the refresh fn.
+    cacheStub = sinon.stub(CacheStorage, 'getGlobalOrRefresh').callsFake(async (_key: string, refresh: any) => refresh());
+  });
+  after(function() { cfgStub.restore(); cacheStub.restore(); });
+
+  it('uses RPC estimateFee, not Mongo tx history', async function() {
+    const provider = new MultiProviderEVMStateProvider('ETH');
+    const estimateFee = sinon.stub().resolves(2_000_000_000n);
+    (provider as any).getWeb3 = async () => ({ rpc: { estimateFee } });
+    const result = await provider.getFee({ network: 'mainnet-getfee-uniq1', target: 4, txType: 2 } as any);
+    expect(result.feerate).to.equal(2_000_000_000);
+    expect(result.blocks).to.equal(4);
+    expect(estimateFee.calledOnce).to.equal(true);
+    expect(estimateFee.firstCall.args[0]).to.deep.equal({ nBlocks: 4, txType: 2 });
+  });
+
+  it('accepts "livenet" alias without throwing', async function() {
+    const provider = new MultiProviderEVMStateProvider('ETH');
+    const estimateFee = sinon.stub().resolves(1_000_000_000n);
+    (provider as any).getWeb3 = async () => ({ rpc: { estimateFee } });
+    const result = await provider.getFee({ network: 'livenet', target: 7 } as any);
+    expect(result.feerate).to.equal(1_000_000_000);
+    expect(result.blocks).to.equal(7);
+  });
+});
+
+describe('MultiProviderEVMStateProvider: streamBlocks and _getBlocks', function() {
+  let cfgStub: sinon.SinonStub;
+  let convertStub: sinon.SinonStub;
+  before(function() {
+    cfgStub = sinon.stub(Config, 'get').returns({ chains: { ETH: {} } } as any);
+    (BaseEVMStateProvider as any).rpcInitialized = { ETH: true };
+    convertStub = sinon.stub(EVMBlockStorage, 'convertRawBlock').callsFake((chain: string, network: string, raw: any) => ({
+      chain, network, height: Number(raw.number), hash: raw.hash
+    }) as any);
+  });
+  after(function() {
+    cfgStub.restore();
+    convertStub.restore();
+  });
+
+  function setupProvider(blockMap: Record<number, any>, tipHeight = 100) {
+    const provider = new MultiProviderEVMStateProvider('ETH');
+    const getBlock = sinon.stub().callsFake(async (n: any) => blockMap[Number(n)] ?? null);
+    const getBlockNumber = sinon.stub().resolves(BigInt(tipHeight));
+    (provider as any).getWeb3 = async () => ({ web3: { eth: { getBlock, getBlockNumber } } });
+    (provider as any).getChainId = async () => 1n;
+    (provider as any).getBlocksRange = async () => [10, 11, 12];
+    return { provider, getBlock };
+  }
+
+  it('_getBlocks fetches blocks via RPC and computes tipHeight from getBlockNumber', async function() {
+    const blockMap: Record<number, any> = {
+      10: { number: 10n, hash: '0xa' },
+      11: { number: 11n, hash: '0xb' },
+      12: { number: 12n, hash: '0xc' },
+      13: { number: 13n, hash: '0xd' }
+    };
+    const { provider } = setupProvider(blockMap, 200);
+    const result = await (provider as any)._getBlocks({ chain: 'ETH', network: 'mainnet' });
+    expect(result.tipHeight).to.equal(200);
+    expect(result.blocks).to.have.length(3);
+    expect(result.blocks[0].height).to.equal(10);
+    expect(result.blocks[2].height).to.equal(12);
+  });
+
+  it('streamBlocks emits blocks from RPC range with confirmations and nextBlockHash', async function() {
+    const blockMap: Record<number, any> = {
+      10: { number: 10n, hash: '0xa' },
+      11: { number: 11n, hash: '0xb' },
+      12: { number: 12n, hash: '0xc' },
+      13: { number: 13n, hash: '0xd' }
+    };
+    const { provider } = setupProvider(blockMap, 100);
+    const stream: any = await (provider as any).streamBlocks({ chain: 'ETH', network: 'mainnet' });
+    const out: any[] = [];
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', (b: any) => out.push(b));
+      stream.on('end', () => resolve());
+      stream.on('error', reject);
+    });
+    expect(out).to.have.length(3);
+    expect(out[0].height).to.equal(10);
+    expect(out[0].confirmations).to.equal(100 - 10 + 1);
+    expect(out[0].nextBlockHash).to.equal('0xb');
+    expect(out[2].nextBlockHash).to.equal('0xd');
   });
 });

--- a/packages/bitcore-node/test/unit/modules/base/csp.test.ts
+++ b/packages/bitcore-node/test/unit/modules/base/csp.test.ts
@@ -483,3 +483,51 @@ describe('MultiProviderEVMStateProvider: streamBlocks and _getBlocks', function(
     expect(out[2].nextBlockHash).to.equal('0xd');
   });
 });
+
+describe('MultiProviderEVMStateProvider: _buildWalletTransactionsStream tokenAddress routing', function() {
+  let cfgStub: sinon.SinonStub;
+  before(function() {
+    cfgStub = sinon.stub(Config, 'get').returns({ chains: { ETH: {} } } as any);
+    (BaseEVMStateProvider as any).rpcInitialized = { ETH: true };
+  });
+  after(function() { cfgStub.restore(); });
+
+  function buildProviderWithFakeAdapter() {
+    const provider = new MultiProviderEVMStateProvider('ETH');
+    const fakeStream = { eventPipe: (s: any) => s };
+    const adapter = {
+      name: 'fake',
+      streamAddressTransactions: sinon.stub().returns(fakeStream),
+      streamERC20Transfers: sinon.stub().returns(fakeStream)
+    };
+    const fakeProvider = { adapter, health: { isAvailable: () => true, recordFailure: sinon.stub() }, priority: 1 };
+    (provider as any).providersByNetwork = new Map([['mainnet', [fakeProvider]]]);
+    (provider as any).getChainId = async () => 1n;
+    // Minimal stub for WalletAddressStorage.updateLastQueryTime
+    (provider as any).updateLastQueryTime = async () => {};
+    return { provider, adapter };
+  }
+
+  it('routes to streamERC20Transfers when args.tokenAddress is set', async function() {
+    const { provider, adapter } = buildProviderWithFakeAdapter();
+    const transactionStream: any = { eventPipe: (s: any) => s };
+    await (provider as any)._buildWalletTransactionsStream(
+      { network: 'mainnet', args: { tokenAddress: '0xtoken' } },
+      { transactionStream, walletAddresses: ['0xaddr1', '0xaddr2'] }
+    );
+    expect(adapter.streamERC20Transfers.callCount).to.equal(2);
+    expect(adapter.streamAddressTransactions.callCount).to.equal(0);
+    expect(adapter.streamERC20Transfers.firstCall.args[0].tokenAddress).to.equal('0xtoken');
+  });
+
+  it('routes to streamAddressTransactions when no tokenAddress is set', async function() {
+    const { provider, adapter } = buildProviderWithFakeAdapter();
+    const transactionStream: any = { eventPipe: (s: any) => s };
+    await (provider as any)._buildWalletTransactionsStream(
+      { network: 'mainnet', args: {} },
+      { transactionStream, walletAddresses: ['0xaddr1'] }
+    );
+    expect(adapter.streamAddressTransactions.callCount).to.equal(1);
+    expect(adapter.streamERC20Transfers.callCount).to.equal(0);
+  });
+});


### PR DESCRIPTION
### Description

Multi-provider chains don't sync the local Mongo block and tx collections, so base CSP methods that read from them either return empty data or compute wrong values (`getLocalTip` returning null, `getFee` falling back to a 0 quartile, `/block` listing nothing). Mirror the override set already on `MoralisAdapter` so the multi-provider CSP serves these from the underlying RPC instead. Also fixes two bugs found while testing the wallet history endpoint.

### Changelog

* Override `getLocalTip` to fetch the latest block via realtime RPC, cached 5s per network to debounce hot route handlers
* Override `getFee` to use `rpc.estimateFee` instead of the empty `EVMTransactionStorage` gas-price history
* Override `streamBlocks` and `_getBlocks` to walk the resolved range via `web3.eth.getBlock` and serialize via `EVMBlockStorage.convertRawBlock`
* Use `transfer.rawContract.value` for asset-transfer amounts in `AlchemyAdapter._transformAssetTransfer`; the `transfer.value` field is a decimal display value and was leaking fractional, non-wei amounts into stored txs
* Route `_buildWalletTransactionsStream` to `streamERC20Transfers` when `args.tokenAddress` is set; previously it always called `streamAddressTransactions`, so wallet history for a specific token returned native transfers instead
* Cover the new overrides and bugfixes with unit tests in `test/unit/modules/base/csp.test.ts` and `test/unit/adapters/alchemy.test.ts`

### Testing Notes

* `/api/:chain/:network/block/tip` should return the live tip block, not null
* `/api/:chain/:network/fee/4` should return a non-zero feerate
* `/api/:chain/:network/block?limit=5` should list the last 5 blocks
* `/api/:chain/:network/wallet/:pubKey/transactions` (no `tokenAddress`) native transfers only, value in wei
* `/api/:chain/:network/wallet/:pubKey/transactions?tokenAddress=0x...`  only that token's transfers, value in token base units

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
* [x] I have added the appropriate package tag(s) (e.g. `BWC` if modifying the bitcore-wallet-client package, `CLI` if modifying the bitcore-cli package, etc.)
* [x] I have verified that this is not an existing PR ([open](https://github.com/bitpay/bitcore/pulls) or [closed](https://github.com/bitpay/bitcore/pulls?q=is%3Apr+is%3Aclosed+))
