### PR TITLE
Increase max commitment length, per BCH's new p2s output type

### DIFF
--- a/packages/bitcore-lib-cash/lib/transaction/output.js
+++ b/packages/bitcore-lib-cash/lib/transaction/output.js
@@ -108,7 +108,7 @@ Object.defineProperty(Output.prototype, 'tokenData', {
         nft.capability = tokenData.nft.capability === undefined ? 'none' : String(tokenData.nft.capability);
         $.checkState(nftCapabilityNumberToLabel.includes(nft.capability), 'nft capability must be "none", "mutable", or "minting".');
         const commitment = tokenData.nft.commitment === undefined ? Buffer.of() : typeof tokenData.nft.commitment === 'string' ? Buffer.from(tokenData.nft.commitment, 'hex') : Buffer.from(tokenData.nft.commitment);
-        $.checkState(commitment.length <= 40, 'nft commitment length must be less than or equal to 40 bytes.');
+        $.checkState(commitment.length <= 128, 'nft commitment length must be less than or equal to 128 bytes.');
         nft.commitment = commitment.toString('hex');
         this._tokenData = { category, amount, nft };
       } else {

--- a/packages/bitcore-lib-cash/test/transaction/output.js
+++ b/packages/bitcore-lib-cash/test/transaction/output.js
@@ -194,7 +194,7 @@ describe("Output", function() {
     expect(() => new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { capability: 'unknown' } } })).to.throw('Invalid state: nft capability must be "none", "mutable", or "minting".');
     expect(() => new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { capability: 'none' } } })).to.not.throw();
     expect(new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { commitment: '' } } })).to.deep.equal(new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { commitment: Buffer.of() } } }));
-    expect(() => new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { commitment: Buffer.from(new Uint8Array(41)) } } })).to.throw('Invalid state: nft commitment length must be less than or equal to 40 bytes.');
+    expect(() => new Output({ satoshis: 1000, script: '51', tokenData: { category: '0102030405060708091011121314151617181920212223242526272829303132', amount: 0, nft: { commitment: Buffer.from(new Uint8Array(129)) } } })).to.throw('Invalid state: nft commitment length must be less than or equal to 128 bytes.');
   });
 
   it('output creation fails if script includes token prefix', function() {

--- a/packages/crypto-rpc/docker-compose.yml
+++ b/packages/crypto-rpc/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     restart: always
 
   bitcoin-cash:
-    image: zquestz/bitcoin-cash-node:28.0.1
+    image: zquestz/bitcoin-cash-node:29.0.0
     ports:
       - "9333:9333"
     networks:


### PR DESCRIPTION
### Description
Per https://github.com/bitjson/bch-p2s/blob/master/readme.md#token-commitment-length, BCH's new P2S output type allows a commitment length up to 128 bytes.

### Changelog

* Changes the max commitment length to 128 bytes

### Testing Notes
Bitcore-node should now sync past mainnet block 951146 (specifically, tx af3c221167a6faae4d5dbb0cd43656ee088e7ea9d269730fe1ee51270c4183e3)

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.