### PR TITLE
[BWS] Feat: security updates for Moonpay

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
@@ -225,6 +225,16 @@ export class MoonpayService {
     if (req.body.paymentMethod) qs.push('paymentMethod=' + encodeURIComponent(req.body.paymentMethod));
     if (req.body.areFeesIncluded) qs.push('areFeesIncluded=' + encodeURIComponent(req.body.areFeesIncluded));
 
+    const deviceIp = Utils.getIpFromReq(req);
+    if (!deviceIp) {
+      throw new ClientError('Could not determine device IP address');
+    }
+    const allowedIpAddress: string = Bitcore.crypto.Hash.sha256hmac(
+      Buffer.from(deviceIp),
+      Buffer.from(SECRET_KEY)
+    ).toString('base64');
+    qs.push('allowedIpAddress=' + encodeURIComponent(allowedIpAddress));
+
     const URL_SEARCH: string = `?${qs.join('&')}`;
 
     const URLSignatureHash: string = Bitcore.crypto.Hash.sha256hmac(

--- a/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
@@ -260,7 +260,9 @@ describe('Moonpay integration', () => {
   describe('#moonpayGetSignedPaymentUrl', () => {
     beforeEach(() => {
       req = {
-        headers: {},
+        headers: {
+          'x-forwarded-for': '1.2.3.4'
+        },
         body: {
           env: 'production',
           currencyCode: 'btc',
@@ -277,7 +279,17 @@ describe('Moonpay integration', () => {
     it('should get the paymentUrl properly if req is OK', () => {
       const data = server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
       should.exist(data.urlWithSignature);
-      data.urlWithSignature.should.equal('widgetApi2?apiKey=apiKey2&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&signature=%2FDnbsboySgE%2FeAvMrwzROCLuuctkhgw5C2t2OofjOzo%3D');
+      data.urlWithSignature.should.equal('widgetApi2?apiKey=apiKey2&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&allowedIpAddress=CN35SFB5PKS4vkiZ4CglTxRgTAaUHBLGZcenAw6gHEY%3D&signature=3XxjRX3EMj2RNaoAwgOwFBOiVTXsgAS7C50uJf9SsvM%3D');
+    });
+
+    it('should return error if request does not have IP', () => {
+      delete req.headers['x-forwarded-for'];
+      try {
+        server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Could not determine device IP address');
+      }
     });
 
     it('should return error if there is some missing arguments', () => {


### PR DESCRIPTION
Description
New security features were required by Moonpay:

> We've introduced an allowedIpAddress parameter as part of your widget URL signing. When set, MoonPay validates that the user opening the widget is on the same IP that was signed, adding a layer of protection against session hijacking and unauthorized routing through intermediary servers.

Changelog
This PR includes the hashed user's IP address within the URL we generated for the Moonpay on-ramp checkout.