### PR TITLE
BWS: Fix XRP sendMax fee calculation

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/chain/xrp/index.ts
@@ -90,14 +90,19 @@ export class XrpChain implements IChain {
   getWalletSendMaxInfo(server, wallet, opts, cb) {
     server.getBalance({}, (err, balance) => {
       if (err) return cb(err);
-      const { availableAmount } = balance;
-      const fee = opts.feePerKb;
-      return cb(null, {
-        utxosBelowFee: 0,
-        amountBelowFee: 0,
-        amount: availableAmount - fee,
-        feePerKb: opts.feePerKb,
-        fee
+
+      server._getFeePerKb(wallet, opts, (err, feePerKb) => {
+        if (err) return cb(err);
+
+        const { availableAmount } = balance;
+        const fee = feePerKb;
+        return cb(null, {
+          utxosBelowFee: 0,
+          amountBelowFee: 0,
+          amount: availableAmount - fee,
+          feePerKb,
+          fee
+        });
       });
     });
   }

--- a/packages/bitcore-wallet-service/test/chain/xrp.test.ts
+++ b/packages/bitcore-wallet-service/test/chain/xrp.test.ts
@@ -10,6 +10,27 @@ const should = chai.should();
 const xpub = 'tpubDD7tYYerLNNm65Ez7pRjxQ2NpRHDoyRWoLWudnQ8agXjr7qs9BsPsRXk8Z6spPPJodnaY158YqeCKT5oXuZvbuNLfm1R4kXGJ2vPd9pUxDT';
 
 describe('Chain XRP', function() { 
+  describe('#getWalletSendMaxInfo', function() {
+    it('should resolve fee level before calculating sendMax amount', function(done) {
+      const server = {
+        getBalance: (_opts, cb) => cb(null, { availableAmount: 1000000 }),
+        _getFeePerKb: (_wallet, opts, cb) => {
+          opts.feeLevel.should.equal('normal');
+          return cb(null, 12);
+        }
+      };
+      const wallet = { chain: 'xrp' };
+
+      ChainService.get('xrp').getWalletSendMaxInfo(server as any, wallet as any, { feeLevel: 'normal' }, (err, info) => {
+        should.not.exist(err);
+        info.amount.should.equal(999988);
+        info.fee.should.equal(12);
+        info.feePerKb.should.equal(12);
+        done();
+      });
+    });
+  });
+
   describe('#getBitcoreTx', function() {
     it('should create a valid bitcore TX', function() {
       const txp = TxProposal.fromObj(aTXP()) as TxProposal;


### PR DESCRIPTION
### Description
Fixes XRP `sendMax` fee calculation in BWS.

The XRP sendMax path calculates the sweepable amount as the wallet’s available balance minus the network fee, but it was relying on `opts.feePerKb` already being populated. This change resolves the fee through BWS before calculating the XRP sendMax amount.

### Changelog

* Update XRP `getWalletSendMaxInfo` to resolve fee via `_getFeePerKb`.
* Calculate XRP sendMax amount using the resolved fee.
* Add XRP chain test coverage for fee resolution before sendMax amount calculation.

### Testing Notes

Ran the XRP test suite

Also verified locally with BitPay autosweep using XRP `sendMax`: tx proposal was created, signed, broadcasted, and confirmed successful on the local XRPL node.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.