### PR TITLE
[BWS] Ref: update Moonpay sessions endpoint and headers

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
@@ -456,7 +456,7 @@ export class MoonpayService {
 
       const headers = {
         'Content-Type': 'application/json',
-        Authorization: 'Api-Key ' + SECRET_KEY,
+        'X-Api-Key': SECRET_KEY,
       };
 
       const body: any = {
@@ -466,7 +466,7 @@ export class MoonpayService {
       if (req.body.email) body.email = req.body.email;
       if (req.body.phoneNumber) body.phoneNumber = req.body.phoneNumber;
 
-      const URL = API + '/platform/v1/session';
+      const URL = API + '/platform/v1/sessions';
 
       this.request.post(
         URL,
@@ -498,7 +498,7 @@ export class MoonpayService {
 
       const headers = {
         Accept: 'application/json',
-        Authorization: 'Api-Key ' + SECRET_KEY
+        'X-Api-Key': SECRET_KEY
       };
 
       const URL = API + '/platform/v1/sessions?externalCustomerId=' + encodeURIComponent(req.body.externalCustomerId);


### PR DESCRIPTION
Description
The Moonpay team recently updated their documentation and asked us to change the endpoint for `createSession` (embedded-buy flow).
This also includes a small change to the authorization headers.

Changelog
`moonpayCreateSession` endpoint updated from `session` to `sessions`.
`Authorization` header changed to `X-Api-Key`