### PR TITLE
[BWS] Skip in-flight nonces when preparing deferred txps

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/common/defaults.ts
+++ b/packages/bitcore-wallet-service/src/lib/common/defaults.ts
@@ -19,6 +19,9 @@ export const Defaults = {
   // TODO: should allow different gap sizes for external/internal chains
   SCAN_ADDRESS_GAP: 30,
 
+  // Lookback window (in seconds) for scanning broadcasted txps during nonce assignment
+  BROADCASTED_NONCE_SCAN_WINDOW: 24 * 3600,
+
   FEE_LEVELS: {
     btc: [
       {

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3360,6 +3360,19 @@ export class WalletService implements IWalletService {
                   return cb(Errors.TX_NONCE_CONFLICT);
                 }
               }
+              // A deferred txp matching a broadcasted txp's nonce means its JIT-assigned
+              // value went stale. Non-deferred txps may reuse an in-flight nonce
+              // intentionally (e.g. speed-up).
+              if (txp.nonce != null && txp.deferNonce) {
+                const broadcastedTxps = await util.promisify(this.storage.fetchBroadcastedTxs).call(this.storage, this.walletId, {
+                  minTs: Math.floor(Date.now() / 1000) - Defaults.BROADCASTED_NONCE_SCAN_WINDOW
+                });
+                for (const t of broadcastedTxps || []) {
+                  if (t.id !== txp.id && t.nonce != null && Number(t.nonce) === Number(txp.nonce)) {
+                    return cb(Errors.TX_NONCE_CONFLICT);
+                  }
+                }
+              }
             } catch (err) {
               return cb(err);
             }
@@ -3488,9 +3501,18 @@ export class WalletService implements IWalletService {
               .filter(t => t.id !== txp.id && t.nonce != null && t.status !== 'rejected')
               .map(t => Number(t.nonce));
 
+            // 2b. Broadcasted-but-unmined txps still occupy their nonces but appear in
+            // neither the confirmed count nor the pending set
+            const broadcastedTxps = await util.promisify(this.storage.fetchBroadcastedTxs).call(this.storage, this.walletId, {
+              minTs: Math.floor(Date.now() / 1000) - Defaults.BROADCASTED_NONCE_SCAN_WINDOW
+            });
+            const inFlightNonces = (broadcastedTxps || [])
+              .filter(t => t.nonce != null && Number(t.nonce) >= Number(confirmedNonce))
+              .map(t => Number(t.nonce));
+
             // 3. Calculate gap-free nonce
             let suggestedNonce = Number(confirmedNonce);
-            const allNonces = pendingNonces.sort((a, b) => a - b);
+            const allNonces = [...pendingNonces, ...inFlightNonces].sort((a, b) => a - b);
             for (const n of allNonces) {
               if (n === suggestedNonce) {
                 suggestedNonce++;

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -8115,6 +8115,144 @@ describe('Wallet service', function() {
       assignedNonces.should.deep.equal([10, 11, 12]);
     });
 
+    async function prepareSignAndBroadcast(txp) {
+      const withNonce = await util.promisify(server.prepareTx).call(server, { txProposalId: txp.id });
+      const fetched = await util.promisify(server.getTx).call(server, { txProposalId: txp.id });
+      const signatures = helpers.clientSign(fetched, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      const signed = await util.promisify(server.signTx).call(server, { txProposalId: txp.id, signatures });
+      helpers.stubBroadcast(signed.txid);
+      const broadcasted = await util.promisify(server.broadcastTx).call(server, { txProposalId: txp.id });
+      broadcasted.status.should.equal('broadcasted');
+      return withNonce;
+    }
+
+    it('should not reuse the nonce of a broadcasted-but-unmined txp', async function() {
+      // Chain count stays at 10 for the whole test: txp1 is broadcast but never mined
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const txp1 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 1000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared1 = await prepareSignAndBroadcast(txp1);
+      prepared1.nonce.should.equal(10);
+
+      const txp2 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 2000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared2 = await util.promisify(server.prepareTx).call(server, { txProposalId: txp2.id });
+      prepared2.nonce.should.equal(11);
+    });
+
+    it('should assign sequential nonces when each txp is broadcast before the next is prepared', async function() {
+      // Bulk payout flow: full prepare -> sign -> broadcast per txp, no block mined in between
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const assignedNonces = [];
+      for (let i = 0; i < 3; i++) {
+        const txp = await helpers.createAndPublishTx(server, {
+          outputs: [{ toAddress: ETH_ADDR, amount: 1000 * (i + 1) }],
+          feePerKb: 123e2,
+          from: fromAddr,
+          deferNonce: true
+        }, TestData.copayers[0].privKey_1H_0);
+        const prepared = await prepareSignAndBroadcast(txp);
+        assignedNonces.push(prepared.nonce);
+      }
+
+      assignedNonces.should.deep.equal([10, 11, 12]);
+    });
+
+    it('should not skip nonces of broadcasted txps already counted by the chain', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const txp1 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 1000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared1 = await prepareSignAndBroadcast(txp1);
+      prepared1.nonce.should.equal(10);
+
+      // txp1 mines: chain count advances past its nonce
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '11');
+
+      const txp2 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 2000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared2 = await util.promisify(server.prepareTx).call(server, { txProposalId: txp2.id });
+      prepared2.nonce.should.equal(11);
+    });
+
+    it('should reject signing a deferred txp whose nonce collides with a broadcasted-but-unmined txp', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const txp1 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 1000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared1 = await prepareSignAndBroadcast(txp1);
+      prepared1.nonce.should.equal(10);
+
+      const txp2 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 2000 }],
+        feePerKb: 123e2,
+        from: fromAddr,
+        deferNonce: true
+      }, TestData.copayers[0].privKey_1H_0);
+      const prepared2 = await util.promisify(server.prepareTx).call(server, { txProposalId: txp2.id });
+      prepared2.nonce.should.equal(11);
+
+      // Client signs with a stale nonce override that duplicates txp1's in-flight nonce
+      const fetched = await util.promisify(server.getTx).call(server, { txProposalId: txp2.id });
+      const signatures = helpers.clientSign(fetched, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      try {
+        await util.promisify(server.signTx).call(server, { txProposalId: txp2.id, signatures, nonce: 10 });
+        throw new Error('should have thrown');
+      } catch (err) {
+        err.should.be.instanceof(ClientError);
+        err.code.should.equal('TX_NONCE_CONFLICT');
+      }
+    });
+
+    it('should allow signing a non-deferred txp that reuses an in-flight nonce (speed-up/replacement)', async function() {
+      blockchainExplorer.getTransactionCount = sinon.stub().callsArgWith(1, null, '10');
+
+      const txp1 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 1000 }],
+        feePerKb: 123e2,
+        from: fromAddr
+      }, TestData.copayers[0].privKey_1H_0);
+      txp1.nonce.should.equal('10');
+      const sigs1 = helpers.clientSign(txp1, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      const signed1 = await util.promisify(server.signTx).call(server, { txProposalId: txp1.id, signatures: sigs1 });
+      helpers.stubBroadcast(signed1.txid);
+      await util.promisify(server.broadcastTx).call(server, { txProposalId: txp1.id });
+
+      // Replacement txp deliberately reuses nonce 10 (e.g. app speedupEth flow)
+      const txp2 = await helpers.createAndPublishTx(server, {
+        outputs: [{ toAddress: ETH_ADDR, amount: 1000 }],
+        feePerKb: 246e2,
+        from: fromAddr
+      }, TestData.copayers[0].privKey_1H_0);
+      txp2.nonce.should.equal('10');
+
+      const sigs2 = helpers.clientSign(txp2, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      const signed2 = await util.promisify(server.signTx).call(server, { txProposalId: txp2.id, signatures: sigs2 });
+      signed2.status.should.equal('accepted');
+    });
+
     it('should return txp with nonce set (extensibility baseline)', async function() {
       const txp = await helpers.createAndPublishTx(server, {
         outputs: [{ toAddress: ETH_ADDR, amount: 8000 }],


### PR DESCRIPTION
### Description
Broadcasted-but-unmined txps weren't counted when `prepareTx` assigns a nonce: they're not in the confirmed tx count and no longer pending. So bulk signing deferred txps reused the same nonce until the previous tx mined.

### Changelog

* Scan broadcasted txps in `_prepareTx` and skip any nonce at or above the confirmed count
* Reject signing a deferred txp whose nonce matches a broadcasted txp. Non-deferred txps with an explicit nonce can still be signed, so speed-up replacements keep working
* Add integration tests for the broadcast window, the bulk sign flow, and the speed-up case

### Testing Notes

1. Create multiple EVM payouts. 
2. In the app, open the pending proposals for the ops wallet, select them all and hit Sign selected. 
3. Each proposal should broadcast with an incrementing nonce. 

Before this fix, every proposal after the first reused the same nonce unless the previous tx had already mined, so only one of them would confirm.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
* [x] I have added the appropriate package tag(s) (e.g. `BWC` if modifying the bitcore-wallet-client package, `CLI` if modifying the bitcore-cli package, etc.)
* [x] I have verified that this is not an existing PR ([open](https://github.com/bitpay/bitcore/pulls) or [closed](https://github.com/bitpay/bitcore/pulls?q=is%3Apr+is%3Aclosed+))