### PR TITLE
More bitcore-cli tweaks and improvements

### DIFF
--- a/packages/bitcore-cli/package.json
+++ b/packages/bitcore-cli/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "bin": {
-    "wallet": "./bin/wallet"
+    "bitcore-cli": "./bin/wallet"
   },
   "scripts": {
     "test": "npm run compile && node copyTestWallets && mocha --exit 'build/test/**/*.js'",

--- a/packages/bitcore-cli/src/commands/create/createMultiSig.ts
+++ b/packages/bitcore-cli/src/commands/create/createMultiSig.ts
@@ -23,7 +23,7 @@ export async function createMultiSigWallet(
 
   const copayerName = await getCopayerName();
   const addressType = await getAddressType({ chain, network, isMultiSig: true });
-  const password = await getPassword('Enter a password for the wallet:', { hidden: false });
+  const password = await getPassword('Lock your wallet with a password:', { hidden: false });
   
   const { key, secret } = await wallet.create({ chain, network, account: 0, n, m, password, mnemonic, addressType, copayerName });
 

--- a/packages/bitcore-cli/src/commands/create/createSingleSig.ts
+++ b/packages/bitcore-cli/src/commands/create/createSingleSig.ts
@@ -14,7 +14,7 @@ export async function createSingleSigWallet(
   const { verbose, mnemonic } = opts;
 
   const addressType = await getAddressType({ chain, network });
-  const password = await getPassword('Enter a password for the wallet:', { hidden: false });
+  const password = await getPassword('Lock your wallet with a password:', { hidden: false });
   const copayerName = process.env.USER || 'copayer';
 
   const { key } = await wallet.create({

--- a/packages/bitcore-cli/src/commands/create/createThresholdSig.ts
+++ b/packages/bitcore-cli/src/commands/create/createThresholdSig.ts
@@ -4,8 +4,9 @@ import url from 'url';
 import { Key, type Network, TssKey } from '@bitpay-labs/bitcore-wallet-client';
 import * as prompt from '@clack/prompts';
 import { UserCancelled } from '../../errors';
-import { getAddressType, getCopayerName, getPassword } from '../../prompts';
+import { getAddressType, getCopayerName, getPassword, promptKeyshareBackup } from '../../prompts';
 import { Utils } from '../../utils';
+import { exportWallet } from '../export';
 import type { CommonArgs } from '../../../types/cli';
 
 
@@ -26,7 +27,7 @@ export async function createThresholdSigWallet(
 
   const copayerName = await getCopayerName();
   const addressType = await getAddressType({ chain, network, isMultiSig: false, isTss: true });
-  const password = await getPassword('Enter a password for the wallet:', { hidden: false });
+  const password = await getPassword('Lock your wallet with a password:', { hidden: false });
 
   let key;
   if (mnemonic) {
@@ -46,6 +47,16 @@ export async function createThresholdSigWallet(
   const tssPassword = crypto.randomBytes(20).toString('hex');
   await tss.newKey({ m, n, password: tssPassword });
   
+  prompt.note(
+    'Next, you will be asked to enter party 1\'s public key. Once you enter it, ' +
+    'a personal join code will be generated for you to give to them.' + os.EOL +
+    'To get their public key, party 1 should go ahead and start the join process ' +
+    'for their wallet by running bitcore-cli and selecting `Join Wallet`. Then they follow the ' +
+    'prompts until it tells them to share the public key with the session leader (you).' + os.EOL + os.EOL +
+    'Repeat this process for the other party members. Once all members have joined, the TSS ' +
+    'wallet creation process will finish.'
+  );
+
   for (let i = 1; i < n; i++) {
     const pubkey = await prompt.text({
       message: `Enter party ${i}'s public key:`,
@@ -133,7 +144,15 @@ export async function createThresholdSigWallet(
     });
   });
 
+
+  // Keyshare backup
+  const ok = await promptKeyshareBackup();
+  if (ok) {
+    await exportWallet({ wallet, opts: { ...opts, readonly: false } });
+  }
+
   return {
-    mnemonic: key.get(password).mnemonic
+    // TSS wallets cannot be restored from a mnemonic alone, so we return null here. All the wallet recovery information is in the keyshare backup file.
+    mnemonic: null
   };
 }

--- a/packages/bitcore-cli/src/commands/create/index.ts
+++ b/packages/bitcore-cli/src/commands/create/index.ts
@@ -30,7 +30,7 @@ export async function createWallet(args: CommonArgs<{ mnemonic?: string }>) {
     const [m, n] = Utils.parseMN(mOfN);
 
     if (useTss) {
-      ({ mnemonic } = await createThresholdSigWallet({ wallet, chain, network, opts, m, n }));
+      await createThresholdSigWallet({ wallet, chain, network, opts, m, n });
     } else {
       ({ mnemonic } = await createMultiSigWallet({ wallet, chain, network, opts, m, n }));
     }
@@ -38,10 +38,9 @@ export async function createWallet(args: CommonArgs<{ mnemonic?: string }>) {
   
   // Re-fetch the client to ensure it has the latest state
   // and to complete the wallet creation process
-
   await wallet.getClient({});
 
-  if (!opts.mnemonic) {
+  if (!opts.mnemonic && mnemonic) {
     await Utils.showMnemonic(wallet.name, mnemonic, opts);
   }
 };

--- a/packages/bitcore-cli/src/commands/export.ts
+++ b/packages/bitcore-cli/src/commands/export.ts
@@ -30,10 +30,10 @@ export async function exportWallet(args: CommonArgs<{ filename?: string; readonl
   }
   const replaceTilde = str => str.startsWith('~') ? str.replace('~', os.homedir()) : str;
 
-  const readOnly = !!opts.readonly || wallet.isReadOnly() || await prompt.confirm({
+  const readOnly = opts.readonly ?? (wallet.isReadOnly() || await prompt.confirm({
     message: 'Export as read-only (cannot send funds)?',
     initialValue: false
-  });
+  }));
   if (prompt.isCancel(readOnly)) {
     throw new UserCancelled();
   }
@@ -66,7 +66,7 @@ export async function exportWallet(args: CommonArgs<{ filename?: string; readonl
     throw new UserCancelled();
   }
 
-  const exportPassword = await getPassword('Import/export password:', { hidden: false, minLength: 6 });
+  const exportPassword = await getPassword('File encryption password:', { hidden: false, minLength: 6 });
 
   await wallet.export({
     filename: replaceTilde(filename),

--- a/packages/bitcore-cli/src/commands/import.ts
+++ b/packages/bitcore-cli/src/commands/import.ts
@@ -26,7 +26,7 @@ export async function importWallet(args: CommonArgs) {
     throw new UserCancelled();
   }
 
-  const importPassword = await getPassword('Import/export password:', { hidden: true });
+  const importPassword = await getPassword('File decryption password:', { hidden: true });
   
   await wallet.import({
     filename: replaceTilde(filename),

--- a/packages/bitcore-cli/src/commands/join/index.ts
+++ b/packages/bitcore-cli/src/commands/join/index.ts
@@ -39,12 +39,12 @@ export async function joinWallet(args: CommonArgs<{ mnemonic?: string }>) {
 
   let mnemonic;
   if (useTss) {
-    ({ mnemonic } = await joinThresholdSigWallet(Object.assign({}, args, { chain })));
+    await joinThresholdSigWallet(Object.assign({}, args, { chain }));
   } else {
     ({ mnemonic } = await joinMultiSigWallet(args));
   }
 
-  if (!opts.mnemonic) {
+  if (!opts.mnemonic && mnemonic) {
     await Utils.showMnemonic(wallet.name, mnemonic, opts);
   }
 };

--- a/packages/bitcore-cli/src/commands/join/joinMultiSig.ts
+++ b/packages/bitcore-cli/src/commands/join/joinMultiSig.ts
@@ -24,7 +24,7 @@ export async function joinMultiSigWallet(args: CommonArgs<{ mnemonic?: string }>
   } = parsed;
 
   const copayerName = await getCopayerName();
-  const password = await getPassword('Enter a password for the wallet:', { hidden: false });
+  const password = await getPassword('Lock your wallet with a password:', { hidden: false });
   const { key, joinedWalletName } = await wallet.create({ chain, network, account: 0, n: 2, m: 1, password, mnemonic, copayerName, joinSecret }); // n gets overwritten
   
   prompt.log.success(Utils.colorText(`Wallet joined: ${joinedWalletName}`, 'green'));

--- a/packages/bitcore-cli/src/commands/join/joinThresholdSig.ts
+++ b/packages/bitcore-cli/src/commands/join/joinThresholdSig.ts
@@ -3,8 +3,9 @@ import url from 'url';
 import { Key, TssKey } from '@bitpay-labs/bitcore-wallet-client';
 import * as prompt from '@clack/prompts';
 import { UserCancelled } from '../../errors';
-import { getCopayerName, getNetwork, getPassword } from '../../prompts';
+import { getCopayerName, getNetwork, getPassword, promptKeyshareBackup } from '../../prompts';
 import { Utils } from '../../utils';
+import { exportWallet } from '../export';
 import type { CommonArgs } from '../../../types/cli';
 
 export async function joinThresholdSigWallet(
@@ -15,7 +16,7 @@ export async function joinThresholdSigWallet(
   
   const network = await getNetwork();
   const copayerName = await getCopayerName();
-  const password = await getPassword('Enter a password for the wallet:', { hidden: false });
+  const password = await getPassword('Lock your wallet with a password:', { hidden: false });
 
   let key;
   if (mnemonic) {
@@ -114,7 +115,15 @@ export async function joinThresholdSigWallet(
     });
   });
 
+
+  // Keyshare backup
+  const ok = await promptKeyshareBackup();
+  if (ok) {
+    await exportWallet({ wallet, opts: { ...opts, readonly: false } });
+  }
+
   return {
-    mnemonic: key.get(password).mnemonic
+    // TSS wallets cannot be restored from a mnemonic alone, so we return null here. All the wallet recovery information is in the keyshare backup file.
+    mnemonic: null
   };
 }

--- a/packages/bitcore-cli/src/commands/register.ts
+++ b/packages/bitcore-cli/src/commands/register.ts
@@ -23,6 +23,14 @@ export async function registerWallet(args: CommonArgs) {
     Object.assign(opts, command(args));
   }
 
+  if (wallet.client.credentials.tssKeyId) {
+    // Calling `wallet.register` will only register the wallet as a single-sig (non-TSS) wallet.
+    // Importing a TSS wallet to a new server will need to initialize a tsskeygen Mongo document on the server
+    // and include the tssKeyId in the wallet registration process.
+    prompt.log.error('This wallet appears to to be a TSS wallet. Registering an existing TSS wallet on a different server is not yet supported.');
+    return;
+  }
+
   const copayerName = wallet.client.credentials.copayerName || process.env.USER || 'copayer';
   await wallet.register({ copayerName });
   prompt.log.success('Wallet registered');

--- a/packages/bitcore-cli/src/commands/register.ts
+++ b/packages/bitcore-cli/src/commands/register.ts
@@ -23,14 +23,6 @@ export async function registerWallet(args: CommonArgs) {
     Object.assign(opts, command(args));
   }
 
-  if (wallet.client.credentials.tssKeyId) {
-    // Calling `wallet.register` will only register the wallet as a single-sig (non-TSS) wallet.
-    // Importing a TSS wallet to a new server will need to initialize a tsskeygen Mongo document on the server
-    // and include the tssKeyId in the wallet registration process.
-    prompt.log.error('This wallet appears to to be a TSS wallet. Registering an existing TSS wallet on a different server is not yet supported.');
-    return;
-  }
-
   const copayerName = wallet.client.credentials.copayerName || process.env.USER || 'copayer';
   await wallet.register({ copayerName });
   prompt.log.success('Wallet registered');

--- a/packages/bitcore-cli/src/commands/status.ts
+++ b/packages/bitcore-cli/src/commands/status.ts
@@ -53,7 +53,7 @@ export async function walletStatus(args: CommonArgs) {
     statusLines.push(`Secret: ${Utils.colorText(w.secret, 'yellow')}`);
   }
 
-  prompt.note(statusLines.join(os.EOL), `${tokenObj ? '(Linked) ' : ''}Wallet info`);
+  prompt.note(statusLines.join(os.EOL), `${tokenObj ? '(Linked) ' : ''}Wallet Info`);
 
   const currency = tokenObj?.displayCode || w.coin;
   displayBalance(currency, status.balance, Object.assign({ showByAddress: false }, tokenObj));

--- a/packages/bitcore-cli/src/constants.ts
+++ b/packages/bitcore-cli/src/constants.ts
@@ -108,18 +108,18 @@ export const Constants = {
     }
   },
   COLOR: {
-    green: '\x1b[32m%s\x1b[0m',
-    red: '\x1b[31m%s\x1b[0m',
-    yellow: '\x1b[33m%s\x1b[0m',
-    blue: '\x1b[34m%s\x1b[0m',
-    orange: '\x1b[38;5;208m%s\x1b[0m',
-    gold: '\x1b[38;5;214m%s\x1b[0m',
-    tan: '\x1b[38;5;180m%s\x1b[0m',
-    beige: '\x1b[38;5;223m%s\x1b[0m',
-    purple: '\x1b[38;5;129m%s\x1b[0m',
-    lightgray: '\x1b[38;5;250m%s\x1b[0m',
-    darkgray: '\x1b[38;5;236m%s\x1b[0m',
-    pink: '\x1b[38;5;213m%s\x1b[0m',
+    green: '\x1b[32m%s\x1b[39m',
+    red: '\x1b[31m%s\x1b[39m',
+    yellow: '\x1b[33m%s\x1b[39m',
+    blue: '\x1b[34m%s\x1b[39m',
+    orange: '\x1b[38;5;208m%s\x1b[39m',
+    gold: '\x1b[38;5;214m%s\x1b[39m',
+    tan: '\x1b[38;5;180m%s\x1b[39m',
+    beige: '\x1b[38;5;223m%s\x1b[39m',
+    purple: '\x1b[38;5;129m%s\x1b[39m',
+    lightgray: '\x1b[38;5;250m%s\x1b[39m',
+    darkgray: '\x1b[38;5;236m%s\x1b[39m',
+    pink: '\x1b[38;5;213m%s\x1b[39m',
     none: '\x1b[0m%s',
   },
   ADDRESS_TYPE: {
@@ -177,7 +177,7 @@ export const Constants = {
     },
     default: 'pubkeyhash'
   }
-};
+} as const;
 
 export const bitcoreLogo = `
  _     _ _                     

--- a/packages/bitcore-cli/src/constants.ts
+++ b/packages/bitcore-cli/src/constants.ts
@@ -1,182 +1,220 @@
-export const Constants = {
-  UNITS2: {
-    'btc': 100000000,
-    'bit': 100,
-    'sat': 1,
-  },
-  COIN: {
-    btc: {
-      name: 'btc',
-      toSatoshis: 100000000,
-      maxDecimals: 8,
-      minDecimals: 8,
-    },
-    bit: {
-      name: 'bit',
-      toSatoshis: 100,
-      maxDecimals: 2,
-      minDecimals: 2,
-    },
-    bch: {
-      name: 'bch',
-      toSatoshis: 100000000,
-      maxDecimals: 8,
-      minDecimals: 8,
-    },
-    doge: {
-      name: 'doge',
-      toSatoshis: 1e8,
-      maxDecimals: 8,
-      minDecimals: 8
-    },
-    eth: {
-      name: 'eth',
-      toSatoshis: 1e18,
-      maxDecimals: 8,
-      minDecimals: 8,
-    },
 
-    USDC: {
-      name: 'USD Coin',
-      toSatoshis: 1e6,
-      maxDecimals: 2,
-      minDecimals: 2,
-    },
-    PAX: {
-      name: 'Paxos Standard',
-      toSatoshis: 1e18,
-      minDecimals: 2,
-      maxDecimals: 2,
-    },
-    GUSD: {
-      name: 'Gemini Dollar',
-      toSatoshis: 1e2,
-      minDecimals: 2,
-      maxDecimals: 2,
-    },
-    DAI: {
-      name: 'Dai',
-      toSatoshis: 1e18,
-      minDecimals: 2,
-      maxDecimals: 2
-    },
-    WBTC: {
-      name: 'Wrapped Bitcoin',
-      toSatoshis: 1e18,
-      minDecimals: 8,
-      maxDecimals: 8
-    },
-    SHIB: {
-      name: 'Shiba Inu',
-      toSatoshis: 1e18,
-      minDecimals: 10,
-      maxDecimals: 10,
-    },
-    EUROC: {
-      name: 'Euro Coin',
-      toSatoshis: 1e6,
-      minDecimals: 2,
-      maxDecimals: 2,
-    },
-    USDT: {
-      name: 'Tether',
-      toSatoshis: 1e6,
-      minDecimals: 2,
-      maxDecimals: 2,
-    },
+const UNITS2 = {
+  'btc': 100000000,
+  'bit': 100,
+  'sat': 1,
+} as const;
+
+const COIN = {
+  btc: {
+    name: 'btc',
+    toSatoshis: 100000000,
+    maxDecimals: 8,
+    minDecimals: 8,
   },
-  PUBLIC_API: {
-    eth: {
-      mainnet: 'https://ethereum-rpc.publicnode.com',
-      testnet: 'https://ethereum-sepolia-rpc.publicnode.com',
+  bit: {
+    name: 'bit',
+    toSatoshis: 100,
+    maxDecimals: 2,
+    minDecimals: 2,
+  },
+  bch: {
+    name: 'bch',
+    toSatoshis: 100000000,
+    maxDecimals: 8,
+    minDecimals: 8,
+  },
+  doge: {
+    name: 'doge',
+    toSatoshis: 1e8,
+    maxDecimals: 8,
+    minDecimals: 8
+  },
+  eth: {
+    name: 'eth',
+    toSatoshis: 1e18,
+    maxDecimals: 8,
+    minDecimals: 8,
+  },
+
+  USDC: {
+    name: 'USD Coin',
+    toSatoshis: 1e6,
+    maxDecimals: 2,
+    minDecimals: 2,
+  },
+  PAX: {
+    name: 'Paxos Standard',
+    toSatoshis: 1e18,
+    minDecimals: 2,
+    maxDecimals: 2,
+  },
+  GUSD: {
+    name: 'Gemini Dollar',
+    toSatoshis: 1e2,
+    minDecimals: 2,
+    maxDecimals: 2,
+  },
+  DAI: {
+    name: 'Dai',
+    toSatoshis: 1e18,
+    minDecimals: 2,
+    maxDecimals: 2
+  },
+  WBTC: {
+    name: 'Wrapped Bitcoin',
+    toSatoshis: 1e18,
+    minDecimals: 8,
+    maxDecimals: 8
+  },
+  SHIB: {
+    name: 'Shiba Inu',
+    toSatoshis: 1e18,
+    minDecimals: 10,
+    maxDecimals: 10,
+  },
+  EUROC: {
+    name: 'Euro Coin',
+    toSatoshis: 1e6,
+    minDecimals: 2,
+    maxDecimals: 2,
+  },
+  USDT: {
+    name: 'Tether',
+    toSatoshis: 1e6,
+    minDecimals: 2,
+    maxDecimals: 2,
+  },
+} as const;
+
+const PUBLIC_API = {
+  eth: {
+    mainnet: 'https://ethereum-rpc.publicnode.com',
+    testnet: 'https://ethereum-sepolia-rpc.publicnode.com',
+  },
+  matic: {
+    mainnet: 'https://polygon-bor-rpc.publicnode.com',
+    testnet: 'https://polygon-amoy-bor-rpc.publicnode.com',
+  },
+  arb: {
+    mainnet: 'https://arbitrum-one.publicnode.com',
+    testnet: 'https://public.stackup.sh/api/v1/node/arbitrum-sepolia',
+  },
+  op: {
+    mainnet: 'https://optimism-rpc.publicnode.com',
+    testnet: 'https://optimism-sepolia-rpc.publicnode.com',
+  },
+  base: {
+    mainnet: 'https:/base-rpc.publicnode.com',
+    testnet: 'https://base-sepolia-rpc.publicnode.com',
+  }
+} as const;
+
+
+/**
+ * The pattern for coloring terminal text in RGB format (replace R, G, B):
+ * Foreground RGB: \x1b[38;2;R;G;Bm ... \x1b[39m (reset to default foreground color)
+ * Background RGB: \x1b[48;2;R;G;Bm ... \x1b[49m (reset to default background color)
+ * 
+ * Alternatively, there are ANSI color codes for standard colors. e.g. 33 for yellow, 31 for red, etc.
+ */
+
+const COLOR = {
+  green: '\x1b[32m%s\x1b[39m',
+  red: '\x1b[31m%s\x1b[39m',
+  yellow: '\x1b[33m%s\x1b[39m',
+  blue: '\x1b[38;2;85;85;255m%s\x1b[39m',
+  orange: '\x1b[38;5;208m%s\x1b[39m',
+  gold: '\x1b[38;5;214m%s\x1b[39m',
+  tan: '\x1b[38;5;180m%s\x1b[39m',
+  beige: '\x1b[38;5;223m%s\x1b[39m',
+  purple: '\x1b[38;5;129m%s\x1b[39m',
+  lightgray: '\x1b[38;5;250m%s\x1b[39m',
+  darkgray: '\x1b[38;5;236m%s\x1b[39m',
+  pink: '\x1b[38;5;213m%s\x1b[39m',
+  none: '\x1b[0m%s',
+} as const;
+
+const CHAIN_COLOR = {
+  btc: COLOR.orange,
+  bch: COLOR.green,
+  // For Dogecoin, using a light beige color to evoke the color scheme of the Dogecoin logo
+  doge: COLOR.beige,
+  // For LTC, medium gray background with bold black text to evoke the silver color of Litecoin
+  ltc: '\x1b[48;2;169;169;169m\x1b[1m\x1b[38;2;0;0;0m%s\x1b[39m\x1b[22m\x1b[49m',
+  // For Ethereum, using a blue color that is commonly associated with the Ethereum logo
+  eth: '\x1b[38;2;97;125;234m%s\x1b[39m',
+  // For Polygon, using a pink color that is commonly associated with the Polygon logo
+  matic: COLOR.pink,
+  // For XRP, use black background with light gray text to evoke the color scheme of the XRP logo
+  xrp: '\x1b[48;2;0;0;0m\x1b[38;5;250m%s\x1b[39m\x1b[49m',
+  // For Solana, using a purple color that is commonly associated with the Solana logo
+  sol: COLOR.purple,
+} as const;
+
+const ADDRESS_TYPE = {
+  BTC: {
+    singleSig: {
+      P2WPKH: 'witnesspubkeyhash',
+      P2PKH: 'pubkeyhash',
+      P2TR: 'taproot'
     },
-    matic: {
-      mainnet: 'https://polygon-bor-rpc.publicnode.com',
-      testnet: 'https://polygon-amoy-bor-rpc.publicnode.com',
+    multiSig: {
+      P2WSH: 'witnessscripthash',
+      P2SH: 'scripthash',
     },
-    arb: {
-      mainnet: 'https://arbitrum-one.publicnode.com',
-      testnet: 'https://public.stackup.sh/api/v1/node/arbitrum-sepolia',
-    },
-    op: {
-      mainnet: 'https://optimism-rpc.publicnode.com',
-      testnet: 'https://optimism-sepolia-rpc.publicnode.com',
-    },
-    base: {
-      mainnet: 'https:/base-rpc.publicnode.com',
-      testnet: 'https://base-sepolia-rpc.publicnode.com',
+    thresholdSig: {
+      P2WSH: 'witnessscripthash',
+      P2PKH: 'pubkeyhash',
+      // TSS doesn't support schnorr sigs, hence no P2TR
     }
   },
-  COLOR: {
-    green: '\x1b[32m%s\x1b[39m',
-    red: '\x1b[31m%s\x1b[39m',
-    yellow: '\x1b[33m%s\x1b[39m',
-    blue: '\x1b[34m%s\x1b[39m',
-    orange: '\x1b[38;5;208m%s\x1b[39m',
-    gold: '\x1b[38;5;214m%s\x1b[39m',
-    tan: '\x1b[38;5;180m%s\x1b[39m',
-    beige: '\x1b[38;5;223m%s\x1b[39m',
-    purple: '\x1b[38;5;129m%s\x1b[39m',
-    lightgray: '\x1b[38;5;250m%s\x1b[39m',
-    darkgray: '\x1b[38;5;236m%s\x1b[39m',
-    pink: '\x1b[38;5;213m%s\x1b[39m',
-    none: '\x1b[0m%s',
+  BCH: {
+    singleSig: {
+      P2PKH: 'pubkeyhash',
+    },
+    multiSig: {
+      P2SH: 'scripthash'
+    },
+    thresholdSig: {
+      P2PKH: 'pubkeyhash',
+    }
   },
-  ADDRESS_TYPE: {
-    BTC: {
-      singleSig: {
-        P2WPKH: 'witnesspubkeyhash',
-        P2PKH: 'pubkeyhash',
-        P2TR: 'taproot'
-      },
-      multiSig: {
-        P2WSH: 'witnessscripthash',
-        P2SH: 'scripthash',
-      },
-      thresholdSig: {
-        P2WSH: 'witnessscripthash',
-        P2PKH: 'pubkeyhash',
-        // TSS doesn't support schnorr sigs, hence no P2TR
-      }
+  LTC: {
+    singleSig: {
+      P2WPKH: 'witnesspubkeyhash',
+      P2PKH: 'pubkeyhash',
     },
-    BCH: {
-      singleSig: {
-        P2PKH: 'pubkeyhash',
-      },
-      multiSig: {
-        P2SH: 'scripthash'
-      },
-      thresholdSig: {
-        P2PKH: 'pubkeyhash',
-      }
+    multiSig: {
+      P2WSH: 'witnessscripthash',
+      P2SH: 'scripthash',
     },
-    LTC: {
-      singleSig: {
-        P2WPKH: 'witnesspubkeyhash',
-        P2PKH: 'pubkeyhash',
-      },
-      multiSig: {
-        P2WSH: 'witnessscripthash',
-        P2SH: 'scripthash',
-      },
-      thresholdSig: {
-        P2WPKH: 'witnesspubkeyhash',
-        P2PKH: 'pubkeyhash',
-      }
+    thresholdSig: {
+      P2WPKH: 'witnesspubkeyhash',
+      P2PKH: 'pubkeyhash',
+    }
+  },
+  DOGE: {
+    singleSig: {
+      P2PKH: 'pubkeyhash',
     },
-    DOGE: {
-      singleSig: {
-        P2PKH: 'pubkeyhash',
-      },
-      multiSig: {
-        P2SH: 'scripthash'
-      },
-      thresholdSig: {
-        P2PKH: 'pubkeyhash',
-      }
+    multiSig: {
+      P2SH: 'scripthash'
     },
-    default: 'pubkeyhash'
-  }
+    thresholdSig: {
+      P2PKH: 'pubkeyhash',
+    }
+  },
+  default: 'pubkeyhash'
+} as const;
+
+export const Constants = {
+  UNITS2,
+  COIN,
+  PUBLIC_API,
+  COLOR,
+  CHAIN_COLOR,
+  ADDRESS_TYPE,
 } as const;
 
 export const bitcoreLogo = `

--- a/packages/bitcore-cli/src/prompts.ts
+++ b/packages/bitcore-cli/src/prompts.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import { Network } from '@bitpay-labs/bitcore-wallet-client';
 import { BitcoreLib, BitcoreLibLtc, Constants as CWCConst } from '@bitpay-labs/crypto-wallet-core';
 import * as prompt from '@clack/prompts';
@@ -232,6 +233,10 @@ export async function getAddressType(
     addressTypes = addressTypes.singleSig;
   }
 
+  if (Object.keys(addressTypes).length === 1) {
+    return Object.values(addressTypes)[0] as string;
+  }
+
   const segwitPrefix = bech32Libs[chain]?.Networks.get(network).bech32prefix;
   const descriptions = {
     P2PKH: 'Standard public key address',
@@ -308,4 +313,29 @@ export async function getFileName(
     throw new UserCancelled();
   }
   return Utils.replaceTilde(fileName);
+}
+
+/**
+ * Informs the user what a keyshare backup is and asks them to confirm they're ready to save it.
+ */
+export async function promptKeyshareBackup(): Promise<boolean> {
+  prompt.note(
+    Utils.colorText('!!! IMPORTANT !!!', 'yellow') + os.EOL +
+    'A keyshare backup file contains the information needed to restore access to your Threshold Signature (TSS) wallet if you lose access to your device.' + os.EOL +
+    'Unlike other wallets, TSS wallets cannot be restored by a 12-24 word phrase alone. They also require your "keyshare" data which is your piece of the TSS key.' + os.EOL +
+    'This keyshare backup file contains both your 12-word mnemonic AND your keyshare data, encrypted with a password you will set in the following prompts.' + os.EOL +
+    'Make sure to:' + os.EOL +
+    `  - Store the file in a ${Utils.underlineText('safe place')}, like a USB drive in a safe, and do not share it with anyone.` + os.EOL +
+    `  - ${Utils.boldText('DO NOT FORGET')} the encryption password! The file is useless without it, and there is no way to reset the password.` + os.EOL +
+    'Both the file + encryption password are as valuable as a non-TSS wallet\'s 12-24 word phrase, so treat them with the same level of security.'
+  );
+  const a = await prompt.select({
+    message: 'Are you ready to save your keyshare backup file?',
+    options: [{ label: 'Yes, let\'s go!', value: true }]
+  });
+  if (prompt.isCancel(a)) {
+    prompt.log.warn('Keyshare backup file not saved. You can do so later with the "Export" option from the wallet Main Menu.');
+    return false;
+  }
+  return true;
 }

--- a/packages/bitcore-cli/src/utils.ts
+++ b/packages/bitcore-cli/src/utils.ts
@@ -63,19 +63,19 @@ export class Utils {
   }
 
   static boldText(text: string) {
-    return '\x1b[1m' + text + '\x1b[0m';
+    return '\x1b[1m' + text + '\x1b[22m';
   }
 
   static italicText(text: string) {
-    return '\x1b[3m' + text + '\x1b[0m';
+    return '\x1b[3m' + text + '\x1b[23m';
   }
 
   static underlineText(text: string) {
-    return '\x1b[4m' + text + '\x1b[0m';
+    return '\x1b[4m' + text + '\x1b[24m';
   }
 
   static strikeText(text: string) {
-    return '\x1b[9m' + text + '\x1b[0m';
+    return '\x1b[9m' + text + '\x1b[29m';
   }
 
   static capitalize(text: string): string {

--- a/packages/bitcore-cli/src/utils.ts
+++ b/packages/bitcore-cli/src/utils.ts
@@ -421,33 +421,12 @@ export class Utils {
     return fileName;
   }
 
-  static getChainColor(chain: string) {
-    switch (chain.toLowerCase()) {
-      case 'btc':
-        return 'orange';
-      case 'bch':
-        return 'green';
-      case 'doge':
-        return 'beige';
-      case 'ltc':
-        return 'lightgray';
-      case 'eth':
-        return 'blue';
-      case 'matic':
-        return 'pink';
-      case 'xrp':
-        return 'darkgray';
-      case 'sol':
-        return 'purple';
-    }
-  }
-
   static colorTextByChain(chain: string, text: string) {
-    const color = Utils.getChainColor(chain);
-    if (!color) {
+    const colorPattern = Constants.CHAIN_COLOR[chain.toLowerCase()];
+    if (!colorPattern) {
       return Utils.boldText(text);
     }
-    return Utils.colorText(text, color);
+    return colorPattern.replace('%s', text);
   }
 
   static colorizeChain(chain: string) {

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -197,12 +197,20 @@ export class Wallet implements IWallet {
     if (!this.client) {
       await this.getClient({ mustExist: true });
     }
-    const { chain, coin, network, m, n, addressType } = this.client.credentials;
+    const { chain, coin, network, m, n, addressType, tssKeyId } = this.client.credentials;
     if (coin && coin !== chain) {
       // temporarily set it to chain for registration.
       // coin != chain for token wallets exported from the app.
       this.client.credentials.coin = chain;
     }
+
+    if (tssKeyId) {
+      // This function will only register the wallet as a single-sig (non-TSS) wallet (BAD!).
+      // Importing a TSS wallet to a new server will need to create a tsskeygen Mongo document
+      // on the server and include the tssKeyId in the wallet registration process.
+      throw new Error('This wallet appears to to be a TSS wallet. Registering an existing TSS wallet on a different server is not yet supported.');
+    }
+
     const { secret } = await this.client.createWallet(
       this.name,
       args.copayerName,

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -188,7 +188,8 @@ export class Wallet implements IWallet {
     this.#walletData = { key, credentials: this.client.credentials };
     await this.save();
     // await this.register({ copayerName });
-    await this.load();
+    // this.load calls openWallet which completes the wallet by fetching any missing info
+    await this.load({ allowCache: true });
     return { key, credentials: this.client.toObj() };
   }
 
@@ -333,7 +334,7 @@ export class Wallet implements IWallet {
       }
 
       if (key.isPrivKeyEncrypted() || (key as TssKey.TssKey).isKeyChainEncrypted?.()) {
-        const walletPassword = await getPassword('Wallet password:');
+        const walletPassword = await getPassword('Unlock wallet:');
         key.decrypt(walletPassword);
       }
     }

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -208,7 +208,7 @@ export class Wallet implements IWallet {
       // This function will only register the wallet as a single-sig (non-TSS) wallet (BAD!).
       // Importing a TSS wallet to a new server will need to create a tsskeygen Mongo document
       // on the server and include the tssKeyId in the wallet registration process.
-      throw new Error('This wallet appears to to be a TSS wallet. Registering an existing TSS wallet on a different server is not yet supported.');
+      throw new Error('This wallet appears to be a TSS wallet. Registering an existing TSS wallet on a different server is not yet supported.');
     }
 
     const { secret } = await this.client.createWallet(

--- a/packages/bitcore-cli/test/create.test.ts
+++ b/packages/bitcore-cli/test/create.test.ts
@@ -548,8 +548,10 @@ describe('Create', function() {
           [copayer2PubKey, KEYSTROKES.ENTER], // Done sharing -- (checkpoint1)
           // Checkpoint2: Extract join code to share with copayer2
           [KEYSTROKES.ENTER], // Done sharing -- (checkpoint2)
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName1}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const stepInputsC2 = [
           [KEYSTROKES.ARROW_DOWN], // Create Wallet -> Join Wallet
@@ -565,8 +567,10 @@ describe('Create', function() {
           // Checkpoint2: Wait for and enter join code from copayer1 to join session
           [joinCode, KEYSTROKES.ENTER], // Enter session code from leader (copayer1)
           [KEYSTROKES.ENTER], // Confirm decoded join code looks correct
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName2}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const step = {
           [walletName1]: 0,
@@ -600,7 +604,7 @@ describe('Create', function() {
             // walletName === walletName1 && process.stdout.write(chunk);
             const stepInputs = walletName === walletName1 ? stepInputsC1 : stepInputsC2;
 
-            const isStep = chunk.endsWith(OUTPUT_END_SEQ) || step[walletName] == stepInputs.length - 1; // viewing mnemonic
+            const isStep = chunk.endsWith(OUTPUT_END_SEQ);
             if (isStep) {
               const lines = checkpointOutput[walletName].split('\n');
               switch (step[walletName]) {
@@ -663,71 +667,87 @@ describe('Create', function() {
           done(e);
         });
         io.on('allClosed', (exitCodes: number[]) => {
-          assert.deepEqual(exitCodes, [0, 0]);
-          // Wallet 1
-          const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet1.credentials.chain, 'btc');
-          assert.strictEqual(wallet1.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet1.credentials.m, 1);
-          assert.strictEqual(wallet1.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
-          assert.strictEqual(wallet1.key.metadata.m, 2);
-          assert.strictEqual(wallet1.key.metadata.n, 2);
+          try {
+            assert.deepEqual(exitCodes, [0, 0]);
+            // Wallet 1
+            const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet1.credentials.chain, 'btc');
+            assert.strictEqual(wallet1.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet1.credentials.m, 1);
+            assert.strictEqual(wallet1.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
+            assert.strictEqual(wallet1.key.metadata.m, 2);
+            assert.strictEqual(wallet1.key.metadata.n, 2);
 
-          // Wallet 2
-          const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet2.credentials.chain, 'btc');
-          assert.strictEqual(wallet2.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet2.credentials.m, 1);
-          assert.strictEqual(wallet2.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
-          assert.strictEqual(wallet2.key.metadata.m, 2);
-          assert.strictEqual(wallet2.key.metadata.n, 2);
+            // Wallet 2
+            const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet2.credentials.chain, 'btc');
+            assert.strictEqual(wallet2.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet2.credentials.m, 1);
+            assert.strictEqual(wallet2.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
+            assert.strictEqual(wallet2.key.metadata.m, 2);
+            assert.strictEqual(wallet2.key.metadata.n, 2);
 
-          // Check wallets are copayers of the same wallet
-          assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
-          assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
-          assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
+            // Check wallets are copayers of the same wallet
+            assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
+            assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
+            assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
 
-          done();
+            // Check keyshare backup files
+            const keyshareBackup1 = path.join(TEMP_DIR, walletName1 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup1), 'Keyshare backup file not found for wallet 1');
+            const keyshare1 = JSON.parse(fs.readFileSync(keyshareBackup1, 'utf-8'));
+            assert.ok(keyshare1.iv && keyshare1.mode && keyshare1.cipher && keyshare1.ct, 'Keyshare backup 1 does not appear to be encrypted');
+            assert.strictEqual(keyshare1.cipher + keyshare1.mode, 'aesgcm', 'Expected keyshare backup 1 to be encrypted with AES-GCM');
+            const keyshareBackup2 = path.join(TEMP_DIR, walletName2 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup2), 'Keyshare backup file not found for wallet 2');
+            const keyshare2 = JSON.parse(fs.readFileSync(keyshareBackup2, 'utf-8'));
+            assert.ok(keyshare2.iv && keyshare2.mode && keyshare2.cipher && keyshare2.ct, 'Keyshare backup 2 does not appear to be encrypted');
+            assert.strictEqual(keyshare2.cipher + keyshare2.mode, 'aesgcm', 'Expected keyshare backup 2 to be encrypted with AES-GCM');
+
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -757,8 +777,10 @@ describe('Create', function() {
           [copayer2PubKey, KEYSTROKES.ENTER], // Done sharing -- (checkpoint1)
           // Checkpoint2: Extract join code to share with copayer2
           [KEYSTROKES.ENTER], // Done sharing -- (checkpoint2)
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName1}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const stepInputsC2 = [
           [KEYSTROKES.ARROW_DOWN], // Create Wallet -> Join Wallet
@@ -773,8 +795,10 @@ describe('Create', function() {
           // Checkpoint2: Wait for and enter join code from copayer1 to join session
           [joinCode, KEYSTROKES.ENTER], // Enter session code from leader (copayer1)
           [KEYSTROKES.ENTER], // Confirm decoded join code looks correct
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName2}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const step = {
           [walletName1]: 0,
@@ -809,7 +833,7 @@ describe('Create', function() {
             // walletName === walletName2 && process.stdout.write(chunk);
             const stepInputs = walletName === walletName1 ? stepInputsC1 : stepInputsC2;
 
-            const isStep = chunk.endsWith(OUTPUT_END_SEQ) || step[walletName] == stepInputs.length - 1; // viewing mnemonic
+            const isStep = chunk.endsWith(OUTPUT_END_SEQ);
             if (isStep) {
               const lines = checkpointOutput[walletName].split('\n');
               switch (step[walletName]) {
@@ -872,71 +896,87 @@ describe('Create', function() {
           done(e);
         });
         io.on('allClosed', (exitCodes: number[]) => {
-          assert.deepEqual(exitCodes, [0, 0]);
-          // Wallet 1
-          const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet1.credentials.chain, 'eth');
-          assert.strictEqual(wallet1.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet1.credentials.m, 1);
-          assert.strictEqual(wallet1.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
-          assert.strictEqual(wallet1.key.metadata.m, 2);
-          assert.strictEqual(wallet1.key.metadata.n, 2);
+          try {
+            assert.deepEqual(exitCodes, [0, 0]);
+            // Wallet 1
+            const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet1.credentials.chain, 'eth');
+            assert.strictEqual(wallet1.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet1.credentials.m, 1);
+            assert.strictEqual(wallet1.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
+            assert.strictEqual(wallet1.key.metadata.m, 2);
+            assert.strictEqual(wallet1.key.metadata.n, 2);
 
-          // Wallet 2
-          const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet2.credentials.chain, 'eth');
-          assert.strictEqual(wallet2.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet2.credentials.m, 1);
-          assert.strictEqual(wallet2.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
-          assert.strictEqual(wallet2.key.metadata.m, 2);
-          assert.strictEqual(wallet2.key.metadata.n, 2);
+            // Wallet 2
+            const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet2.credentials.chain, 'eth');
+            assert.strictEqual(wallet2.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet2.credentials.m, 1);
+            assert.strictEqual(wallet2.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
+            assert.strictEqual(wallet2.key.metadata.m, 2);
+            assert.strictEqual(wallet2.key.metadata.n, 2);
 
-          // Check wallets are copayers of the same wallet
-          assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
-          assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
-          assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
+            // Check wallets are copayers of the same wallet
+            assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
+            assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
+            assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
 
-          done();
+            // Check keyshare backup files
+            const keyshareBackup1 = path.join(TEMP_DIR, walletName1 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup1), 'Keyshare backup file not found for wallet 1');
+            const keyshare1 = JSON.parse(fs.readFileSync(keyshareBackup1, 'utf-8'));
+            assert.ok(keyshare1.iv && keyshare1.mode && keyshare1.cipher && keyshare1.ct, 'Keyshare backup 1 does not appear to be encrypted');
+            assert.strictEqual(keyshare1.cipher + keyshare1.mode, 'aesgcm', 'Expected keyshare backup 1 to be encrypted with AES-GCM');
+            const keyshareBackup2 = path.join(TEMP_DIR, walletName2 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup2), 'Keyshare backup file not found for wallet 2');
+            const keyshare2 = JSON.parse(fs.readFileSync(keyshareBackup2, 'utf-8'));
+            assert.ok(keyshare2.iv && keyshare2.mode && keyshare2.cipher && keyshare2.ct, 'Keyshare backup 2 does not appear to be encrypted');
+            assert.strictEqual(keyshare2.cipher + keyshare2.mode, 'aesgcm', 'Expected keyshare backup 2 to be encrypted with AES-GCM');
+
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });
@@ -966,8 +1006,10 @@ describe('Create', function() {
           [copayer2PubKey, KEYSTROKES.ENTER], // Done sharing -- (checkpoint1)
           // Checkpoint2: Extract join code to share with copayer2
           [KEYSTROKES.ENTER], // Done sharing -- (checkpoint2)
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName1}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const stepInputsC2 = [
           [KEYSTROKES.ARROW_DOWN], // Create Wallet -> Join Wallet
@@ -982,8 +1024,10 @@ describe('Create', function() {
           // Checkpoint2: Wait for and enter join code from copayer1 to join session
           [joinCode, KEYSTROKES.ENTER], // Enter session code from leader (copayer1)
           [KEYSTROKES.ENTER], // Confirm decoded join code looks correct
-          [KEYSTROKES.ENTER], // View mnemonic
-          [':', 'q', KEYSTROKES.ENTER] // vim input to quit viewing mnemonic
+          [KEYSTROKES.ENTER], // Yes, continue with keyshare export
+          [...Array(50).fill(KEYSTROKES.BACKSPACE), `${TEMP_DIR}/${walletName2}-export.json`, KEYSTROKES.ENTER], // Export keyshare backup file to temp dir
+          ['exportpassword', KEYSTROKES.ENTER], // Password for exported keyshare backup file
+          ['testpassword', KEYSTROKES.ENTER], // Unlock wallet
         ];
         const step = {
           [walletName1]: 0,
@@ -1017,7 +1061,7 @@ describe('Create', function() {
             // walletName === walletName1 && process.stdout.write(chunk);
             const stepInputs = walletName === walletName1 ? stepInputsC1 : stepInputsC2;
 
-            const isStep = chunk.endsWith(OUTPUT_END_SEQ) || step[walletName] == stepInputs.length - 1; // viewing mnemonic
+            const isStep = chunk.endsWith(OUTPUT_END_SEQ);
             if (isStep) {
               const lines = checkpointOutput[walletName].split('\n');
               switch (step[walletName]) {
@@ -1080,71 +1124,87 @@ describe('Create', function() {
           done(e);
         });
         io.on('allClosed', (exitCodes: number[]) => {
-          assert.deepEqual(exitCodes, [0, 0]);
-          // Wallet 1
-          const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet1.credentials.chain, 'xrp');
-          assert.strictEqual(wallet1.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet1.credentials.m, 1);
-          assert.strictEqual(wallet1.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
-          assert.strictEqual(wallet1.key.metadata.m, 2);
-          assert.strictEqual(wallet1.key.metadata.n, 2);
+          try {
+            assert.deepEqual(exitCodes, [0, 0]);
+            // Wallet 1
+            const wallet1 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet1.credentials.chain, 'xrp');
+            assert.strictEqual(wallet1.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet1.credentials.m, 1);
+            assert.strictEqual(wallet1.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet1.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet1.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet1.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet1, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet1.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet1.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet1.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet1.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet1.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet1.key.metadata.id, 'string');
+            assert.strictEqual(wallet1.key.metadata.m, 2);
+            assert.strictEqual(wallet1.key.metadata.n, 2);
 
-          // Wallet 2
-          const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet2.credentials.chain, 'xrp');
-          assert.strictEqual(wallet2.credentials.network, 'testnet');
-          // Still treated as single sig wallet
-          assert.strictEqual(wallet2.credentials.m, 1);
-          assert.strictEqual(wallet2.credentials.n, 1);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
-          // Ensure TSS fields are present and encrypted
-          assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
-          assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
-          assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
-          assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
-          assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
-          assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
-          assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
-          assert.strictEqual(wallet2.key.metadata.m, 2);
-          assert.strictEqual(wallet2.key.metadata.n, 2);
+            // Wallet 2
+            const wallet2 = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName2 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet2.credentials.chain, 'xrp');
+            assert.strictEqual(wallet2.credentials.network, 'testnet');
+            // Still treated as single sig wallet
+            assert.strictEqual(wallet2.credentials.m, 1);
+            assert.strictEqual(wallet2.credentials.n, 1);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet2.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet2.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet2.key, 'xPrivKeyEDDSA'));
+            // Ensure TSS fields are present and encrypted
+            assert.ok(Object.hasOwn(wallet2, 'key'), 'No key property found on wallet');
+            assert.ok(Object.hasOwn(wallet2.key, 'keychain'), 'No key.keychain property found on wallet');
+            assert.strictEqual(typeof wallet2.key.keychain.commonKeyChain, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShare == null, 'privateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.privateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.privateKeyShareEncrypted.startsWith('{"iv":"'), 'privateKeyShareEncrypted should be encrypted');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShare == null, 'reducedPrivateKeyShare should not be present on wallet keychain');
+            assert.strictEqual(typeof wallet2.key.keychain.reducedPrivateKeyShareEncrypted, 'string');
+            assert.ok(wallet2.key.keychain.reducedPrivateKeyShareEncrypted.startsWith('{"iv":"'), 'reducedPrivateKeyShareEncrypted should be encrypted');
+            assert.ok(Object.hasOwn(wallet2.key, 'metadata'), 'No key.metadata property found on wallet');
+            assert.strictEqual(typeof wallet2.key.metadata.id, 'string');
+            assert.strictEqual(wallet2.key.metadata.m, 2);
+            assert.strictEqual(wallet2.key.metadata.n, 2);
 
-          // Check wallets are copayers of the same wallet
-          assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
-          assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
-          assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
+            // Check wallets are copayers of the same wallet
+            assert.strictEqual(wallet1.credentials.walletId, wallet2.credentials.walletId, 'Wallet IDs do not match');
+            assert.strictEqual(wallet1.key.metadata.id, wallet2.key.metadata.id, 'Key metadata IDs do not match');
+            assert.strictEqual(wallet1.key.keychain.commonKeyChain, wallet2.key.keychain.commonKeyChain, 'Common key chains do not match');
 
-          done();
+            // Check keyshare backup files
+            const keyshareBackup1 = path.join(TEMP_DIR, walletName1 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup1), 'Keyshare backup file not found for wallet 1');
+            const keyshare1 = JSON.parse(fs.readFileSync(keyshareBackup1, 'utf-8'));
+            assert.ok(keyshare1.iv && keyshare1.mode && keyshare1.cipher && keyshare1.ct, 'Keyshare backup 1 does not appear to be encrypted');
+            assert.strictEqual(keyshare1.cipher + keyshare1.mode, 'aesgcm', 'Expected keyshare backup 1 to be encrypted with AES-GCM');
+            const keyshareBackup2 = path.join(TEMP_DIR, walletName2 + '-export.json');
+            assert.ok(fs.existsSync(keyshareBackup2), 'Keyshare backup file not found for wallet 2');
+            const keyshare2 = JSON.parse(fs.readFileSync(keyshareBackup2, 'utf-8'));
+            assert.ok(keyshare2.iv && keyshare2.mode && keyshare2.cipher && keyshare2.ct, 'Keyshare backup 2 does not appear to be encrypted');
+            assert.strictEqual(keyshare2.cipher + keyshare2.mode, 'aesgcm', 'Expected keyshare backup 2 to be encrypted with AES-GCM');
+
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
     });

--- a/packages/bitcore-cli/test/create.test.ts
+++ b/packages/bitcore-cli/test/create.test.ts
@@ -69,18 +69,22 @@ describe('Create', function() {
         done(e);
       });
       child.on('close', (code) => {
-        assert.equal(code, 0);
-        const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
-        assert.strictEqual(wallet.credentials.chain, 'btc');
-        assert.strictEqual(wallet.credentials.network, 'testnet');
-        // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-        assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
-        done();
+        try {
+          assert.equal(code, 0);
+          const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
+          assert.strictEqual(wallet.credentials.chain, 'btc');
+          assert.strictEqual(wallet.credentials.network, 'testnet');
+          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+          assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -128,18 +132,22 @@ describe('Create', function() {
         done(e);
       });
       child.on('close', (code) => {
-        assert.equal(code, 0);
-        const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
-        assert.strictEqual(wallet.credentials.chain, 'eth');
-        assert.strictEqual(wallet.credentials.network, 'testnet');
-        // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-        assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
-        done();
+        try {
+          assert.equal(code, 0);
+          const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
+          assert.strictEqual(wallet.credentials.chain, 'eth');
+          assert.strictEqual(wallet.credentials.network, 'testnet');
+          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+          assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -187,18 +195,22 @@ describe('Create', function() {
         done(e);
       });
       child.on('close', (code) => {
-        assert.equal(code, 0);
-        const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
-        assert.strictEqual(wallet.credentials.chain, 'xrp');
-        assert.strictEqual(wallet.credentials.network, 'testnet');
-        // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-        assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
-        done();
+        try {
+          assert.equal(code, 0);
+          const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
+          assert.strictEqual(wallet.credentials.chain, 'xrp');
+          assert.strictEqual(wallet.credentials.network, 'testnet');
+          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+          assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
 
@@ -246,18 +258,22 @@ describe('Create', function() {
         done(e);
       });
       child.on('close', (code) => {
-        assert.equal(code, 0);
-        const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
-        assert.strictEqual(wallet.credentials.chain, 'sol');
-        assert.strictEqual(wallet.credentials.network, 'testnet');
-        // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-        assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
-        assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
-        assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
-        done();
+        try {
+          assert.equal(code, 0);
+          const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName + '.json'), 'utf-8'));
+          assert.strictEqual(wallet.credentials.chain, 'sol');
+          assert.strictEqual(wallet.credentials.network, 'testnet');
+          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+          assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
+          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
+          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
+          done();
+        } catch (e) {
+          done(e);
+        }
       });
     });
   });
@@ -337,20 +353,24 @@ describe('Create', function() {
           done(e);
         });
         child.on('close', (code) => {
-          assert.equal(code, 0);
-          const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
-          assert.strictEqual(wallet.credentials.chain, 'btc');
-          assert.strictEqual(wallet.credentials.network, 'testnet');
-          assert.strictEqual(wallet.credentials.m, 2);
-          assert.strictEqual(wallet.credentials.n, 2);
-          // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
-          assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
-          assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
-          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
-          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
-          assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
-          assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
-          done();
+          try {
+            assert.equal(code, 0);
+            const wallet = JSON.parse(fs.readFileSync(path.join(TEMP_DIR, walletName1 + '.json'), 'utf-8'));
+            assert.strictEqual(wallet.credentials.chain, 'btc');
+            assert.strictEqual(wallet.credentials.network, 'testnet');
+            assert.strictEqual(wallet.credentials.m, 2);
+            assert.strictEqual(wallet.credentials.n, 2);
+            // Ensure that sensitive wallet key properties are encrypted and not present in plaintext
+            assert.ok(Object.hasOwn(wallet.key, 'mnemonicEncrypted'));
+            assert.ok(!Object.hasOwn(wallet.key, 'mnemonic'));
+            assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEncrypted'));
+            assert.ok(!Object.hasOwn(wallet.key, 'xPrivKey'));
+            assert.ok(Object.hasOwn(wallet.key, 'xPrivKeyEDDSAEncrypted'));
+            assert.ok(!Object.hasOwn(wallet.key, 'xPrivKeyEDDSA'));
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 
@@ -509,10 +529,14 @@ describe('Create', function() {
             done(e);
           });
           child.on('close', (code) => {
-            assert.equal(code, 1); // Exit code 1 since flow is cancelled with ctrl+c
-            // No wallet file should have been created or saved
-            assert.ok(!fs.existsSync(path.join(TEMP_DIR, walletName + '.json')));
-            done();
+            try {
+              assert.equal(code, 1); // Exit code 1 since flow is cancelled with ctrl+c
+              // No wallet file should have been created or saved
+              assert.ok(!fs.existsSync(path.join(TEMP_DIR, walletName + '.json')));
+              done();
+            } catch (e) {
+              done(e);
+            }
           });
         });
       }

--- a/packages/bitcore-cli/test/helpers.ts
+++ b/packages/bitcore-cli/test/helpers.ts
@@ -259,7 +259,7 @@ export const blockchainExplorerMock = {
 
 export function decolor(text: string) {
   // eslint-disable-next-line no-control-regex
-  text = text?.replace(/\x1b\[[0-9]+m/g, ''); // Remove ANSI color codes
+  text = text?.replace(/\x1b\[[;0-9]+m/g, ''); // Remove ANSI color codes
   return text;
 };
 

--- a/packages/bitcore-cli/test/proposals.test.ts
+++ b/packages/bitcore-cli/test/proposals.test.ts
@@ -202,7 +202,7 @@ describe('Proposals', function() {
               case Array.from(checkpoints)[0]:
                 // Assert there's an indication of a pending proposal in main menu
                 // eslint-disable-next-line no-control-regex
-                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[0m/);
+                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[39m/);
                 break;
               case Array.from(checkpoints)[1]:
                 assert.ok(checkpointOutput.includes(`Broadcasted txid: ${Utils.colorText('5ba5df9de6c7f6043de8ade09c2dab08a1fb60724320f8cb4f00c9df2ec73035', 'green')}`));
@@ -274,7 +274,7 @@ describe('Proposals', function() {
               case Array.from(checkpoints)[0]:
                 // Assert there's an indication of a pending proposal in main menu
                 // eslint-disable-next-line no-control-regex
-                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[0m/);
+                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[39m/);
                 break;
               case Array.from(checkpoints)[1]:
                 assert.match(checkpointOutput, /Enter rejection reason:/);
@@ -366,7 +366,7 @@ describe('Proposals', function() {
               case Array.from(checkpoints)[0]:
                 // Assert there's an indication of a pending proposal in main menu
                 // eslint-disable-next-line no-control-regex
-                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[0m/);
+                assert.match(checkpointOutput, /Proposals\x1B\[33m \(1\)\x1B\[39m/);
                 break;
               case Array.from(checkpoints)[1]:
               case Array.from(checkpoints)[2]:
@@ -452,7 +452,7 @@ describe('Proposals', function() {
                   case Array.from(checkpoints)[0]:
                     // Assert there's an indication of a pending proposal in main menu
                     // eslint-disable-next-line no-control-regex
-                    assert.match(checkpointOutput, /Proposals\x1B\[33m \(2\)\x1B\[0m/);
+                    assert.match(checkpointOutput, /Proposals\x1B\[33m \(2\)\x1B\[39m/);
                     checkpointOutput = ''; // reset output to avoid false positives in next checkpoints
                     break;
                   case Array.from(checkpoints)[1]:

--- a/packages/bitcore-cli/test/tssCoordinator.ts
+++ b/packages/bitcore-cli/test/tssCoordinator.ts
@@ -6,7 +6,7 @@ import * as helpers from './helpers';
 const { WALLETS } = helpers.CONSTANTS;
 const { CLI_EXEC, CLI_OPTS } = WALLETS;
 
-const tssInstances: { [key: string]: ChildProcess } = {};
+const tssInstances: { [key: string]: ChildProcess & { endIt?: boolean } } = {};
 
 export type TssTransformOptions = TransformOptions & {
   transform: (
@@ -49,8 +49,10 @@ export function startTssWallets(ioHandler: TssTransform, walletNames: string[], 
             endIt
           } = JSON.parse(data.toString());
           if (destWalletName === walletName) {
-            if (endIt) {
-              // send EOF to process so it can exit cleanly
+            tssInstances[walletName].endIt = endIt;
+            if (Object.values(tssInstances).every(instance => instance.endIt)) {
+              // send EOF so processes can exit cleanly
+              // Note, ending will trickle up and cause other walletProcesses to end as well, so we only call it once all tssInstances have signaled they're ready to end
               walletProcess.stdin.end();
             }
             next(null, chunk);

--- a/packages/bitcore-cli/test/tssCoordinator.ts
+++ b/packages/bitcore-cli/test/tssCoordinator.ts
@@ -53,7 +53,11 @@ export function startTssWallets(ioHandler: TssTransform, walletNames: string[], 
             if (Object.values(tssInstances).every(instance => instance.endIt)) {
               // send EOF so processes can exit cleanly
               // Note, ending will trickle up and cause other walletProcesses to end as well, so we only call it once all tssInstances have signaled they're ready to end
-              walletProcess.stdin.end();
+              for (const wn of walletNames) {
+                if (tssInstances[wn]?.stdin && !tssInstances[wn].stdin.closed) {
+                  tssInstances[wn].stdin.end();
+                }
+              }
             }
             next(null, chunk);
           } else {

--- a/packages/bitcore-cli/test/utils.test.ts
+++ b/packages/bitcore-cli/test/utils.test.ts
@@ -113,17 +113,17 @@ describe('Utils', function() {
   describe('colorText', function() {
     it('should wrap text in green ANSI codes', function() {
       const result = Utils.colorText('hello', 'green');
-      assert.strictEqual(result, '\x1b[32mhello\x1b[0m');
+      assert.strictEqual(result, '\x1b[32mhello\x1b[39m');
     });
 
     it('should wrap text in red ANSI codes', function() {
       const result = Utils.colorText('error', 'red');
-      assert.strictEqual(result, '\x1b[31merror\x1b[0m');
+      assert.strictEqual(result, '\x1b[31merror\x1b[39m');
     });
 
     it('should wrap text in yellow ANSI codes', function() {
       const result = Utils.colorText('warn', 'yellow');
-      assert.strictEqual(result, '\x1b[33mwarn\x1b[0m');
+      assert.strictEqual(result, '\x1b[33mwarn\x1b[39m');
     });
   });
 
@@ -131,25 +131,25 @@ describe('Utils', function() {
 
   describe('boldText', function() {
     it('should wrap text in bold ANSI codes', function() {
-      assert.strictEqual(Utils.boldText('hi'), '\x1b[1mhi\x1b[0m');
+      assert.strictEqual(Utils.boldText('hi'), '\x1b[1mhi\x1b[22m');
     });
   });
 
   describe('italicText', function() {
     it('should wrap text in italic ANSI codes', function() {
-      assert.strictEqual(Utils.italicText('hi'), '\x1b[3mhi\x1b[0m');
+      assert.strictEqual(Utils.italicText('hi'), '\x1b[3mhi\x1b[23m');
     });
   });
 
   describe('underlineText', function() {
     it('should wrap text in underline ANSI codes', function() {
-      assert.strictEqual(Utils.underlineText('hi'), '\x1b[4mhi\x1b[0m');
+      assert.strictEqual(Utils.underlineText('hi'), '\x1b[4mhi\x1b[24m');
     });
   });
 
   describe('strikeText', function() {
     it('should wrap text in strikethrough ANSI codes', function() {
-      assert.strictEqual(Utils.strikeText('hi'), '\x1b[9mhi\x1b[0m');
+      assert.strictEqual(Utils.strikeText('hi'), '\x1b[9mhi\x1b[29m');
     });
   });
 

--- a/packages/bitcore-cli/test/utils.test.ts
+++ b/packages/bitcore-cli/test/utils.test.ts
@@ -585,30 +585,6 @@ describe('Utils', function() {
     });
   });
 
-  // ─── getChainColor ───────────────────────────────────────────────────────────
-
-  describe('getChainColor', function() {
-    const cases: [string, string][] = [
-      ['btc', 'orange'],
-      ['bch', 'green'],
-      ['doge', 'beige'],
-      ['ltc', 'lightgray'],
-      ['eth', 'blue'],
-      ['matic', 'pink'],
-      ['xrp', 'darkgray'],
-      ['sol', 'purple'],
-    ];
-
-    for (const [chain, color] of cases) {
-      it(`should return ${color} for ${chain}`, function() {
-        assert.strictEqual(Utils.getChainColor(chain), color);
-      });
-    }
-
-    it('should be case-insensitive', function() {
-      assert.strictEqual(Utils.getChainColor('BTC'), 'orange');
-    });
-  });
 
   // ─── colorTextByChain ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Description
Fixes various bitcore-cli bugs and makes some flow improvements

### Changelog

* TSS Creation flow:
  * Adds helper instructions for the pub key/join code exchange
  * Replaces mnemonic backup with keyshare file backup
* Creation flow: skips address type prompt if only 1 address type available (e.g. DOGE)
* Creation flow: updated wallet password setting prompts to better reflect the `Unlock wallet` prompt. This is to assist user comprehension when exporting a wallet, which asks for an encryption password immediately followed by an unlock password (non read-only export).
* Improves text modding functions (colorText, boldText, etc.) to undo the mods rather than resetting to `\x1b[0m` (which also removes any previous text formatting)
* Fixed `opts.readonly` being false in exportWallet()
* Blocks `--register` from working on a TSS wallet since that'll register the wallet as just a single-sig wallet
* Fixes tests
* Updates the bin from `wallet` (very generic) to `bitcore-cli` (more specific)


### Testing Notes
Add any helpful notes for reviewers to test your code here.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.