### PR TITLE
Change default number format from hex to number

### DIFF
--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -46,6 +46,8 @@ for (const network in NetworkChar) { // invert NetworkChar
   NetworkChar[NetworkChar[network]] = network;
 }
 
+const defaultNumberFormat = 'number'; // 'number' | 'string' | 'hex'
+
 const BASE_URL = 'http://localhost:3232/bws/api';
 
 export class API extends EventEmitter {
@@ -1400,7 +1402,7 @@ export class API extends EventEmitter {
       qs.push(`includeExtendedInfo=${opts.includeExtendedInfo ? '1' : '0'}`);
       qs.push(`twoStep=${opts.twoStep ? '1' : '0'}`);
       qs.push('serverMessageArray=1');
-      qs.push('numberFormat=hex'); // Only applies to `pendingTxps` in response. TODO apply this to balances as well.
+      qs.push('numberFormat=' + defaultNumberFormat); // Only applies to `pendingTxps` in response. TODO apply this to balances as well.
 
       if (opts.tokenAddress) {
         qs.push('tokenAddress=' + opts.tokenAddress);
@@ -1732,7 +1734,7 @@ export class API extends EventEmitter {
       const args = {
         proposalSignature: Utils.signMessage(hash, this.credentials.requestPrivKey)
       };
-      const qs = `numberFormat=${opts.numberFormat || 'hex'}`;
+      const qs = `numberFormat=${opts.numberFormat || defaultNumberFormat}`;
 
       const url = `/v2/txproposals/${opts.txp.id}/publish?${qs}`;
       const { body: txp } = await this.request.post<object, PublishedTxp>(url, args);
@@ -1937,7 +1939,7 @@ export class API extends EventEmitter {
 
       opts = opts || {};
       const { doNotVerify, forAirGapped, doNotEncryptPkr } = opts;
-      const qs = `numberFormat=${opts.numberFormat || 'hex'}`;
+      const qs = `numberFormat=${opts.numberFormat || defaultNumberFormat}`;
 
       const { body: txps } = await this.request.get(`/v2/txproposals?${qs}`);
       this._processTxps(txps);

--- a/packages/bitcore-wallet-client/test/api.test.ts
+++ b/packages/bitcore-wallet-client/test/api.test.ts
@@ -5451,8 +5451,8 @@ describe('client API', function() {
             txp.outputs[0].message.should.equal('output 0');
             txp.message.should.equal('hello');
             txp.txType.should.equal(2);
-            txp.maxGasFee.should.equal('0x4e20'); // 20000
-            txp.priorityGasFee.should.equal('0x1388'); // 5000
+            txp.maxGasFee.should.equal(20000); // 0x4e20
+            txp.priorityGasFee.should.equal(5000); // 0x1388
             const signatures = await keys[0].sign(clients[0].getRootPath(), txp);
             clients[0].pushSignatures(txp, signatures, (err, txp) => {
               should.not.exist(err);


### PR DESCRIPTION
### Description
Current default number format is hex which needs some further refinement

### Changelog

* Changes default numberFormat from 'hex' to 'number'

### Testing Notes
Add any helpful notes for reviewers to test your code here.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.