### PR TITLE
[BCN] fix gnosis token history casing gap and return 400 for invalid ethmultisig addresses

### DIFF
--- a/packages/bitcore-node/src/providers/chain-state/evm/api/gnosis.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/gnosis.ts
@@ -160,6 +160,10 @@ export class GnosisApi {
     const transactionQuery = getCSP(chain, network).getWalletTransactionQuery(params);
     delete transactionQuery.wallets;
     delete transactionQuery['wallets.0'];
+    // effects.* addresses were stored raw (lowercase) until 1df63364f and were
+    // never backfilled (fixEvmTxToFromAddressesCase.js only rewrites top-level
+    // to/from), so match either casing
+    const eitherCase = (address: string) => ({ $in: [address, address.toLowerCase()] });
     let query;
     if (tokenAddress) {
       query = {
@@ -176,13 +180,13 @@ export class GnosisApi {
           },
           {
             ...transactionQuery,
-            'effects.contractAddress': tokenAddress,
-            'effects.from': normalizedMultisigContractAddress
+            'effects.contractAddress': eitherCase(tokenAddress),
+            'effects.from': eitherCase(normalizedMultisigContractAddress)
           },
           {
             ...transactionQuery,
-            'effects.contractAddress': tokenAddress,
-            'effects.to': normalizedMultisigContractAddress
+            'effects.contractAddress': eitherCase(tokenAddress),
+            'effects.to': eitherCase(normalizedMultisigContractAddress)
           }
         ]
       };
@@ -191,7 +195,7 @@ export class GnosisApi {
         $or: [
           { ...transactionQuery, to: normalizedMultisigContractAddress },
           { ...transactionQuery, 'internal.action.to': normalizedMultisigContractAddress.toLowerCase() },
-          { ...transactionQuery, 'effects.to': normalizedMultisigContractAddress }
+          { ...transactionQuery, 'effects.to': eitherCase(normalizedMultisigContractAddress) }
         ]
       };
     }

--- a/packages/bitcore-node/src/providers/chain-state/evm/api/routes.ts
+++ b/packages/bitcore-node/src/providers/chain-state/evm/api/routes.ts
@@ -238,6 +238,15 @@ export class EVMRouter {
   private streamGnosisWalletTransactions(router: Router) { 
     router.get(`/api/${this.chain}/:network/ethmultisig/transactions/:multisigContractAddress`, async (req, res) => {
       const { network, multisigContractAddress } = req.params;
+      const { tokenAddress } = req.query;
+      // Validate and return a helpful 400 before toChecksumAddress throws downstream (which
+      // would surface as a 500). isAddress(x, false) accepts exactly what toChecksumAddress accepts.
+      if (!Web3.utils.isAddress(multisigContractAddress, false)) {
+        return res.status(400).send('Invalid multisig contract address');
+      }
+      if (tokenAddress !== undefined && (typeof tokenAddress !== 'string' || !Web3.utils.isAddress(tokenAddress, false))) {
+        return res.status(400).send('Invalid token address');
+      }
       try {
         return await Gnosis.streamGnosisWalletTransactions({
           chain: this.chain,

--- a/packages/bitcore-node/test/unit/models/transaction.test.ts
+++ b/packages/bitcore-node/test/unit/models/transaction.test.ts
@@ -504,8 +504,8 @@ describe('Transaction Model', function() {
         expect(findQuery.$or).to.deep.include({
           chain: 'ETH',
           network: 'mainnet',
-          'effects.contractAddress': gnosisBusdToken,
-          'effects.to': gnosisMultisigContractAddress
+          'effects.contractAddress': { $in: [gnosisBusdToken, gnosisBusdToken.toLowerCase()] },
+          'effects.to': { $in: [gnosisMultisigContractAddress, gnosisMultisigContractAddress.toLowerCase()] }
         });
       });
 
@@ -528,8 +528,8 @@ describe('Transaction Model', function() {
         expect(findQuery.$or).to.deep.include({
           chain: 'ETH',
           network: 'mainnet',
-          'effects.contractAddress': gnosisBusdToken,
-          'effects.to': gnosisMultisigContractAddress
+          'effects.contractAddress': { $in: [gnosisBusdToken, gnosisBusdToken.toLowerCase()] },
+          'effects.to': { $in: [gnosisMultisigContractAddress, gnosisMultisigContractAddress.toLowerCase()] }
         });
       });
 


### PR DESCRIPTION
### Description

Two fixes for Gnosis multisig token history:

1. The transaction query matches `effects.*` addresses case-sensitively against checksummed values, but effect addresses weren't checksummed at ingestion until 1df63364f, and `effects.*` was never backfilled (`fixEvmTxToFromAddressesCase.js` only rewrites top-level `to`/`from`). Docs synced before then store lowercase effect addresses, so the query silently drops them before the case-insensitive matching from [#4186](https://github.com/bitpay/bitcore/pull/4186#issuecomment-4712660189) can see them. The query now accepts both casings.
2. Since #4186, a malformed request address makes `toChecksumAddress` throw and the endpoint returns a 500 (previously an empty 200). It now returns a 400.

### Changelog

* Match both casings for `effects.contractAddress`, `effects.from`, and `effects.to` in the Gnosis transaction query via `$in` (still uses the existing indexes).
* Return a 400 for invalid addresses on `/ethmultisig/transactions/:multisigContractAddress`, validating with the same validation logic as `toChecksumAddress`.
* Update the Gnosis unit test query assertions to match.

### Testing Notes

* `cd packages/bitcore-node && npm run test:unit` — the "EVM token wallet history filtering" suite covers both the query shape and row emission. On Node below 22.12, run with `NODE_OPTIONS=--experimental-require-module`.
* `GET /api/ETH/mainnet/ethmultisig/transactions/notanaddress` returns 400 (previously 500); valid addresses in either casing stream normally.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
