### PR TITLE
.agents and .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules/
 .zed
 coverage
 .nyc_output
+.agents
+.claude
 
 # VIM ignore
 [._]*.s[a-w][a-z]


### PR DESCRIPTION
### Description
Add .agents and .claude to .gitignore. The .agents folder is for skills: https://agentskills.io/home.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.