### PR TITLE
[BCN] Filter failed EVM token history rows

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/api/erc20Transform.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/erc20Transform.ts
@@ -13,7 +13,7 @@ export class Erc20RelatedFilterTransform extends TransformWithEventPipe {
     if (tx.effects && tx.effects.length) {
       // Get all effects where contractAddress is tokenAddress
       const tokenRelatedInternalTxs = tx.effects.filter(
-        (effect: any) => effect.contractAddress === this.tokenAddress
+        (effect: any) => effect.contractAddress?.toLowerCase() === this.tokenAddress.toLowerCase()
       );
 
       // Create a tx object for each erc20 transfer
@@ -22,6 +22,7 @@ export class Erc20RelatedFilterTransform extends TransformWithEventPipe {
         _tx.value = Number(internalTx.amount);
         _tx.to = internalTx.to;
         _tx.from = internalTx.from;
+        _tx.effects = [internalTx];
         if (internalTx.from != tx.from) {
           _tx.initialFrom = tx.from;
         }

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/gnosis.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/gnosis.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { Utils } from '@bitpay-labs/crypto-wallet-core';
+import { Utils, Web3 } from '@bitpay-labs/crypto-wallet-core';
 import { ChainStateProvider } from '../../';
 import { Config } from '../../../../services/config';
 import { IEVMNetworkConfig } from '../../../../types/Config';
@@ -155,42 +155,49 @@ export class GnosisApi {
 
   async streamGnosisWalletTransactions(params: { multisigContractAddress: string } & StreamWalletTransactionsParams) {
     const { chain, network, multisigContractAddress, res, args } = params;
+    const normalizedMultisigContractAddress = Web3.utils.toChecksumAddress(multisigContractAddress);
+    const tokenAddress = args.tokenAddress ? Web3.utils.toChecksumAddress(args.tokenAddress) : undefined;
     const transactionQuery = getCSP(chain, network).getWalletTransactionQuery(params);
     delete transactionQuery.wallets;
     delete transactionQuery['wallets.0'];
     let query;
-    if (args.tokenAddress) {
+    if (tokenAddress) {
       query = {
         $or: [
           {
             ...transactionQuery,
-            to: args.tokenAddress,
-            'abiType.params.0.value': multisigContractAddress.toLowerCase()
+            to: tokenAddress,
+            'abiType.params.0.value': normalizedMultisigContractAddress.toLowerCase()
           },
           {
             ...transactionQuery,
-            'internal.action.to': args.tokenAddress.toLowerCase(),
-            'internal.action.from': multisigContractAddress.toLowerCase()
+            'internal.action.to': tokenAddress.toLowerCase(),
+            'internal.action.from': normalizedMultisigContractAddress.toLowerCase()
           },
           {
             ...transactionQuery,
-            'effects.contractAddress': args.tokenAddress,
-            'effects.from': multisigContractAddress
+            'effects.contractAddress': tokenAddress,
+            'effects.from': normalizedMultisigContractAddress
+          },
+          {
+            ...transactionQuery,
+            'effects.contractAddress': tokenAddress,
+            'effects.to': normalizedMultisigContractAddress
           }
         ]
       };
     } else {
       query = {
         $or: [
-          { ...transactionQuery, to: multisigContractAddress },
-          { ...transactionQuery, 'internal.action.to': multisigContractAddress.toLowerCase() },
-          { ...transactionQuery, 'effects.to': multisigContractAddress }
+          { ...transactionQuery, to: normalizedMultisigContractAddress },
+          { ...transactionQuery, 'internal.action.to': normalizedMultisigContractAddress.toLowerCase() },
+          { ...transactionQuery, 'effects.to': normalizedMultisigContractAddress }
         ]
       };
     }
 
     let transactionStream = new Readable({ objectMode: true });
-    const ethTransactionTransform = new EVMListTransactionsStream([multisigContractAddress, args.tokenAddress]);
+    const ethTransactionTransform = new EVMListTransactionsStream([normalizedMultisigContractAddress], tokenAddress);
     const EVM = getCSP(chain, network);
     const populateReceipt = new PopulateReceiptTransform(EVM);
     const populateEffects = new PopulateEffectsTransform(EVM);
@@ -221,7 +228,7 @@ export class GnosisApi {
     transactionStream = cursor.pipe(populateEffects); // For old db entries
 
     if (multisigContractAddress) {
-      const multisigTransform = new MultisigRelatedFilterTransform(multisigContractAddress, args.tokenAddress);
+      const multisigTransform = new MultisigRelatedFilterTransform(normalizedMultisigContractAddress, tokenAddress);
       transactionStream = transactionStream.pipe(multisigTransform);
     }
 

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/multisigTransform.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/multisigTransform.ts
@@ -8,16 +8,21 @@ export class MultisigRelatedFilterTransform extends Transform {
   }
 
   async _transform(tx: MongoBound<IEVMTransactionInProcess>, _, done) {
+    const multisigContractAddressLower = this.multisigContractAddress.toLowerCase();
+    const tokenAddressLower = this.tokenAddress?.toLowerCase();
     let hasEffects = false;
     if (tx.effects && tx.effects.length) {
       // All internal to and from multisig - if tokenAddress is undefined then it only gets native transfers
       const walletRelatedInternalTxs = tx.effects.filter(
         (internalTx: any) => {
-          if (this.tokenAddress) {
-            return [internalTx.to, internalTx.from].includes(this.multisigContractAddress) && internalTx.contractAddress && internalTx.contractAddress.toLowerCase() === this.tokenAddress.toLowerCase();
+          const relatedToMultisig = [internalTx.to, internalTx.from].some(address => (
+            address?.toLowerCase() === multisigContractAddressLower
+          ));
+          if (tokenAddressLower) {
+            return relatedToMultisig && internalTx.contractAddress && internalTx.contractAddress.toLowerCase() === tokenAddressLower;
           } else {
             // contractAddress is undefined on native asset transfers
-            return [internalTx.to, internalTx.from].includes(this.multisigContractAddress) && !internalTx.contractAddress;
+            return relatedToMultisig && !internalTx.contractAddress;
           }
         }
       );
@@ -35,11 +40,11 @@ export class MultisigRelatedFilterTransform extends Transform {
       hasEffects = !!walletRelatedInternalTxs.length;
     } 
 
-    if (hasEffects && this.tokenAddress) {
+    if (hasEffects && tokenAddressLower) {
       return done();
     }
     
-    if (!hasEffects && tx.to !== this.multisigContractAddress) {
+    if (!hasEffects && tx.to?.toLowerCase() !== multisigContractAddressLower) {
       // If no effects and tx isn't to multisig, we don't care about original tx, return done()
       return done();
     }

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/multisigTransform.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/multisigTransform.ts
@@ -3,7 +3,7 @@ import { MongoBound } from '../../../../models/base';
 import { IEVMTransactionInProcess } from '../types';
 
 export class MultisigRelatedFilterTransform extends Transform {
-  constructor(private multisigContractAddress: string, private tokenAddress: string) {
+  constructor(private multisigContractAddress: string, private tokenAddress?: string) {
     super({ objectMode: true });
   }
 
@@ -14,7 +14,7 @@ export class MultisigRelatedFilterTransform extends Transform {
       const walletRelatedInternalTxs = tx.effects.filter(
         (internalTx: any) => {
           if (this.tokenAddress) {
-            return [internalTx.to, internalTx.from].includes(this.multisigContractAddress) && internalTx.contractAddress && internalTx.contractAddress.toLowerCase() == this.tokenAddress.toLowerCase();
+            return [internalTx.to, internalTx.from].includes(this.multisigContractAddress) && internalTx.contractAddress && internalTx.contractAddress.toLowerCase() === this.tokenAddress.toLowerCase();
           } else {
             // contractAddress is undefined on native asset transfers
             return [internalTx.to, internalTx.from].includes(this.multisigContractAddress) && !internalTx.contractAddress;
@@ -28,11 +28,16 @@ export class MultisigRelatedFilterTransform extends Transform {
         _tx.value = Number(internalTx.amount);
         _tx.to = internalTx.to;
         _tx.from = internalTx.from;
+        _tx.effects = [internalTx];
         this.push(_tx);
       }
       // If we didn't find any internal transfers, original tx may be inconsequential
       hasEffects = !!walletRelatedInternalTxs.length;
     } 
+
+    if (hasEffects && this.tokenAddress) {
+      return done();
+    }
     
     if (!hasEffects && tx.to !== this.multisigContractAddress) {
       // If no effects and tx isn't to multisig, we don't care about original tx, return done()

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/transform.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/transform.ts
@@ -5,11 +5,20 @@ import { jsonStringify, overlaps } from '../../../../utils';
 import { TransformWithEventPipe } from '../../../../utils/streamWithEventPipe';
 import { IEVMTransactionTransformed } from '../types';
 
+const isFailedReceipt = (receipt?: { status?: boolean | number | string | bigint }) => {
+  const status = receipt?.status;
+  return status === false || status === 0 || status === 0n || status === '0' || status === '0x0';
+};
+
 export class EVMListTransactionsStream extends TransformWithEventPipe {
   constructor(private walletAddresses: Array<string>, private tokenAddress?: string) {
     super({ objectMode: true });
   }
   async _transform(transaction: MongoBound<IEVMTransactionTransformed>, _, done) {
+    if (this.tokenAddress && isFailedReceipt(transaction.receipt)) {
+      return done();
+    }
+
     const baseTx = {
       id: transaction._id,
       txid: transaction.txid,

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/transform.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/transform.ts
@@ -1,7 +1,7 @@
 import { MongoBound } from '../../../../models/base';
 import { Config } from '../../../../services/config';
 import { IEVMNetworkConfig } from '../../../../types/Config';
-import { jsonStringify, overlaps } from '../../../../utils';
+import { jsonStringify } from '../../../../utils';
 import { TransformWithEventPipe } from '../../../../utils/streamWithEventPipe';
 import { IEVMTransactionTransformed } from '../types';
 
@@ -11,11 +11,20 @@ const isFailedReceipt = (receipt?: { status?: boolean | number | string | bigint
 };
 
 export class EVMListTransactionsStream extends TransformWithEventPipe {
-  constructor(private walletAddresses: Array<string>, private tokenAddress?: string) {
+  private walletAddressSet: Set<string>;
+
+  constructor(walletAddresses: Array<string>, private tokenAddress?: string) {
     super({ objectMode: true });
+    this.walletAddressSet = new Set(walletAddresses.map(address => address.toLowerCase()));
   }
+
+  private isWalletAddress(address?: string) {
+    return !!address && this.walletAddressSet.has(address.toLowerCase());
+  }
+
   async _transform(transaction: MongoBound<IEVMTransactionTransformed>, _, done) {
-    if (this.tokenAddress && isFailedReceipt(transaction.receipt)) {
+    const tokenAddressLower = this.tokenAddress?.toLowerCase();
+    if (tokenAddressLower && isFailedReceipt(transaction.receipt)) {
       return done();
     }
 
@@ -47,9 +56,9 @@ export class EVMListTransactionsStream extends TransformWithEventPipe {
       baseTx.calls = transaction.calls;
       baseTx.data = transaction.data ? transaction.data.toString() : '';
     }
-    const sending = this.walletAddresses.includes(transaction.from);
+    const sending = this.isWalletAddress(transaction.from);
     if (sending) {
-      const sendingToOurself = this.walletAddresses.includes(transaction.to);
+      const sendingToOurself = this.isWalletAddress(transaction.to);
       if (!sendingToOurself) {
         baseTx.category = 'send';
         baseTx.satoshis = -transaction.value;
@@ -65,12 +74,12 @@ export class EVMListTransactionsStream extends TransformWithEventPipe {
       }
     } else {
       baseTx.category = 'receive'; // assume it's a receive, but may not be sent
-      const weReceived = this.walletAddresses.includes(transaction.to);
-      const weReceivedInternal = overlaps(this.walletAddresses, transaction.effects?.map(e => e.to));
+      const weReceived = this.isWalletAddress(transaction.to);
+      const weReceivedInternal = transaction.effects?.some(e => this.isWalletAddress(e.to));
       if (weReceivedInternal) {
         baseTx.satoshis = 0n;
         for (const effect of transaction.effects!) {
-          if (this.walletAddresses.includes(effect.to) && (effect.contractAddress == this.tokenAddress)) {
+          if (this.isWalletAddress(effect.to) && (effect.contractAddress?.toLowerCase() == tokenAddressLower)) {
             baseTx.satoshis += BigInt(effect.amount || 0);
           }
         }
@@ -78,7 +87,6 @@ export class EVMListTransactionsStream extends TransformWithEventPipe {
           jsonStringify(baseTx) + '\n'
         );
       } else if (weReceived) {
-        // console.log(weReceived, weReceivedInternal, transaction.to, this.walletAddresses, transaction);
         baseTx.satoshis = BigInt(transaction.value || 0);
         this.push(
           jsonStringify(baseTx) + '\n'

--- a/packages/bitcore-node/test/unit/models/transaction.test.ts
+++ b/packages/bitcore-node/test/unit/models/transaction.test.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from 'bson';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { Readable } from 'stream';
+import { Readable, Writable } from 'stream';
 import { Web3 } from '@bitpay-labs/crypto-wallet-core';
 import { CoinStorage } from '../../../src/models/coin';
 import { MintOp, SpendOp, TaggedBitcoinTx, TransactionStorage, TxOp } from '../../../src/models/transaction';
+import { ChainStateProvider } from '../../../src/providers/chain-state';
+import { Gnosis } from '../../../src/providers/chain-state/evm/api/gnosis';
+import { Config } from '../../../src/services/config';
+import { EVMListTransactionsStream } from '../../../src/providers/chain-state/evm/api/transform';
 import { EVMTransactionStorage } from '../../../src/providers/chain-state/evm/models/transaction';
 import { WalletAddressStorage } from '../../../src/models/walletAddress';
 import { BitcoinTransaction, TransactionInput } from '../../../src/types/namespaces/Bitcoin';
@@ -16,6 +20,22 @@ import { BitcoreLib } from '@bitpay-labs/crypto-wallet-core';
 
 describe('Transaction Model', function() {
   const { Transaction } = BitcoreLib;
+  const collectEvmListTransactionRows = async (walletAddresses: Array<string>, tokenAddress: string | undefined, txs: Array<any>) => {
+    const rows = new Array<any>();
+    const stream = new EVMListTransactionsStream(walletAddresses, tokenAddress);
+    const done = new Promise<void>((resolve, reject) => {
+      stream
+        .on('data', chunk => rows.push(JSON.parse(chunk.toString())))
+        .on('error', reject)
+        .on('end', resolve);
+    });
+    for (const tx of txs) {
+      stream.write(tx);
+    }
+    stream.end();
+    await done;
+    return rows;
+  };
   
   before(unitBeforeHelper);
   after(unitAfterHelper);
@@ -198,6 +218,199 @@ describe('Transaction Model', function() {
   });
 
   describe('EVM', function() {
+    describe('EVM token wallet history filtering', function() {
+      beforeEach(() => {
+        sandbox.stub(Config, 'chainConfig').returns({ leanTransactionStorage: false } as any);
+      });
+
+      const gnosisBusdToken = Web3.utils.toChecksumAddress('0x4fabb145d64652a948d72533023f6e7a623c7c53');
+      const gnosisMultisigContractAddress = Web3.utils.toChecksumAddress('0xa91cfe0dcad33f36f3c9428d48eccbd8a71951b4');
+      const gnosisCounterpartyAddress = Web3.utils.toChecksumAddress('0x8489935991b0eac9ce9e9330d35b9734ecdf2cad');
+      const gnosisTokenEffect = (overrides: Record<string, any> = {}) => ({
+        to: gnosisCounterpartyAddress,
+        from: gnosisMultisigContractAddress,
+        amount: '112519572370000003072',
+        type: 'ERC20:transfer',
+        contractAddress: gnosisBusdToken,
+        callStack: '0',
+        ...overrides
+      });
+      const gnosisTokenTx = (overrides: Record<string, any> = {}) => ({
+        _id: new ObjectId(),
+        txid: '0x28d6aa82a06e58290d10cc33ed2bc782d6c7aeb38d29ce218be53678731fe911',
+        chain: 'ETH',
+        network: 'mainnet',
+        blockHeight: 15950646,
+        blockTimeNormalized: new Date('2022-11-12T01:26:59.000Z'),
+        from: gnosisMultisigContractAddress,
+        to: gnosisBusdToken,
+        value: 0,
+        fee: 622112000000000,
+        gasPrice: 16000000000,
+        gasLimit: 160000,
+        nonce: 5,
+        transactionIndex: 0,
+        data: Buffer.from(''),
+        internal: [],
+        calls: [],
+        receipt: { status: true },
+        effects: [gnosisTokenEffect()],
+        ...overrides
+      });
+      const collectGnosisTokenHistoryRows = async (
+        tx: Record<string, any>,
+        requestOverrides: { multisigContractAddress?: string; tokenAddress?: string } = {}
+      ) => {
+        const cursor = Readable.from([tx], { objectMode: true }) as any;
+        cursor.sort = sandbox.stub().returns(cursor);
+        cursor.addCursorFlag = sandbox.stub().returns(cursor);
+        cursor.close = sandbox.stub();
+        let findQuery: any;
+        sandbox.stub(EVMTransactionStorage, 'collection').get(() => ({
+          find: sandbox.stub().callsFake(query => {
+            findQuery = query;
+            return cursor;
+          })
+        }));
+        sandbox.stub(ChainStateProvider, 'get').returns({
+          getWalletTransactionQuery: sandbox.stub().returns({
+            chain: 'ETH',
+            network: 'mainnet',
+            wallets: new ObjectId(),
+            'wallets.0': { $exists: true }
+          }),
+          populateEffects: sandbox.stub().callsFake(tx => tx),
+          populateReceipt: sandbox.stub().callsFake(tx => tx)
+        } as any);
+
+        const rows = new Array<any>();
+        const req = new Readable({ read() {} }) as any;
+        const res = new Writable({
+          write(chunk, _, done) {
+            for (const line of chunk.toString().split('\n').filter(Boolean)) {
+              rows.push(JSON.parse(line));
+            }
+            done();
+          }
+        }) as any;
+        const finished = new Promise<void>((resolve, reject) => {
+          res.on('finish', resolve);
+          res.on('error', reject);
+        });
+
+        await Gnosis.streamGnosisWalletTransactions({
+          chain: 'ETH',
+          network: 'mainnet',
+          multisigContractAddress: requestOverrides.multisigContractAddress || gnosisMultisigContractAddress,
+          wallet: { _id: new ObjectId() },
+          req,
+          res,
+          args: { tokenAddress: requestOverrides.tokenAddress || gnosisBusdToken }
+        } as any);
+        await finished;
+        return { findQuery, rows };
+      };
+
+      it('should not emit token history rows for failed ERC20 sends', async () => {
+        const busdToken = Web3.utils.toChecksumAddress('0x4fabb145d64652a948d72533023f6e7a623c7c53');
+        const walletAddress = Web3.utils.toChecksumAddress('0xa91cfe0dcad33f36f3c9428d48eccbd8a71951b4');
+        const counterpartyAddress = Web3.utils.toChecksumAddress('0x8489935991b0eac9ce9e9330d35b9734ecdf2cad');
+        const rows = await collectEvmListTransactionRows([walletAddress], busdToken, [{
+          _id: new ObjectId(),
+          txid: '0x28d6aa82a06e58290d10cc33ed2bc782d6c7aeb38d29ce218be53678731fe911',
+          chain: 'ETH',
+          network: 'mainnet',
+          blockHeight: 15950646,
+          blockTimeNormalized: new Date('2022-11-12T01:26:59.000Z'),
+          from: walletAddress,
+          to: counterpartyAddress,
+          value: 112519572370000003072,
+          fee: 622112000000000,
+          gasPrice: 16000000000,
+          gasLimit: 160000,
+          nonce: 5,
+          transactionIndex: 0,
+          data: Buffer.from(''),
+          internal: [],
+          calls: [],
+          receipt: { status: false },
+          effects: [{
+            to: counterpartyAddress,
+            from: walletAddress,
+            amount: '112519572370000003072',
+            type: 'ERC20:transfer',
+            contractAddress: busdToken,
+            callStack: '0'
+          }]
+        }]);
+
+        expect(rows).to.deep.equal([]);
+      });
+
+      it('should not emit Gnosis token history rows for failed ERC20 sends', async () => {
+        const { rows } = await collectGnosisTokenHistoryRows(gnosisTokenTx({
+          receipt: { status: false }
+        }));
+
+        expect(rows).to.deep.equal([]);
+      });
+
+      it('should emit one Gnosis token history row for successful ERC20 sends', async () => {
+        const { rows } = await collectGnosisTokenHistoryRows(gnosisTokenTx({
+          effects: [gnosisTokenEffect({ amount: '100' })]
+        }));
+
+        expect(rows).to.have.length(1);
+        expect(rows[0].category).to.equal('send');
+        expect(rows[0].satoshis).to.equal(-100);
+      });
+
+      it('should emit one Gnosis token history row for successful ERC20 receives', async () => {
+        const { findQuery, rows } = await collectGnosisTokenHistoryRows(gnosisTokenTx({
+          from: gnosisCounterpartyAddress,
+          effects: [gnosisTokenEffect({
+            to: gnosisMultisigContractAddress,
+            from: gnosisCounterpartyAddress,
+            amount: '100'
+          })]
+        }));
+
+        expect(rows).to.have.length(1);
+        expect(rows[0].category).to.equal('receive');
+        expect(rows[0].satoshis).to.equal('100');
+        expect(findQuery.$or).to.deep.include({
+          chain: 'ETH',
+          network: 'mainnet',
+          'effects.contractAddress': gnosisBusdToken,
+          'effects.to': gnosisMultisigContractAddress
+        });
+      });
+
+      it('should match Gnosis token receives when request addresses are lowercase', async () => {
+        const { findQuery, rows } = await collectGnosisTokenHistoryRows(gnosisTokenTx({
+          from: gnosisCounterpartyAddress,
+          effects: [gnosisTokenEffect({
+            to: gnosisMultisigContractAddress,
+            from: gnosisCounterpartyAddress,
+            amount: '100'
+          })]
+        }), {
+          multisigContractAddress: gnosisMultisigContractAddress.toLowerCase(),
+          tokenAddress: gnosisBusdToken.toLowerCase()
+        });
+
+        expect(rows).to.have.length(1);
+        expect(rows[0].category).to.equal('receive');
+        expect(rows[0].satoshis).to.equal('100');
+        expect(findQuery.$or).to.deep.include({
+          chain: 'ETH',
+          network: 'mainnet',
+          'effects.contractAddress': gnosisBusdToken,
+          'effects.to': gnosisMultisigContractAddress
+        });
+      });
+    });
+
     describe('getEffects', function() {
       it('should get effects for simple USDC transaction', async () => {
         const effects = EVMTransactionStorage.getEffects(EvmTxData.SimpleUSDCTransfer);

--- a/packages/bitcore-node/test/unit/models/transaction.test.ts
+++ b/packages/bitcore-node/test/unit/models/transaction.test.ts
@@ -7,6 +7,8 @@ import { CoinStorage } from '../../../src/models/coin';
 import { MintOp, SpendOp, TaggedBitcoinTx, TransactionStorage, TxOp } from '../../../src/models/transaction';
 import { ChainStateProvider } from '../../../src/providers/chain-state';
 import { Gnosis } from '../../../src/providers/chain-state/evm/api/gnosis';
+import { Erc20RelatedFilterTransform } from '../../../src/providers/chain-state/evm/api/erc20Transform';
+import { MultisigRelatedFilterTransform } from '../../../src/providers/chain-state/evm/api/multisigTransform';
 import { Config } from '../../../src/services/config';
 import { EVMListTransactionsStream } from '../../../src/providers/chain-state/evm/api/transform';
 import { EVMTransactionStorage } from '../../../src/providers/chain-state/evm/models/transaction';
@@ -257,6 +259,42 @@ describe('Transaction Model', function() {
         effects: [gnosisTokenEffect()],
         ...overrides
       });
+      const collectGnosisTokenRowsAfterRetrieval = async (tx: Record<string, any>) => {
+        const rows = new Array<any>();
+        const multisigTransform = new MultisigRelatedFilterTransform(gnosisMultisigContractAddress, gnosisBusdToken);
+        const listTransform = new EVMListTransactionsStream([gnosisMultisigContractAddress], gnosisBusdToken);
+        const done = new Promise<void>((resolve, reject) => {
+          multisigTransform
+            .pipe(listTransform)
+            .on('data', chunk => rows.push(JSON.parse(chunk.toString())))
+            .on('error', reject)
+            .on('end', resolve);
+        });
+        multisigTransform.write(tx);
+        multisigTransform.end();
+        await done;
+        return rows;
+      };
+      const collectTokenRowsAfterErc20Filter = async (
+        walletAddress: string,
+        tokenAddress: string,
+        tx: Record<string, any>
+      ) => {
+        const rows = new Array<any>();
+        const erc20Transform = new Erc20RelatedFilterTransform(tokenAddress);
+        const listTransform = new EVMListTransactionsStream([walletAddress], tokenAddress);
+        const done = new Promise<void>((resolve, reject) => {
+          erc20Transform
+            .pipe(listTransform)
+            .on('data', chunk => rows.push(JSON.parse(chunk.toString())))
+            .on('error', reject)
+            .on('end', resolve);
+        });
+        erc20Transform.write(tx);
+        erc20Transform.end();
+        await done;
+        return rows;
+      };
       const collectGnosisTokenHistoryRows = async (
         tx: Record<string, any>,
         requestOverrides: { multisigContractAddress?: string; tokenAddress?: string } = {}
@@ -347,6 +385,91 @@ describe('Transaction Model', function() {
         expect(rows).to.deep.equal([]);
       });
 
+      it('should emit token history rows with lowercase effect contract addresses', async () => {
+        const busdToken = Web3.utils.toChecksumAddress('0x4fabb145d64652a948d72533023f6e7a623c7c53');
+        const walletAddress = Web3.utils.toChecksumAddress('0xa91cfe0dcad33f36f3c9428d48eccbd8a71951b4');
+        const counterpartyAddress = Web3.utils.toChecksumAddress('0x8489935991b0eac9ce9e9330d35b9734ecdf2cad');
+        const rows = await collectTokenRowsAfterErc20Filter(walletAddress, busdToken, {
+          _id: new ObjectId(),
+          txid: '0x28d6aa82a06e58290d10cc33ed2bc782d6c7aeb38d29ce218be53678731fe911',
+          chain: 'ETH',
+          network: 'mainnet',
+          blockHeight: 15950646,
+          blockTimeNormalized: new Date('2022-11-12T01:26:59.000Z'),
+          from: counterpartyAddress,
+          to: busdToken,
+          value: 0,
+          fee: 622112000000000,
+          gasPrice: 16000000000,
+          gasLimit: 160000,
+          nonce: 5,
+          transactionIndex: 0,
+          data: Buffer.from(''),
+          internal: [],
+          calls: [],
+          receipt: { status: true },
+          effects: [{
+            to: walletAddress,
+            from: counterpartyAddress,
+            amount: '100',
+            type: 'ERC20:transfer',
+            contractAddress: busdToken.toLowerCase(),
+            callStack: '0'
+          }]
+        });
+
+        expect(rows).to.have.length(1);
+        expect(rows[0].category).to.equal('receive');
+        expect(rows[0].satoshis).to.equal('100');
+      });
+
+      it('should emit one row per ERC20 transfer without summing sibling effects', async () => {
+        const busdToken = Web3.utils.toChecksumAddress('0x4fabb145d64652a948d72533023f6e7a623c7c53');
+        const walletAddress = Web3.utils.toChecksumAddress('0xa91cfe0dcad33f36f3c9428d48eccbd8a71951b4');
+        const counterpartyAddress = Web3.utils.toChecksumAddress('0x8489935991b0eac9ce9e9330d35b9734ecdf2cad');
+        const rows = await collectTokenRowsAfterErc20Filter(walletAddress, busdToken, {
+          _id: new ObjectId(),
+          txid: '0x28d6aa82a06e58290d10cc33ed2bc782d6c7aeb38d29ce218be53678731fe911',
+          chain: 'ETH',
+          network: 'mainnet',
+          blockHeight: 15950646,
+          blockTimeNormalized: new Date('2022-11-12T01:26:59.000Z'),
+          from: counterpartyAddress,
+          to: busdToken,
+          value: 0,
+          fee: 622112000000000,
+          gasPrice: 16000000000,
+          gasLimit: 160000,
+          nonce: 5,
+          transactionIndex: 0,
+          data: Buffer.from(''),
+          internal: [],
+          calls: [],
+          receipt: { status: true },
+          effects: [
+            {
+              to: walletAddress,
+              from: counterpartyAddress,
+              amount: '100',
+              type: 'ERC20:transfer',
+              contractAddress: busdToken,
+              callStack: '0'
+            },
+            {
+              to: walletAddress,
+              from: counterpartyAddress,
+              amount: '200',
+              type: 'ERC20:transfer',
+              contractAddress: busdToken,
+              callStack: '1'
+            }
+          ]
+        });
+
+        expect(rows).to.have.length(2);
+        expect(rows.map(row => row.satoshis)).to.deep.equal(['100', '200']);
+      });
+
       it('should not emit Gnosis token history rows for failed ERC20 sends', async () => {
         const { rows } = await collectGnosisTokenHistoryRows(gnosisTokenTx({
           receipt: { status: false }
@@ -408,6 +531,24 @@ describe('Transaction Model', function() {
           'effects.contractAddress': gnosisBusdToken,
           'effects.to': gnosisMultisigContractAddress
         });
+      });
+
+      it('should emit Gnosis token receives with lowercase effects after retrieval', async () => {
+        const lowercaseEffect = gnosisTokenEffect({
+          to: gnosisMultisigContractAddress.toLowerCase(),
+          from: gnosisCounterpartyAddress.toLowerCase(),
+          contractAddress: gnosisBusdToken.toLowerCase(),
+          amount: '100'
+        });
+
+        const rows = await collectGnosisTokenRowsAfterRetrieval(gnosisTokenTx({
+          from: gnosisCounterpartyAddress,
+          effects: [lowercaseEffect]
+        }));
+
+        expect(rows).to.have.length(1);
+        expect(rows[0].category).to.equal('receive');
+        expect(rows[0].satoshis).to.equal('100');
       });
     });
 


### PR DESCRIPTION
### Description

This PR fixes EVM token wallet history rows for failed ERC20 transactions. Failed token transfers could appear as successful sends because token effects were emitted before receipt status was considered.

It also fixes related Gnosis token history behavior, including duplicate token rows, missing token receives, and request address casing.

### Changelog

* Filter failed EVM token history rows when the transaction receipt status is failed.
* Pass Gnosis token addresses as token context instead of treating them as wallet addresses.
* Avoid duplicate Gnosis token history rows for successful sends and receives.
* Fetch Gnosis token receives that are stored as `effects.to`.
* Normalize Gnosis multisig and token addresses before querying and streaming history.
* Add regression coverage for failed token sends and Gnosis token send/receive history.

### Testing Notes

Run the bitcore-node unit tests from the package directory:

```sh
cd packages/bitcore-node
npm run test:unit
```

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.