### PR TITLE
[BCN] Handle missing Solana token ATA in txhistory

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/svm/api/csp.ts
+++ b/packages/bitcore-node/src/providers/chain-state/svm/api/csp.ts
@@ -1,4 +1,5 @@
 import { CryptoRpc } from '@bitpay-labs/crypto-rpc';
+import { SOL_ERROR_MESSAGES } from '@bitpay-labs/crypto-rpc/lib/sol/error_messages';
 import { instructionKeys } from '@bitpay-labs/crypto-rpc/lib/sol/transaction-parser';
 import { fetchDigitalAsset, mplTokenMetadata } from '@metaplex-foundation/mpl-token-metadata';
 import { createUmi } from '@metaplex-foundation/umi-bundle-defaults';
@@ -36,9 +37,11 @@ import type { SolRpc } from '@bitpay-labs/crypto-rpc/lib/sol/SolRpc';
 
 export interface GetSolWeb3Response { rpc: SolRpc; connection: any; umi: any; dataType: string; lastPingTime?: number };
 
+const MISSING_ATA_ERROR = 'Missing ATA';
+
 function isMissingAtaError(err: any): boolean {
   const message = err?.message || '';
-  return message === 'Missing ATA' || message.includes('ATA not initialized');
+  return message === MISSING_ATA_ERROR || message === SOL_ERROR_MESSAGES.ATA_NOT_INITIALIZED;
 }
 
 export class BaseSVMStateProvider extends InternalStateProvider implements IChainStateService {
@@ -291,12 +294,12 @@ export class BaseSVMStateProvider extends InternalStateProvider implements IChai
         if (tokenAddress) {
           try {
             _address = await rpc.getConfirmedAta({ solAddress: address, mintAddress: tokenAddress });
-            if (!_address) throw new Error('Missing ATA');
+            if (!_address) throw new Error(MISSING_ATA_ERROR);
           } catch (e: any) {
             if (isMissingAtaError(e)) {
               // A closed ATA is not returned by getConfirmedAta, but its address can still have history.
               _address = await rpc.deriveAta({ solAddress: address, mintAddress: tokenAddress });
-              if (!_address) throw new Error('Missing ATA');
+              if (!_address) throw new Error(MISSING_ATA_ERROR);
             } else {
               const errMsg = 'Error getting ATA address';
               logger.error(`${errMsg} %o`, e.stack || e.message || e);

--- a/packages/bitcore-node/src/providers/chain-state/svm/api/csp.ts
+++ b/packages/bitcore-node/src/providers/chain-state/svm/api/csp.ts
@@ -36,6 +36,11 @@ import type { SolRpc } from '@bitpay-labs/crypto-rpc/lib/sol/SolRpc';
 
 export interface GetSolWeb3Response { rpc: SolRpc; connection: any; umi: any; dataType: string; lastPingTime?: number };
 
+function isMissingAtaError(err: any): boolean {
+  const message = err?.message || '';
+  return message === 'Missing ATA' || message.includes('ATA not initialized');
+}
+
 export class BaseSVMStateProvider extends InternalStateProvider implements IChainStateService {
   static rpcs: { [chainNetwork: string]: { historical: GetSolWeb3Response[]; realtime: GetSolWeb3Response[] } } = {};
   static rpcIndicies: { [chainNetwork: string]: { historical: number; realtime: number } } = {};
@@ -285,13 +290,18 @@ export class BaseSVMStateProvider extends InternalStateProvider implements IChai
         let _address = address;
         if (tokenAddress) {
           try {
-            const { rpc } = await this.getRpc(network);
             _address = await rpc.getConfirmedAta({ solAddress: address, mintAddress: tokenAddress });
             if (!_address) throw new Error('Missing ATA');
           } catch (e: any) {
-            const errMsg = 'Error getting ATA address';
-            logger.error(`${errMsg} %o`, e.stack || e.message || e);
-            throw new Error(errMsg);
+            if (isMissingAtaError(e)) {
+              // A closed ATA is not returned by getConfirmedAta, but its address can still have history.
+              _address = await rpc.deriveAta({ solAddress: address, mintAddress: tokenAddress });
+              if (!_address) throw new Error('Missing ATA');
+            } else {
+              const errMsg = 'Error getting ATA address';
+              logger.error(`${errMsg} %o`, e.stack || e.message || e);
+              throw new Error(errMsg);
+            }
           }
         }
         do {

--- a/packages/bitcore-node/test/integration/solana/csp.test.ts
+++ b/packages/bitcore-node/test/integration/solana/csp.test.ts
@@ -1,6 +1,7 @@
 import { ObjectId } from 'bson';
 import { expect } from 'chai';
 import { Request, Response } from 'express-serve-static-core';
+import { SOL_ERROR_MESSAGES } from '@bitpay-labs/crypto-rpc/lib/sol/error_messages';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
 import { MongoBound } from '../../../src/models/base';
@@ -106,6 +107,8 @@ describe('Solana API', function() {
 
   describe('#streamWalletTransactions', () => {
     const address = 'DGqGrPJu5QgQ5pFHimGKX6wqPmUVnk5L1NAmpHdP6n8F';
+    const tokenAddress = 'So11111111111111111111111111111111111111112';
+    const derivedAtaAddress = '9xQeWvG816bUx9EPfEZbrrpK5n8W5x2nqE8h9vDOMkMt';
     let wallet: IWallet;
 
     // Set up wallet before running wallet tests
@@ -222,14 +225,12 @@ describe('Solana API', function() {
     });
 
     it('should stream empty SPL token history from derived ATA when current ATA is not initialized', async () => {
-      const tokenAddress = '11111111111111111111111111111112';
-      const derivedAtaAddress = 'derivedTokenAccountAddress';
       const chunks: string[] = [];
       const connection = {
         getSignaturesForAddress: sandbox.stub().returns({ send: sandbox.stub().resolves([]) })
       };
       const rpc = {
-        getConfirmedAta: sandbox.stub().rejects(new Error('ATA not initialized on mint for provided account. Initialize ATA first.')),
+        getConfirmedAta: sandbox.stub().rejects(new Error(SOL_ERROR_MESSAGES.ATA_NOT_INITIALIZED)),
         deriveAta: sandbox.stub().resolves(derivedAtaAddress)
       };
 
@@ -271,6 +272,73 @@ describe('Solana API', function() {
       expect(rpc.deriveAta.calledOnceWithExactly({ solAddress: address, mintAddress: tokenAddress })).to.be.true;
       expect(connection.getSignaturesForAddress.calledOnce).to.be.true;
       expect(connection.getSignaturesForAddress.firstCall.args[0]).to.equal(derivedAtaAddress);
+    });
+
+    it('should stream SPL token history from derived ATA when current ATA was closed', async () => {
+      const signature = {
+        signature: '2mtY1zc9B6vjXPkFvSRu1Fuz9VJQhVQJQ4VDaqq5y91U2coJMSM5JEbP9ubS3TbvBCNhYtVKURqtPE5AeJrTYz9S',
+        slot: 123,
+        confirmationStatus: 'finalized'
+      };
+      const transformedTx = {
+        txid: signature.signature,
+        category: 'receive',
+        satoshis: 1000000,
+        height: signature.slot,
+        chain,
+        network
+      };
+      const chunks: string[] = [];
+      const connection = {
+        getSignaturesForAddress: sandbox.stub().returns({ send: sandbox.stub().resolves([signature]) })
+      };
+      const rpc = {
+        getConfirmedAta: sandbox.stub().rejects(new Error(SOL_ERROR_MESSAGES.ATA_NOT_INITIALIZED)),
+        deriveAta: sandbox.stub().resolves(derivedAtaAddress)
+      };
+
+      sandbox.stub(SOL, 'getRpc').resolves({ rpc, connection });
+      sandbox.stub(SOL, 'getWalletAddresses').resolves([{ address }]);
+      const getTransformedTx = sandbox.stub(SOL, '_getTransformedTx').resolves(transformedTx as any);
+
+      const req = (new Writable({
+        write: function(_data, _, cb) {
+          cb();
+        }
+      }) as unknown) as Request;
+
+      const res = (new Writable({
+        write: function(data, _, cb) {
+          chunks.push(data.toString());
+          cb();
+        }
+      }) as unknown) as Response;
+      res.type = () => res;
+
+      const err = await new Promise(r => {
+        res
+          .on('error', r)
+          .on('finish', () => r(undefined));
+
+        SOL.streamWalletTransactions({
+          chain,
+          network,
+          wallet,
+          req,
+          res,
+          args: { tokenAddress, limit: 1 }
+        })
+          .catch(e => r(e));
+      });
+
+      const streamedTxs = chunks.join('').trim().split('\n').map(line => JSON.parse(line));
+
+      expect(err).to.not.exist;
+      expect(rpc.deriveAta.calledOnceWithExactly({ solAddress: address, mintAddress: tokenAddress })).to.be.true;
+      expect(connection.getSignaturesForAddress.calledOnce).to.be.true;
+      expect(connection.getSignaturesForAddress.firstCall.args[0]).to.equal(derivedAtaAddress);
+      expect(getTransformedTx.calledOnceWithExactly(rpc, network, signature, derivedAtaAddress, tokenAddress)).to.be.true;
+      expect(streamedTxs).to.deep.equal([transformedTx]);
     });
   });
 

--- a/packages/bitcore-node/test/integration/solana/csp.test.ts
+++ b/packages/bitcore-node/test/integration/solana/csp.test.ts
@@ -220,6 +220,58 @@ describe('Solana API', function() {
       expect(err).to.not.exist;
       expect(counter).to.be.gt(0);
     });
+
+    it('should stream empty SPL token history from derived ATA when current ATA is not initialized', async () => {
+      const tokenAddress = '11111111111111111111111111111112';
+      const derivedAtaAddress = 'derivedTokenAccountAddress';
+      const chunks: string[] = [];
+      const connection = {
+        getSignaturesForAddress: sandbox.stub().returns({ send: sandbox.stub().resolves([]) })
+      };
+      const rpc = {
+        getConfirmedAta: sandbox.stub().rejects(new Error('ATA not initialized on mint for provided account. Initialize ATA first.')),
+        deriveAta: sandbox.stub().resolves(derivedAtaAddress)
+      };
+
+      sandbox.stub(SOL, 'getRpc').resolves({ rpc, connection });
+      sandbox.stub(SOL, 'getWalletAddresses').resolves([{ address }]);
+
+      const req = (new Writable({
+        write: function(_data, _, cb) {
+          cb();
+        }
+      }) as unknown) as Request;
+
+      const res = (new Writable({
+        write: function(data, _, cb) {
+          chunks.push(data.toString());
+          cb();
+        }
+      }) as unknown) as Response;
+      res.type = () => res;
+
+      const err = await new Promise(r => {
+        res
+          .on('error', r)
+          .on('finish', () => r(undefined));
+
+        SOL.streamWalletTransactions({
+          chain,
+          network,
+          wallet,
+          req,
+          res,
+          args: { tokenAddress }
+        })
+          .catch(e => r(e));
+      });
+
+      expect(err).to.not.exist;
+      expect(chunks.join('')).to.equal('');
+      expect(rpc.deriveAta.calledOnceWithExactly({ solAddress: address, mintAddress: tokenAddress })).to.be.true;
+      expect(connection.getSignaturesForAddress.calledOnce).to.be.true;
+      expect(connection.getSignaturesForAddress.firstCall.args[0]).to.equal(derivedAtaAddress);
+    });
   });
 
   it('should correctly transform transaction data', () => {


### PR DESCRIPTION
### Description
Fixes a BitPay app txhistory failure observed with zero-balance Solana token wallets.

Zero-balance Solana token wallets can still have transaction history. A user may have received or sent a token before, then sent the balance back to zero or closed the associated token account. In that state, the wallet should still be able to show historical activity.

**Observed failure mode:** When the app fetched txhistory for one of these token wallets, BWS returned a plain-text `Error getting ATA address` response instead of an empty or historical transaction list.

**Root cause:** BWS forwards `/v1/txhistory/` requests with `tokenAddress` to bitcore-node wallet transaction streaming. In the Solana token path, bitcore-node resolves the wallet address's associated token account before listing signatures. If there is no currently initialized ATA, `getConfirmedAta` throws and the stream fails.

**The fix:** This change keeps `getConfirmedAta` as the first lookup, so invalid mints and other non-missing-ATA failures keep their existing behavior. For the missing or uninitialized ATA case, it derives the deterministic ATA address and uses it to find any prior token-account activity. If prior activity exists, txhistory returns the corresponding transaction history even if the ATA was later closed.

### Changelog

* Fall back to the derived Solana ATA when SPL token txhistory has no currently initialized ATA.
* Preserve existing error behavior for invalid mints and other non-missing-ATA failures.
* Add regression coverage for `SOL + tokenAddress + missing current ATA`.

### Testing Notes

From `packages/bitcore-node`, run:

```bash
npm run tsc && BCN_LOG_LEVEL=none npm exec -- mocha 'build/test/integration/solana/csp.test.js' --grep 'derived ATA'
npm run test:integration
```