### PR TITLE
Fix no txps in CLI command mode

### DIFF
--- a/packages/bitcore-cli/src/commands/txproposals.ts
+++ b/packages/bitcore-cli/src/commands/txproposals.ts
@@ -91,8 +91,10 @@ export async function getTxProposals(
     txp = txps[i];
 
     if (!txp) {
-      prompt.log.info('No more proposals');
-      return { result: [], hasNextPage: false, hasPrevPage: page > 1 };
+      !printRaw && prompt.log.info('No more proposals');
+      return opts.command
+        ? {} // Don't wait for user input in CLI mode
+        : { result: [], hasNextPage: false, hasPrevPage: page > 1 };
     }
 
     const hasNextPage = page < txps.length;


### PR DESCRIPTION
### Description
Running `--command txproposals --page 2` prompts for user input.

### Changelog

* Return {} if in command mode
* Makes `--raw` return nothing if there are no txps

### Testing Notes
* Running `bitcore-cli <name> --command txproposals --page 2` should not prompt for user input (no pending txps required).
* Running `bitcore-cli <name> --command txproposals --raw` should not output anything (assuming no pending txps. If there are, you can use the `--page` opt to get to a response with no txp).

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.