### PR TITLE
Add first-pass ARC network support

### DIFF
--- a/bitcore-test.config.json
+++ b/bitcore-test.config.json
@@ -103,6 +103,22 @@
           "threads": 0
         }
       },
+      "ARC": {
+        "testnet": {
+          "chainSource": "external",
+          "module": "./moralis",
+          "trustedPeers": [],
+          "providers": [
+            {
+              "host": "rpc.testnet.arc.network",
+              "protocol": "https",
+              "port": "",
+              "dataType": "combined"
+            }
+          ],
+          "threads": 0
+        }
+      },
       "BASE": {
         "sepolia": {
           "chainSource": "external",

--- a/packages/bitcore-client/src/wallet.ts
+++ b/packages/bitcore-client/src/wallet.ts
@@ -37,6 +37,7 @@ const chainLibs = {
   ARB: { Web3, ethers },
   BASE: { Web3, ethers },
   OP: { Web3, ethers },
+  ARC: { Web3, ethers },
   XRP: xrpl,
   SOL: { SolKit, SolanaProgram }
 };
@@ -303,7 +304,7 @@ export class Wallet {
    * @returns {Boolean}
    */
   isEvmChain() {
-    return ['ETH', 'MATIC', 'ARB', 'OP', 'BASE'].includes(this.chain?.toUpperCase());
+    return ['ETH', 'MATIC', 'ARB', 'OP', 'BASE', 'ARC'].includes(this.chain?.toUpperCase());
   }
 
   isSolanaChain() {

--- a/packages/bitcore-client/test/unit/wallet.arc.test.ts
+++ b/packages/bitcore-client/test/unit/wallet.arc.test.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { Wallet } from '../../src/wallet';
+
+describe('Wallet ARC support', function() {
+  it('should treat ARC as an EVM chain', function() {
+    const arcWallet = Object.assign(Object.create(Wallet.prototype), { chain: 'ARC' }) as Wallet;
+    expect(arcWallet.isEvmChain()).to.equal(true);
+    expect(arcWallet.getLib()).to.have.keys(['Web3', 'ethers']);
+  });
+});

--- a/packages/crypto-wallet-core/src/constants/chains.ts
+++ b/packages/crypto-wallet-core/src/constants/chains.ts
@@ -23,6 +23,7 @@ export const EVM_CHAIN_NETWORK_TO_CHAIN_ID = {
   ARB_mainnet: 42161,
   BASE_mainnet: 8453,
   OP_mainnet: 10,
+  ARC_mainnet: 'unsupported',
   // ETH testnets
   ETH_holesky: 17000,
   ETH_sepolia: 11155111,

--- a/packages/crypto-wallet-core/src/constants/chains.ts
+++ b/packages/crypto-wallet-core/src/constants/chains.ts
@@ -1,6 +1,6 @@
 
 export const UTXO_CHAINS = ['btc', 'bch', 'doge', 'ltc'];
-export const EVM_CHAINS = ['eth', 'matic', 'arb', 'base', 'op'];
+export const EVM_CHAINS = ['eth', 'matic', 'arb', 'base', 'op', 'arc'];
 export const SVM_CHAINS = ['sol'];
 export const RIPPLE_CHAINS = ['xrp'];
 export const CHAINS = [...UTXO_CHAINS, ...EVM_CHAINS, ...SVM_CHAINS, ...RIPPLE_CHAINS];
@@ -12,7 +12,8 @@ export const EVM_CHAIN_DEFAULT_TESTNET = {
   MATIC: 'amoy',
   ARB: 'sepolia',
   BASE: 'sepolia',
-  OP: 'sepolia'
+  OP: 'sepolia',
+  ARC: 'testnet'
 };
 
 export const EVM_CHAIN_NETWORK_TO_CHAIN_ID = {
@@ -41,6 +42,8 @@ export const EVM_CHAIN_NETWORK_TO_CHAIN_ID = {
   // OP testnets
   OP_sepolia: 11155420,
   OP_goerli: 28528,
+  // ARC testnets
+  ARC_testnet: 5042002,
   // Regtests
   ETH_regtest: 1337,
   MATIC_regtest: 13375,

--- a/packages/crypto-wallet-core/src/constants/units.ts
+++ b/packages/crypto-wallet-core/src/constants/units.ts
@@ -90,8 +90,8 @@ export const UNITS = {
   arc: {
     toSatoshis: 1e18,
     full: {
-      maxDecimals: 8,
-      minDecimals: 8
+      maxDecimals: 6,
+      minDecimals: 6
     },
     short: {
       maxDecimals: 6,

--- a/packages/crypto-wallet-core/src/constants/units.ts
+++ b/packages/crypto-wallet-core/src/constants/units.ts
@@ -87,6 +87,17 @@ export const UNITS = {
       minDecimals: 2
     }
   },
+  arc: {
+    toSatoshis: 1e18,
+    full: {
+      maxDecimals: 8,
+      minDecimals: 8
+    },
+    short: {
+      maxDecimals: 6,
+      minDecimals: 2
+    }
+  },
   xrp: {
     toSatoshis: 1e6,
     full: {

--- a/packages/crypto-wallet-core/src/derivation/index.ts
+++ b/packages/crypto-wallet-core/src/derivation/index.ts
@@ -23,6 +23,7 @@ const derivers: { [chain: string]: IDeriver } = {
   ARB: new ArbDeriver(),
   BASE: new BaseDeriver(),
   OP: new OpDeriver(),
+  ARC: new EthDeriver(),
   SOL: new SolDeriver()
 };
 

--- a/packages/crypto-wallet-core/src/derivation/paths.ts
+++ b/packages/crypto-wallet-core/src/derivation/paths.ts
@@ -33,6 +33,9 @@ export const Paths = {
   BASE: {
     default: "m/44'/60'/",
   },
+  ARC: {
+    default: "m/44'/60'/",
+  },
   SOL: {
     default: "m/44'/501'/",
   },

--- a/packages/crypto-wallet-core/src/transactions/index.ts
+++ b/packages/crypto-wallet-core/src/transactions/index.ts
@@ -41,6 +41,8 @@ const providers = {
   BASEERC20: new BASEERC20TxProvider(),
   OP: new OPTxProvider(),
   OPERC20: new OPERC20TxProvider(),
+  ARC: new ETHTxProvider('ARC'),
+  ARCERC20: new ERC20TxProvider('ARC'),
   SOL: new SOLTxProvider(),
   SOLSPL: new SPLTxProvider(),
 };

--- a/packages/crypto-wallet-core/src/validation/arc/index.ts
+++ b/packages/crypto-wallet-core/src/validation/arc/index.ts
@@ -1,0 +1,8 @@
+import { EthValidation } from '../eth';
+
+export class ArcValidation extends EthValidation {
+  constructor() {
+    super();
+    this.regex = /arc/i;
+  }
+}

--- a/packages/crypto-wallet-core/src/validation/index.ts
+++ b/packages/crypto-wallet-core/src/validation/index.ts
@@ -1,4 +1,5 @@
 import { ArbValidation } from './arb';
+import { ArcValidation } from './arc';
 import { BaseValidation } from './base';
 import { BchValidation } from './bch';
 import { BtcValidation } from './btc';
@@ -11,9 +12,6 @@ import { SolValidation } from './sol';
 import { XrpValidation } from './xrp';
 import type { IValidation } from '../types/validation';
 
-const arcValidation = new EthValidation();
-arcValidation.regex = /arc/i;
-
 const validation: { [chain: string]: IValidation } = {
   BTC: new BtcValidation(),
   BCH: new BchValidation(),
@@ -25,7 +23,7 @@ const validation: { [chain: string]: IValidation } = {
   ARB: new ArbValidation(),
   BASE: new BaseValidation(),
   OP: new OpValidation(),
-  ARC: arcValidation,
+  ARC: new ArcValidation(),
   SOL: new SolValidation(),
 };
 

--- a/packages/crypto-wallet-core/src/validation/index.ts
+++ b/packages/crypto-wallet-core/src/validation/index.ts
@@ -11,6 +11,9 @@ import { SolValidation } from './sol';
 import { XrpValidation } from './xrp';
 import type { IValidation } from '../types/validation';
 
+const arcValidation = new EthValidation();
+arcValidation.regex = /arc/i;
+
 const validation: { [chain: string]: IValidation } = {
   BTC: new BtcValidation(),
   BCH: new BchValidation(),
@@ -22,6 +25,7 @@ const validation: { [chain: string]: IValidation } = {
   ARB: new ArbValidation(),
   BASE: new BaseValidation(),
   OP: new OpValidation(),
+  ARC: arcValidation,
   SOL: new SolValidation(),
 };
 

--- a/packages/crypto-wallet-core/test/address.test.ts
+++ b/packages/crypto-wallet-core/test/address.test.ts
@@ -88,6 +88,18 @@ describe('Address Derivation', () => {
     expect(address).to.equal(expectedAddress);
   });
 
+  it('should be able to generate a valid ARC address', () => {
+    const xPub = 'xpub6D8rChqkgFuaZULuq2n6VrS4zB5Cmv24gcRc889dFRRgYAH1CGQmQZ9kcPfMAfWGPnyMd1X5foBYFmJ5ZPfvwhm6tXjaY13ao1rQHRtkKDv';
+    // 'select scout crash enforce riot rival spring whale hollow radar rule sentence';
+
+    const path = Deriver.pathFor('ARC', 'testnet');
+    expect(path).to.equal("m/44'/60'/0'");
+
+    const address = Deriver.deriveAddress('ARC', 'testnet', xPub, 0, false);
+    const expectedAddress = '0x9dbfE221A6EEa27a0e2f52961B339e95426931F9';
+    expect(address).to.equal(expectedAddress);
+  });
+
   it('should be able to generate a valid ETH address, privKey, pubKey', () => {
     const privKey = 'xprv9ypBjKErGMqCdzd44hfSdy1Vk6PGtU3si8ogZcow7rA23HTxMi9XfT99EKmiNdLMr9BAZ9S8ZKCYfN1eCmzYSmXYHje1jnYQseV1VJDDfdS';
 

--- a/packages/crypto-wallet-core/test/transactions.test.ts
+++ b/packages/crypto-wallet-core/test/transactions.test.ts
@@ -4,7 +4,7 @@ import bitcoreLib from '@bitpay-labs/bitcore-lib';
 import bitcoreLibCash from '@bitpay-labs/bitcore-lib-cash';
 import bitcoreLibDoge from '@bitpay-labs/bitcore-lib-doge';
 import bitcoreLibLtc from '@bitpay-labs/bitcore-lib-ltc';
-import { Transactions } from '../src';
+import { Constants, Transactions } from '../src';
 
 describe('Transaction', function() {
   describe('create', () => {
@@ -1748,6 +1748,57 @@ describe('Transaction', function() {
 
       const regtestId = Transactions.get({ chain: 'MATIC' }).getChainId('regtest');
       expect(regtestId).to.equal(13375);
+    });
+  });
+
+  describe('ARC EVM support', () => {
+    it('should get the correct testnet chainId', () => {
+      const testnetId = Transactions.get({ chain: 'ARC' }).getChainId('testnet');
+      expect(testnetId).to.equal(5042002);
+    });
+
+    it('should create an ARC native transaction using 18-decimal base units', () => {
+      const tx = Transactions.create({
+        chain: 'ARC',
+        recipients: [{ address: '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A', amount: '1000000000000000000' }],
+        nonce: 0,
+        gasPrice: 1,
+        gasLimit: 21000,
+        network: 'testnet',
+        data: '0x'
+      });
+      const parsed = ethers.Transaction.from(tx);
+      expect(parsed.chainId).to.equal(5042002n);
+      expect(parsed.value).to.equal(1000000000000000000n);
+    });
+
+    it('should create an ARC ERC20 transaction using ARC testnet chainId', () => {
+      const tokenAddress = '0x3600000000000000000000000000000000000000';
+      const recipient = '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A';
+      const amount = '1000000';
+      const tx = Transactions.create({
+        chain: 'ARCERC20',
+        recipients: [{ address: recipient, amount }],
+        nonce: 0,
+        gasPrice: 1,
+        gasLimit: 200000,
+        network: 'testnet',
+        tokenAddress
+      });
+      const parsed = ethers.Transaction.from(tx);
+
+      expect(parsed.chainId).to.equal(5042002n);
+      expect(parsed.to).to.equal(ethers.getAddress(tokenAddress));
+      expect(parsed.value).to.equal(0n);
+      expect(parsed.data).to.equal(
+        '0xa9059cbb' +
+        '00000000000000000000000037d7b3bbd88efde6a93cf74d2f5b0385d3e3b08a' +
+        '00000000000000000000000000000000000000000000000000000000000f4240'
+      );
+    });
+
+    it('should define ARC native units as 18 decimals', () => {
+      expect(Constants.UNITS.arc.toSatoshis).to.equal(1e18);
     });
   });
 

--- a/packages/crypto-wallet-core/test/transactions.test.ts
+++ b/packages/crypto-wallet-core/test/transactions.test.ts
@@ -1799,6 +1799,8 @@ describe('Transaction', function() {
 
     it('should define ARC native units as 18 decimals', () => {
       expect(Constants.UNITS.arc.toSatoshis).to.equal(1e18);
+      expect(Constants.UNITS.arc.full.maxDecimals).to.equal(6);
+      expect(Constants.UNITS.arc.full.minDecimals).to.equal(6);
     });
   });
 

--- a/packages/crypto-wallet-core/test/validation.test.ts
+++ b/packages/crypto-wallet-core/test/validation.test.ts
@@ -239,6 +239,27 @@ describe('Address Validation', () => {
     expect(inValidMaticPrefix).to.equal(false);
   });
 
+  it('should validate ARC addresses', async () => {
+    const address = '37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A';
+    const prefixedAddress = `0x${address}`;
+
+    expect(await Validation.validateAddress('ARC', 'testnet', address)).to.equal(true);
+    expect(await Validation.validateAddress('ARC', 'testnet', prefixedAddress)).to.equal(true);
+    expect(await Validation.validateAddress('ARC', 'testnet', address.slice(1))).to.equal(false);
+  });
+
+  it('should validate ARC URIs', async () => {
+    const address = '0x37d7B3bBD88EFdE6a93cF74D2F5b0385D3E3B08A';
+    const uri = `arc:${address}`;
+    const uriParams = `${uri}?value=123&gasPrice=123&gas=123&gasLimit=123`;
+
+    expect(await Validation.validateUri('ARC', uri)).to.equal(true);
+    expect(await Validation.validateUri('ARC', uriParams)).to.equal(true);
+    expect(await Validation.validateUri('ARC', `${uri}?value=123`)).to.equal(true);
+    expect(await Validation.validateUri('ARC', address)).to.equal(false);
+    expect(await Validation.validateUri('ARC', `${uri}?value=invalid&gasLimit=123&gas=123`)).to.equal(false);
+  });
+
   it('should be able to validate a SOL address', async () => {
     const isValidAddress = await Validation.validateAddress('SOL', 'mainnet', solAddress);
     expect(isValidAddress).to.equal(true);


### PR DESCRIPTION
## Summary
Adds first-pass ARC testnet support as an EVM-compatible chain.

- Configures ARC testnet in `bitcore-test.config.json` via `./moralis`
- Adds ARC chain ID/default network/18-decimal native units in crypto-wallet-core
- Reuses ETH derivation, validation, native tx, and ERC20 tx providers for ARC
- Treats ARC as an EVM chain in bitcore-client
- Adds focused tests for derivation, validation, native txs, ERC20 txs, and client EVM recognition

## Notes / Follow-ups
ARC native USDC and the ARC ERC-20 USDC interface represent the same underlying balance with different units:

- Native ARC balance: 18 decimals
- ERC-20 USDC interface `0x3600000000000000000000000000000000000000`: 6 decimals

Follow-up work is needed for:
- BitPay `/currencies` metadata for native ARC and ARC USDC
- BWS/BWC handling so native ARC and ERC-20 USDC are not double-counted
- Fee/spend checks, because gas and ERC-20 USDC transfers draw from the same underlying USDC balance

## Validation
Automated:
- `packages/crypto-wallet-core`: `npm run test`
- `packages/bitcore-client`: `npm run compile`
- `packages/bitcore-client`: `./node_modules/.bin/mocha -r tsx --exit 'test/unit/wallet.arc.test.ts'`

Manual smoke:
- Started bitcore-node with ARC testnet configured via `./moralis`
- Verified ARC enabled-chain, fee, priority fee, and nonce routes
- Smoke tested bitcore-client CLI:
  - `wallet-create`
  - `wallet-derive`
  - `wallet-balance`
  - `wallet-send`
- Confirmed native ARC send on testnet:
  - `0x686cd1fa60743fc35a61ead24e2f37a9444907eab1dfa3658208668a6c6e5ed1`