### PR TITLE
[BWS] Feat: security updates for Transak

### DIFF
--- a/packages/bitcore-wallet-service/bws.example.config.js
+++ b/packages/bitcore-wallet-service/bws.example.config.js
@@ -325,7 +325,7 @@ module.exports = {
   //     publicKey: 'simplex_web_public_key_here',
   //   }
   // },
-  // thorswap : {
+  // thorswap: {
   //   sandbox: {
   //     api: 'https://dev-api.thorswap.net',
   //     apiKey: 'thorswap_sandbox_api_key_here',
@@ -339,7 +339,7 @@ module.exports = {
   //     referer: 'thorswap_production_referer_here'
   //   },
   // },
-  // transak : {
+  // transak: {
   //   sandbox: {
   //     api: 'https://api-stg.transak.com',
   //     widgetApi: 'https://api-gateway-stg.transak.com',
@@ -363,7 +363,8 @@ module.exports = {
   //     widgetApi: 'https://api-gateway.transak.com',
   //     apiKey: 'transak_production_web_api_key_here',
   //     secretKey: 'transak_production_web_secret_key_here',
-  //   }
+  //   },
+  //   whitelist: []
   // },
   // wyre: {
   //   sandbox: {

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -400,7 +400,7 @@ const Config = (): any => {
     //     publicKey: 'simplex_web_public_key_here',
     //   }
     // },
-    // thorswap : {
+    // thorswap: {
     //   sandbox: {
     //     api: 'https://dev-api.thorswap.net',
     //     apiKey: 'thorswap_sandbox_api_key_here',
@@ -414,7 +414,7 @@ const Config = (): any => {
     //     referer: 'thorswap_production_referer_here'
     //   },
     // },
-    // transak : {
+    // transak: {
     //   sandbox: {
     //     api: 'https://api-stg.transak.com',
     //     widgetApi: 'https://global-stg.transak.com',
@@ -438,7 +438,8 @@ const Config = (): any => {
     //     widgetApi: 'https://global.transak.com',
     //     apiKey: 'transak_production_web_api_key_here',
     //     secretKey: 'transak_production_web_secret_key_here',
-    //   }
+    //   },
+    //   whitelist: []
     // },
     // wyre: {
     //   sandbox: {

--- a/packages/bitcore-wallet-service/src/externalservices/transak.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/transak.ts
@@ -1,5 +1,6 @@
 import * as request from 'request';
 import config from '../config';
+import { Utils } from '../lib/common/utils';
 import { ClientError } from '../lib/errors/clienterror';
 import { checkRequired } from '../lib/server';
 
@@ -50,6 +51,8 @@ export class TransakService {
       const headers = {
         'Content-Type': 'application/json',
         'api-secret': SECRET_KEY,
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const body = {
@@ -85,10 +88,13 @@ export class TransakService {
         return reject(err);
       }
       const API = keys.API;
+      const API_KEY = keys.API_KEY;
 
       const headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const URL: string = API + '/api/v2/currencies/crypto-currencies';
@@ -124,6 +130,8 @@ export class TransakService {
       const headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const URL: string = API + `/api/v2/currencies/fiat-currencies?apiKey=${API_KEY}`;
@@ -162,6 +170,8 @@ export class TransakService {
 
       const headers = {
         Accept: 'application/json',
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const qs: string[] = [];
@@ -227,6 +237,8 @@ export class TransakService {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'access-token': req.body.accessToken,
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const body = {
@@ -266,6 +278,7 @@ export class TransakService {
         return reject(err);
       }
       const API = keys.API;
+      const API_KEY = keys.API_KEY;
 
       if (!checkRequired(req.body, ['orderId', 'accessToken'])) {
         return reject(new ClientError("Transak's request missing arguments"));
@@ -274,6 +287,8 @@ export class TransakService {
       const headers = {
         Accept: 'application/json',
         'access-token': req.body.accessToken,
+        'x-api-key': API_KEY,
+        'x-user-ip': Utils.getIpFromReq(req),
       };
 
       const URL: string = API + `/partners/api/v2/order/${req.body.orderId}`;

--- a/packages/bitcore-wallet-service/src/lib/routes/services.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/services.ts
@@ -1,5 +1,7 @@
+import cors from 'cors';
 import express from 'express';
 import rp from 'request-promise-native';
+import config from '../../config';
 import { Common } from '../common';
 import type * as Types from '../../types/expressapp';
 import type { WalletService } from '../server';
@@ -64,6 +66,20 @@ function respondWithAuthServer(req, res, context: RouteContext, handler: RouteHa
 
 export function registerServiceRoutes(router: express.Router, context: RouteContext) {
   const { getServerWithAuth, setPublicCache, returnError } = context;
+
+  const transakCorsOptions = {
+    origin: (origin, cb) => {
+      if (!origin) {
+        return cb(null, true);
+      }
+      const transakWhiteList = config.transak?.whitelist ?? [];
+      if (transakWhiteList.indexOf(origin) !== -1) {
+        cb(null, true);
+      } else {
+        cb(new Error('Not allowed by CORS'));
+      }
+    }
+  };
 
   router.get('/latest-version', async (req, res) => {
     setPublicCache(res, 10 * ONE_MINUTE);
@@ -420,37 +436,37 @@ export function registerServiceRoutes(router: express.Router, context: RouteCont
     });
   });
 
-  router.post('/v1/service/transak/getAccessToken', (req, res) => {
+  router.post('/v1/service/transak/getAccessToken', cors(transakCorsOptions), (req, res) => {
     respondWithAuthServer(req, res, context, server => {
       return server.externalServices.transak.transakGetAccessToken(req);
     });
   });
 
-  router.post('/v1/service/transak/cryptoCurrencies', (req, res) => {
+  router.post('/v1/service/transak/cryptoCurrencies', cors(transakCorsOptions), (req, res) => {
     respondWithPublicServer(req, res, context, server => {
       return server.externalServices.transak.transakGetCryptoCurrencies(req);
     });
   });
 
-  router.post('/v1/service/transak/fiatCurrencies', (req, res) => {
+  router.post('/v1/service/transak/fiatCurrencies', cors(transakCorsOptions), (req, res) => {
     respondWithPublicServer(req, res, context, server => {
       return server.externalServices.transak.transakGetFiatCurrencies(req);
     });
   });
 
-  router.post('/v1/service/transak/quote', (req, res) => {
+  router.post('/v1/service/transak/quote', cors(transakCorsOptions), (req, res) => {
     respondWithAuthServer(req, res, context, server => {
       return server.externalServices.transak.transakGetQuote(req);
     });
   });
 
-  router.post('/v1/service/transak/signedPaymentUrl', (req, res) => {
+  router.post('/v1/service/transak/signedPaymentUrl', cors(transakCorsOptions), (req, res) => {
     respondWithAuthServer(req, res, context, server => {
       return server.externalServices.transak.transakGetSignedPaymentUrl(req);
     });
   });
 
-  router.post('/v1/service/transak/orderDetails', (req, res) => {
+  router.post('/v1/service/transak/orderDetails', cors(transakCorsOptions), (req, res) => {
     respondWithPublicServer(req, res, context, server => {
       return server.externalServices.transak.transakGetOrderDetails(req);
     });


### PR DESCRIPTION
Description
New security features were required by Transak:

```
1. CORS protection on your APIs
Restrict any of your APIs that call Transak to your own front-end domains, and block requests from any other origin. Never use a wildcard.
Access-Control-Allow-Origin: https://YOUR_DOMAIN.com

2. Forward the end-user IP header
Send the end user's originating IP on every call to Transak's APIs, matching the IP from which the user accesses the widget. If you are behind a CDN, use its client IP header (e.g. Cloudflare's cf-connecting-ip).
x-user-ip: your.users.ip

3. Send your partner API key in the header
Send your partner API key from your backend on every call to Transak's APIs. Your key is available in the Transak Partner Dashboard.
x-api-key: your-api-key-here
```

Changelog
In this pull request, `origin` checking via CORS was added, in addition to adding the `x-user-ip` and `x-api-key` headers to all requests to Transak.