### PR TITLE
Fix bitcore-node command path

### DIFF
--- a/packages/bitcore-node/bin/start
+++ b/packages/bitcore-node/bin/start
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../server.js');
+require('../build/src/server.js');


### PR DESCRIPTION
### Description
Fix bitcore-node/bin/start script path. The bitcore-node command does not work currently. Hasn't been changed in 8 years, before typescript was integrated ([8435853](https://github.com/bitpay/bitcore/commit/8435853f2ac7cce368a3022a5c54e6902fda0295)).
### Changelog

* Changed path for packages/bitcore-node/bin/start to include build and src

### Testing Notes
bitcore-node command does not work.
Install:
```
$ npm install -g bitcore-node
```
Run:
```
$ bitcore-node # or ./bin/start from bitcore-node, same result

node:internal/modules/cjs/loader:1247
  throw err;
  ^

Error: Cannot find module '../server.js'
Require stack:
- /home/micah/.nvm/versions/node/v22.13.1/lib/node_modules/bitcore-node/bin/start
    at Function._resolveFilename (node:internal/modules/cjs/loader:1244:15)
    at Function._load (node:internal/modules/cjs/loader:1070:27)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1335:12)
    at require (node:internal/modules/helpers:136:16)
    at Object.<anonymous> (/home/micah/.nvm/versions/node/v22.13.1/lib/node_modules/bitcore-node/bin/start:2:1)
    at Module._compile (node:internal/modules/cjs/loader:1562:14)
    at Object..js (node:internal/modules/cjs/loader:1699:10)
    at Module.load (node:internal/modules/cjs/loader:1313:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/micah/.nvm/versions/node/v22.13.1/lib/node_modules/bitcore-node/bin/start'
  ]
}


Node.js v22.13.1
```

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.