### PR TITLE
Add wallet lock file to bitcore-cli

### DIFF
--- a/packages/bitcore-cli/createBin
+++ b/packages/bitcore-cli/createBin
@@ -8,7 +8,7 @@ const verbose = process.argv.includes('-v');
 
 const source = path.join(__dirname, 'build/src/cli.js');
 const targetDir = path.join(__dirname, 'bin');
-const target = path.join(targetDir, 'wallet');
+const target = path.join(targetDir, 'bitcore-cli');
 
 if (!fs.existsSync(targetDir)) {
   fs.mkdirSync(targetDir);

--- a/packages/bitcore-cli/package.json
+++ b/packages/bitcore-cli/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "bin": {
-    "bitcore-cli": "./bin/wallet"
+    "bitcore-cli": "./bin/bitcore-cli"
   },
   "scripts": {
     "test": "npm run compile && node copyTestWallets && mocha --exit 'build/test/**/*.js'",

--- a/packages/bitcore-cli/src/utils.ts
+++ b/packages/bitcore-cli/src/utils.ts
@@ -58,6 +58,10 @@ export class Utils {
     return path.join(dir, walletName + '.json');
   }
 
+  static getWalletLockFileName(walletName, dir) {
+    return path.join(dir, '.' + walletName + '.LOCK');
+  }
+
   static colorText(text: string, color: Color): string {
     return Constants.COLOR[color.toLowerCase()].replace('%s', text);
   }

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -228,6 +228,25 @@ export class Wallet implements IWallet {
     return secret as string | undefined;
   }
 
+  private lockLoadedWallet() {
+    try {
+      const lockFilename = Utils.getWalletLockFileName(this.name, this.dir);
+      fs.writeFileSync(lockFilename, '', { flag: 'wx' }); // wx flag ensures it fails if the file already exists
+      process.on('exit', () => {
+        // Note, this does not fire in a `kill -9` scenario, but that's unavoidable. In that case, the lock file will be left behind and should be removed manually.
+        try {
+          fs.rmSync(lockFilename);
+        } catch (e) {
+          _verbose && console.error(e);
+          console.error('Failed to remove wallet lock file on exit. Please check for orphaned lock files in the wallet directory.');
+        }
+      });
+    } catch (e) {
+      _verbose && console.error(e);
+      Utils.die('Wallet is already open in another process.');
+    }
+  }
+
   async load(opts?: { doNotComplete?: boolean; allowCache?: boolean }) {
     const { doNotComplete, allowCache } = opts || {};
 
@@ -280,6 +299,7 @@ export class Wallet implements IWallet {
       credentials: Credentials.fromObj(walletData.credentials)
     } as WalletData;
 
+    this.lockLoadedWallet();
     if (doNotComplete) return key;
 
     const status = await this.client.openWallet();

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import url from 'url';
 import {
@@ -48,6 +49,7 @@ process.on('uncaughtException', (uncaught) => {
 });
 
 let _verbose = false;
+let _hasLockFile = false;
 
 export class Wallet implements IWallet {
   static _bpCurrencies: ITokenObj[];
@@ -230,9 +232,13 @@ export class Wallet implements IWallet {
   }
 
   private lockLoadedWallet() {
+    if (_hasLockFile) {
+      return;
+    }
     const lockFilename = Utils.getWalletLockFileName(this.name, this.dir);
     try {
       fs.writeFileSync(lockFilename, process.pid.toString(), { flag: 'wx', mode: 0o444 }); // wx flag ensures it fails if the file already exists
+      _hasLockFile = true;
       process.on('exit', () => {
         try {
           fs.rmSync(lockFilename);
@@ -245,12 +251,19 @@ export class Wallet implements IWallet {
       if (e.code === 'EEXIST') {
         // Check if process is still running
         const pid = fs.readFileSync(lockFilename, 'utf-8')?.trim();
-        const response = execSync(`ps -q ${pid} -o args || true`, { encoding: 'utf-8' });
-        const command = response?.split('\n')[1] || '';
-        if (!command.includes(`bitcore-cli ${this.name}`)) {
-          // Stale lock file, remove it and continue
-          fs.rmSync(lockFilename);
-          return this.lockLoadedWallet();
+        if (os.platform() === 'win32') {
+          // TODO
+        } else {
+          const stat = fs.statSync(lockFilename);
+          if (stat.uid === process.getuid()) { // make sure the lock file belongs to the current user
+            const response = execSync(`ps -q ${pid} -o args || true`, { encoding: 'utf-8' });
+            const command = response?.split('\n')[1] || '';
+            if (!command.includes(`bitcore-cli ${this.name}`) && !command.includes(`build/src/cli.js ${this.name}`)) {
+              // Stale lock file, remove it and continue
+              fs.rmSync(lockFilename);
+              return this.lockLoadedWallet();
+            }
+          }
         }
       }
       _verbose && console.error(e);

--- a/packages/bitcore-cli/src/wallet.ts
+++ b/packages/bitcore-cli/src/wallet.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
@@ -229,19 +230,29 @@ export class Wallet implements IWallet {
   }
 
   private lockLoadedWallet() {
+    const lockFilename = Utils.getWalletLockFileName(this.name, this.dir);
     try {
-      const lockFilename = Utils.getWalletLockFileName(this.name, this.dir);
-      fs.writeFileSync(lockFilename, '', { flag: 'wx' }); // wx flag ensures it fails if the file already exists
+      fs.writeFileSync(lockFilename, process.pid.toString(), { flag: 'wx', mode: 0o444 }); // wx flag ensures it fails if the file already exists
       process.on('exit', () => {
-        // Note, this does not fire in a `kill -9` scenario, but that's unavoidable. In that case, the lock file will be left behind and should be removed manually.
         try {
           fs.rmSync(lockFilename);
         } catch (e) {
           _verbose && console.error(e);
-          console.error('Failed to remove wallet lock file on exit. Please check for orphaned lock files in the wallet directory.');
+          console.error('Failed to remove wallet lock file on exit.');
         }
       });
     } catch (e) {
+      if (e.code === 'EEXIST') {
+        // Check if process is still running
+        const pid = fs.readFileSync(lockFilename, 'utf-8')?.trim();
+        const response = execSync(`ps -q ${pid} -o args || true`, { encoding: 'utf-8' });
+        const command = response?.split('\n')[1] || '';
+        if (!command.includes(`bitcore-cli ${this.name}`)) {
+          // Stale lock file, remove it and continue
+          fs.rmSync(lockFilename);
+          return this.lockLoadedWallet();
+        }
+      }
       _verbose && console.error(e);
       Utils.die('Wallet is already open in another process.');
     }

--- a/packages/bitcore-cli/test/utils.test.ts
+++ b/packages/bitcore-cli/test/utils.test.ts
@@ -108,6 +108,15 @@ describe('Utils', function() {
     });
   });
 
+  // ─── getWalletLockFileName ───────────────────────────────────────────────────────
+
+  describe('getWalletLockFileName', function() {
+    it('should return the wallet lock file path', function() {
+      const result = Utils.getWalletLockFileName('myWallet', '/home/user/wallets');
+      assert.strictEqual(result, path.join('/home/user/wallets', '.myWallet.LOCK'));
+    });
+  });
+
   // ─── colorText ───────────────────────────────────────────────────────────────
 
   describe('colorText', function() {

--- a/packages/bitcore-cli/test/utils.test.ts
+++ b/packages/bitcore-cli/test/utils.test.ts
@@ -108,7 +108,7 @@ describe('Utils', function() {
     });
   });
 
-  // ─── getWalletLockFileName ───────────────────────────────────────────────────────
+  // ─── getWalletLockFileName ───────────────────────────────────────────────────
 
   describe('getWalletLockFileName', function() {
     it('should return the wallet lock file path', function() {

--- a/packages/bitcore-cli/test/wallet.test.ts
+++ b/packages/bitcore-cli/test/wallet.test.ts
@@ -1,0 +1,206 @@
+import { spawn } from 'child_process';
+import assert from 'assert';
+import sinon from 'sinon';
+import fs from 'fs';
+import os from 'os';
+import { Transform } from 'stream';
+import * as helpers from './helpers';
+import * as walletData from './data/walletsData';
+import { Utils } from '../src/utils';
+
+describe('Wallet', function() {
+  this.timeout(Math.max(this['_timeout'] || 0, 5000));
+  const { KEYSTROKES, WALLETS, OUTPUT_END_SEQ } = helpers.CONSTANTS;
+  const { CLI_EXEC, CLI_OPTS, COMMON_OPTS, DIR } = WALLETS;
+  const cmdOpts = [...COMMON_OPTS, '--dir', DIR];
+
+  before(async function() {
+    await helpers.startBws();
+    await helpers.loadWalletData(walletData.btcSingleSigWallet);
+    sinon.stub(process, 'exit').throws(new Error('process.exit was called')); // prevent accidental exits during test
+  });
+
+  after(async function() {
+    await helpers.stopBws();
+    sinon.restore();
+  });
+
+  // ─── lockLoadedWallet ───────────────────────────────────────────────────────
+
+  describe('lockLoadedWallet', function() {
+    it('should lock the loaded wallet', function(done) {
+      const stepInputs = [
+        // Checkpoint1: Upon wallet load
+        [KEYSTROKES.ARROW_UP], // Proposals -> Exit
+        [KEYSTROKES.ENTER], // Exit
+      ];
+      let step = 0;
+      let checkpointOutput = '';
+      // stepInputs indexes corresponding to checkpoints in test flow where we want to assert on CLI output
+      const checkpoints = new Set([0]);
+      const io = new Transform({
+        encoding: 'utf-8',
+        transform: async function (chunk, encoding, respond) {
+          try {
+            chunk = chunk.toString();
+            if (checkpoints.has(step)) {
+              checkpointOutput += chunk;
+            } else {
+              checkpointOutput = '';
+            }
+
+            // Uncomment to see CLI output during test
+            // process.stdout.write(chunk);
+
+            const isStep = chunk.endsWith(OUTPUT_END_SEQ);
+            if (isStep) {
+              switch (step) {
+                default:
+                  break; // no-op for non-checkpoint steps
+                case Array.from(checkpoints)[0]:
+                  // Try to load the same wallet in a second process while the first one is still running, should get an error about wallet being locked
+                  let secondOutput = '';
+                  await new Promise<void>((resolve, reject) => {
+                    const io2 = new Transform({
+                      encoding: 'utf-8',
+                      transform(chunk, encoding, respond) {
+                        chunk = chunk.toString();
+                        secondOutput += chunk;
+                        // Uncomment to see CLI output during test
+                        // process.stdout.write(chunk);
+
+                        { // This block is a contingency in case this second wallet doesn't exit like it's supposed to
+                          if (chunk.endsWith(OUTPUT_END_SEQ)) {
+                            this.push(KEYSTROKES.ARROW_UP);
+                            this.push(KEYSTROKES.ENTER);
+                          };
+
+                          if (chunk.includes('👋')) {
+                            child2.stdin.end(); // send EOF to child so it can exit cleanly
+                          }
+                        }
+
+                        respond();
+                      }
+                    });
+
+                    const child2 = spawn('node', [CLI_EXEC, WALLETS.BTC.SINGLE_SIG, ...cmdOpts], CLI_OPTS);
+                    child2.stderr.pipe(process.stderr);
+                    child2.stdout.pipe(io2).pipe(child2.stdin);
+                    io2.on('close', () => {
+                      try {
+                        assert.match(secondOutput, /!! Wallet is already open in another process./);
+                        resolve();
+                      } catch (e) {
+                        reject(e);
+                      }
+                    });
+                  });
+                  break;
+              }
+
+              for (const input of stepInputs[step]) {
+                this.push(input);
+              }
+              step++;
+            } else if (chunk.includes('Error:')) {
+              return respond(chunk);
+            }
+            if (chunk.includes('👋')) {
+              child.stdin.end(); // send EOF to child so it can exit cleanly
+            }
+            respond();
+          } catch (e) {
+            return respond(e);
+          }
+        }
+      });
+      const child = spawn('node', [CLI_EXEC, WALLETS.BTC.SINGLE_SIG, ...cmdOpts], CLI_OPTS);
+      child.stderr.pipe(process.stderr);
+      child.stdout.pipe(io).pipe(child.stdin);
+      io.on('error', (e) => {
+        done(e);
+      });
+      child.on('error', (e) => {
+        done(e);
+      });
+      child.on('close', (code) => {
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+    it('should handle stale lock file', function(done) {
+      const lockFileName = Utils.getWalletLockFileName(WALLETS.BTC.SINGLE_SIG, DIR);
+      fs.writeFileSync(lockFileName, '999999', { mode: 0o444 }); // create a lock file with a PID that doesn't exist
+      assert(fs.readFileSync(lockFileName, 'utf-8') === '999999', 'Failed to create lock file with test PID');
+
+      const stepInputs = [
+        // Checkpoint1: Upon wallet load
+        [KEYSTROKES.ARROW_UP], // Proposals -> Exit
+        [KEYSTROKES.ENTER], // Exit
+      ];
+      let step = 0;
+      let checkpointOutput = '';
+      // stepInputs indexes corresponding to checkpoints in test flow where we want to assert on CLI output
+      const checkpoints = new Set([0]);
+      const io = new Transform({
+        encoding: 'utf-8',
+        transform: async function (chunk, encoding, respond) {
+          try {
+            chunk = chunk.toString();
+            if (checkpoints.has(step)) {
+              checkpointOutput += chunk;
+            } else {
+              checkpointOutput = '';
+            }
+
+            // Uncomment to see CLI output during test
+            // process.stdout.write(chunk);
+
+            const isStep = chunk.endsWith(OUTPUT_END_SEQ);
+            if (isStep) {
+              switch (step) {
+                default:
+                  break; // no-op for non-checkpoint steps
+                case Array.from(checkpoints)[0]:
+                  const lines = helpers.decolor(checkpointOutput).split(os.EOL);
+                  const mainmenuLine = lines.findIndex(l => l.match(`[  Main Menu - ${WALLETS.BTC.SINGLE_SIG}  ]`));
+                  assert(mainmenuLine > -1, 'Did not reach main menu. Got: ' + checkpointOutput);
+                  assert(fs.readFileSync(lockFileName, 'utf-8') === child.pid.toString(), 'Lock file does not match child PID');
+                  break;
+              }
+
+              for (const input of stepInputs[step]) {
+                this.push(input);
+              }
+              step++;
+            } else if (chunk.includes('Error:')) {
+              return respond(chunk);
+            }
+            if (chunk.includes('👋')) {
+              child.stdin.end(); // send EOF to child so it can exit cleanly
+            }
+            respond();
+          } catch (e) {
+            return respond(e);
+          }
+        }
+      });
+      const child = spawn('node', [CLI_EXEC, WALLETS.BTC.SINGLE_SIG, ...cmdOpts], CLI_OPTS);
+      child.stderr.pipe(process.stderr);
+      child.stdout.pipe(io).pipe(child.stdin);
+      io.on('error', (e) => {
+        done(e);
+      });
+      child.on('error', (e) => {
+        done(e);
+      });
+      child.on('close', (code) => {
+        assert.equal(code, 0);
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
### Description
It's currently possible to run multiple instances of bitcore-cli for the same wallet. This has some obvious downsides as state can become stale between instances.

Note, this PR is intended to handle general idiot-proofing, not to withstand a comprehensive security audit. We can iterate over what I've done here in future PRs if the latter is desired. 

### Changelog

* Adds lock file logic to the wallet.load() method.

### Testing Notes
* You should not be able to load the same wallet in multiple terminal instances.
* Clean and unclean internal exits (e.g. uncaught exception) from an open process should remove the lock file.
* A hard, external exit (kill -9, hard machine reboot, etc.) will leave a residual lock file. This should not be a problem as starting a new wallet instance should check that the lock file is still relevant (pid is associated to a running process AND pid command is indeed the wallet command). If not, then it should remove it and create a new one.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.