### PR TITLE
[BWS] Ref: Transak accessToken is now required from frontend

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/transak.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/transak.ts
@@ -197,6 +197,7 @@ export class TransakService {
   transakGetSignedPaymentUrl(req): Promise<{ urlWithSignature: string }> {
     return new Promise(async (resolve, reject) => {
       const appRequiredParams = [
+        'accessToken',
         'walletAddress',
         'redirectURL',
         'fiatAmount',
@@ -207,7 +208,7 @@ export class TransakService {
         'partnerCustomerId',
       ];
 
-      const requiredParams = req.body.context === 'web' ? [] : appRequiredParams;
+      const requiredParams = req.body.context === 'web' ? ['accessToken'] : appRequiredParams;
       const referrerDomain = req.body.referrerDomain ?? req.body.context === 'web' ? 'bitpay.com' : 'bitpay';
       let keys;
       try {
@@ -222,22 +223,10 @@ export class TransakService {
         return reject(new ClientError("Transak's request missing arguments"));
       }
 
-      let accessToken;
-      if (req.body.accessToken) {
-        accessToken = req.body.accessToken;
-      } else {
-        try {
-          const accessTokenData = await this.transakGetAccessToken(req);
-          accessToken = accessTokenData?.data?.accessToken;
-        } catch (err) {
-          return reject(err?.body ? err.body : err);
-        }
-      }
-
       const headers = {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        'access-token': accessToken,
+        'access-token': req.body.accessToken,
       };
 
       const body = {
@@ -278,25 +267,13 @@ export class TransakService {
       }
       const API = keys.API;
 
-      if (!checkRequired(req.body, ['orderId'])) {
+      if (!checkRequired(req.body, ['orderId', 'accessToken'])) {
         return reject(new ClientError("Transak's request missing arguments"));
-      }
-
-      let accessToken;
-      if (req.body.accessToken) {
-        accessToken = req.body.accessToken;
-      } else {
-        try {
-          const accessTokenData = await this.transakGetAccessToken(req);
-          accessToken = accessTokenData?.data?.accessToken;
-        } catch (err) {
-          return reject(err?.body ? err.body : err);
-        }
       }
 
       const headers = {
         Accept: 'application/json',
-        'access-token': accessToken,
+        'access-token': req.body.accessToken,
       };
 
       const URL: string = API + `/partners/api/v2/order/${req.body.orderId}`;


### PR DESCRIPTION
Description
Transak reported rate-limited errors stemming from the generation of access tokens that did not meet the expiration time. Access tokens will now be handled from the front end.

Changelog
This pull request removes the ability to create an access token unless it is sent from the front end (app/web).