### PR TITLE
[BWS] Fix: Ramp Network signed payment url params update

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/ramp.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/ramp.ts
@@ -112,14 +112,13 @@ export class RampService {
     const webRequiredParams = [
       'selectedCountryCode',
     ];
-    const appRequiredParams = [
+    let appRequiredParams = [
       'enabledFlows',
       'defaultFlow',
       'selectedCountryCode',
-      'defaultAsset',
     ];
-    const extraRequiredParams = req.body.flow && req.body.flow === 'sell' ? ['offrampAsset'] : ['finalUrl', 'userAddress', 'swapAmount', 'swapAsset'];
-    appRequiredParams.concat(extraRequiredParams);
+    const extraRequiredParams = req.body.flow && req.body.flow === 'sell' ? [] : ['finalUrl', 'userAddress'];
+    appRequiredParams = appRequiredParams.concat(extraRequiredParams);
 
     const requiredParams = req.body.context === 'web' ? webRequiredParams : appRequiredParams;
     const keys = this.rampGetKeys(req);
@@ -138,21 +137,42 @@ export class RampService {
     qs.push('selectedCountryCode=' + encodeURIComponent(req.body.selectedCountryCode));
     if (req.body.finalUrl) qs.push('finalUrl=' + encodeURIComponent(req.body.finalUrl));
     if (req.body.userAddress) qs.push('userAddress=' + encodeURIComponent(req.body.userAddress));
-    if (req.body.swapAsset) qs.push('swapAsset=' + encodeURIComponent(req.body.swapAsset));
-    if (req.body.offrampAsset) qs.push('offrampAsset=' + encodeURIComponent(req.body.offrampAsset));
     if (req.body.enabledFlows) qs.push('enabledFlows=' + encodeURIComponent(req.body.enabledFlows));
     if (req.body.defaultFlow) qs.push('defaultFlow=' + encodeURIComponent(req.body.defaultFlow));
     if (req.body.hostLogoUrl) qs.push('hostLogoUrl=' + encodeURIComponent(req.body.hostLogoUrl));
     if (req.body.hostAppName) qs.push('hostAppName=' + encodeURIComponent(req.body.hostAppName));
-    if (req.body.swapAmount) qs.push('swapAmount=' + encodeURIComponent(req.body.swapAmount));
-    if (req.body.fiatValue) qs.push('fiatValue=' + encodeURIComponent(req.body.fiatValue));
-    if (req.body.fiatCurrency) qs.push('fiatCurrency=' + encodeURIComponent(req.body.fiatCurrency));
-    if (req.body.defaultAsset) qs.push('defaultAsset=' + encodeURIComponent(req.body.defaultAsset));
     if (req.body.userEmailAddress) qs.push('userEmailAddress=' + encodeURIComponent(req.body.userEmailAddress));
     if (req.body.useSendCryptoCallback) qs.push('useSendCryptoCallback=' + encodeURIComponent(req.body.useSendCryptoCallback));
     if (req.body.paymentMethodType) qs.push('paymentMethodType=' + encodeURIComponent(req.body.paymentMethodType));
     if (req.body.hideExitButton) qs.push('hideExitButton=' + encodeURIComponent(req.body.hideExitButton));
-    if (req.body.useSendCryptoCallbackVersion) qs.push('useSendCryptoCallbackVersion=' + encodeURIComponent(req.body.useSendCryptoCallbackVersion));
+
+    // Ramp deprecated the legacy per-flow search params in favor of a unified format.
+    // Ref: https://docs.rampnetwork.com/search-params-migration
+    // Older app versions still send the legacy fields, so we translate them into the new
+    // unified params here to keep those requests working going forward.
+    // `flow === 'sell'` => OFFRAMP; otherwise => ONRAMP.
+    // If a newer client already sends the new params, those take precedence.
+    const isOfframp = req.body.flow === 'sell';
+
+    // enabledCryptoAssets <- swapAsset (onramp) / offrampAsset (offramp)
+    const enabledCryptoAssets = req.body.enabledCryptoAssets ?? (isOfframp ? req.body.offrampAsset : req.body.swapAsset);
+    if (enabledCryptoAssets) qs.push('enabledCryptoAssets=' + encodeURIComponent(enabledCryptoAssets));
+
+    // inAsset (incoming, paid by the user) <- fiatCurrency (onramp) / defaultAsset (offramp)
+    const inAsset = req.body.inAsset ?? (isOfframp ? req.body.defaultAsset : req.body.fiatCurrency);
+    if (inAsset) qs.push('inAsset=' + encodeURIComponent(inAsset));
+
+    // outAsset (outgoing, received by the user) <- defaultAsset (onramp) / fiatCurrency (offramp)
+    const outAsset = req.body.outAsset ?? (isOfframp ? req.body.fiatCurrency : req.body.defaultAsset);
+    if (outAsset) qs.push('outAsset=' + encodeURIComponent(outAsset));
+
+    // inAssetValue (units, no decimals) <- fiatValue (onramp) / swapAmount (offramp)
+    const inAssetValue = req.body.inAssetValue ?? (isOfframp ? req.body.swapAmount : req.body.fiatValue);
+    if (inAssetValue) qs.push('inAssetValue=' + encodeURIComponent(inAssetValue));
+
+    // outAssetValue (units, no decimals) <- swapAmount (onramp) / fiatValue (offramp)
+    const outAssetValue = req.body.outAssetValue ?? (isOfframp ? req.body.fiatValue : req.body.swapAmount);
+    if (outAssetValue) qs.push('outAssetValue=' + encodeURIComponent(outAssetValue));
 
     const queryString = qs.join('&');
 

--- a/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
@@ -223,7 +223,28 @@ describe('Ramp integration', () => {
       server.externalServices.ramp.request = fakeRequest;
     });
 
-    it('should get the paymentUrl properly if req is OK', () => {
+    // ONRAMP (buy) - legacy params sent by older app versions.
+    // The service must translate them into Ramp's new unified search params:
+    //   swapAsset    -> enabledCryptoAssets
+    //   defaultAsset -> outAsset
+    //   swapAmount   -> outAssetValue
+    //   fiatCurrency -> inAsset
+    //   fiatValue    -> inAssetValue
+    it('should get the paymentUrl properly with legacy onramp params', () => {
+      req.body = {
+        env: 'production',
+        flow: 'buy',
+        swapAsset: 'BTC_BTC',
+        swapAmount: '1000000',
+        defaultAsset: 'BTC_BTC',
+        fiatCurrency: 'USD',
+        fiatValue: 50,
+        enabledFlows: 'ONRAMP',
+        defaultFlow: 'ONRAMP',
+        userAddress: 'bitcoin:123123',
+        selectedCountryCode: 'US',
+        finalUrl: 'bitpay://ramp',
+      };
       const data = server.externalServices.ramp.rampGetSignedPaymentUrl(req);
       should.exist(data.urlWithSignature);
       const [base, qs] = data.urlWithSignature.split('?');
@@ -235,11 +256,65 @@ describe('Ramp integration', () => {
       params.selectedCountryCode.should.equal('US');
       params.finalUrl.should.equal('bitpay://ramp');
       params.userAddress.should.equal('bitcoin:123123');
-      params.swapAsset.should.equal('BTC_BTC');
       params.enabledFlows.should.equal('ONRAMP');
       params.defaultFlow.should.equal('ONRAMP');
-      params.swapAmount.should.equal('1000000');
-      params.defaultAsset.should.equal('BTC_BTC');
+
+      // legacy fields must be translated into the new unified params
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.outAsset.should.equal('BTC_BTC');
+      params.outAssetValue.should.equal('1000000');
+      params.inAsset.should.equal('USD');
+      params.inAssetValue.should.equal('50');
+
+      // legacy fields must NOT be forwarded to Ramp
+      should.not.exist(params.swapAsset);
+      should.not.exist(params.swapAmount);
+      should.not.exist(params.defaultAsset);
+      should.not.exist(params.fiatCurrency);
+      should.not.exist(params.fiatValue);
+
+      // timestamp must exist and be numeric
+      params.timestamp.should.match(/^\d+$/);
+
+      // signature must exist and not be empty
+      params.signature.should.be.a('string').and.not.equal('');
+    });
+
+    // ONRAMP (buy) - new unified params sent by newer app versions.
+    // They must be forwarded as-is.
+    it('should get the paymentUrl properly with new onramp params', () => {
+      req.body = {
+        env: 'production',
+        flow: 'buy',
+        enabledCryptoAssets: 'BTC_BTC',
+        outAsset: 'BTC_BTC',
+        outAssetValue: '1000000',
+        inAsset: 'USD',
+        inAssetValue: 50,
+        enabledFlows: 'ONRAMP',
+        defaultFlow: 'ONRAMP',
+        userAddress: 'bitcoin:123123',
+        selectedCountryCode: 'US',
+        finalUrl: 'bitpay://ramp',
+      };
+      const data = server.externalServices.ramp.rampGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      const [base, qs] = data.urlWithSignature.split('?');
+
+      base.should.equal('widgetApi2');
+
+      const params = Object.fromEntries(new URLSearchParams(qs));
+      params.hostApiKey.should.equal('apiKey2');
+      params.selectedCountryCode.should.equal('US');
+      params.finalUrl.should.equal('bitpay://ramp');
+      params.userAddress.should.equal('bitcoin:123123');
+      params.enabledFlows.should.equal('ONRAMP');
+      params.defaultFlow.should.equal('ONRAMP');
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.outAsset.should.equal('BTC_BTC');
+      params.outAssetValue.should.equal('1000000');
+      params.inAsset.should.equal('USD');
+      params.inAssetValue.should.equal('50');
 
       // timestamp must exist and be numeric
       params.timestamp.should.match(/^\d+$/);
@@ -269,8 +344,8 @@ describe('Ramp integration', () => {
       params.selectedCountryCode.should.equal('US');
       params.finalUrl.should.equal('bitpay://ramp');
       params.userAddress.should.equal('bitcoin:123123');
-      params.swapAsset.should.equal('BTC_BTC');
-      params.defaultAsset.should.equal('BTC_BTC');
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.outAsset.should.equal('BTC_BTC');
 
       // timestamp must exist and be numeric
       params.timestamp.should.match(/^\d+$/);
@@ -280,7 +355,7 @@ describe('Ramp integration', () => {
     });
 
     it('should return error if there is some missing arguments', () => {
-      delete req.body.defaultAsset;
+      delete req.body.selectedCountryCode;
       try {
         server.externalServices.ramp.rampGetSignedPaymentUrl(req);
         should.fail('should have thrown');
@@ -300,18 +375,26 @@ describe('Ramp integration', () => {
       }
     });
 
-    it('should get the sell paymentUrl properly if req is OK', () => {
+    // OFFRAMP (sell) - legacy params sent by older app versions.
+    // The service must translate them into Ramp's new unified search params:
+    //   offrampAsset -> enabledCryptoAssets
+    //   defaultAsset -> inAsset
+    //   swapAmount   -> inAssetValue
+    //   fiatCurrency -> outAsset
+    //   fiatValue    -> outAssetValue
+    it('should get the sell paymentUrl properly with legacy offramp params', () => {
       req.body = {
         env: 'production',
         flow: 'sell',
         offrampAsset: 'BTC_BTC',
         swapAmount: '1000000',
+        defaultAsset: 'BTC_BTC',
+        fiatCurrency: 'USD',
+        fiatValue: 50,
         enabledFlows: 'OFFRAMP',
         defaultFlow: 'OFFRAMP',
         selectedCountryCode: 'US',
-        defaultAsset: 'BTC_BTC',
         useSendCryptoCallback: true,
-        useSendCryptoCallbackVersion: 1,
         hideExitButton: false,
       };
       const data = server.externalServices.ramp.rampGetSignedPaymentUrl(req);
@@ -322,13 +405,63 @@ describe('Ramp integration', () => {
       const params = Object.fromEntries(new URLSearchParams(qs));
       params.hostApiKey.should.equal('apiKey2');
       params.selectedCountryCode.should.equal('US');
-      params.offrampAsset.should.equal('BTC_BTC');
       params.enabledFlows.should.equal('OFFRAMP');
       params.defaultFlow.should.equal('OFFRAMP');
-      params.swapAmount.should.equal('1000000');
-      params.defaultAsset.should.equal('BTC_BTC');
       params.useSendCryptoCallback.should.equal('true');
-      params.useSendCryptoCallbackVersion.should.equal('1');
+
+      // legacy fields must be translated into the new unified params
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.inAsset.should.equal('BTC_BTC');
+      params.inAssetValue.should.equal('1000000');
+      params.outAsset.should.equal('USD');
+      params.outAssetValue.should.equal('50');
+
+      // legacy fields must NOT be forwarded to Ramp
+      should.not.exist(params.offrampAsset);
+      should.not.exist(params.swapAmount);
+      should.not.exist(params.defaultAsset);
+      should.not.exist(params.fiatCurrency);
+      should.not.exist(params.fiatValue);
+
+      // timestamp must exist and be numeric
+      params.timestamp.should.match(/^\d+$/);
+
+      // signature must exist and not be empty
+      params.signature.should.be.a('string').and.not.equal('');
+    });
+
+    // OFFRAMP (sell) - new unified params sent by newer app versions.
+    it('should get the sell paymentUrl properly with new offramp params', () => {
+      req.body = {
+        env: 'production',
+        flow: 'sell',
+        enabledCryptoAssets: 'BTC_BTC',
+        inAsset: 'BTC_BTC',
+        inAssetValue: '1000000',
+        outAsset: 'USD',
+        outAssetValue: 50,
+        enabledFlows: 'OFFRAMP',
+        defaultFlow: 'OFFRAMP',
+        selectedCountryCode: 'US',
+        useSendCryptoCallback: true,
+        hideExitButton: false,
+      };
+      const data = server.externalServices.ramp.rampGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      const [base, qs] = data.urlWithSignature.split('?');
+      base.should.equal('widgetApi2');
+
+      const params = Object.fromEntries(new URLSearchParams(qs));
+      params.hostApiKey.should.equal('apiKey2');
+      params.selectedCountryCode.should.equal('US');
+      params.enabledFlows.should.equal('OFFRAMP');
+      params.defaultFlow.should.equal('OFFRAMP');
+      params.useSendCryptoCallback.should.equal('true');
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.inAsset.should.equal('BTC_BTC');
+      params.inAssetValue.should.equal('1000000');
+      params.outAsset.should.equal('USD');
+      params.outAssetValue.should.equal('50');
 
       // timestamp must exist and be numeric
       params.timestamp.should.match(/^\d+$/);
@@ -344,12 +477,11 @@ describe('Ramp integration', () => {
         context: 'web',
         offrampAsset: 'BTC_BTC',
         swapAmount: '1000000',
+        defaultAsset: 'BTC_BTC',
         enabledFlows: 'OFFRAMP',
         defaultFlow: 'OFFRAMP',
         selectedCountryCode: 'US',
-        defaultAsset: 'BTC_BTC',
         useSendCryptoCallback: true,
-        useSendCryptoCallbackVersion: 1,
         hideExitButton: false,
       };
       const data = server.externalServices.ramp.rampGetSignedPaymentUrl(req);
@@ -360,13 +492,12 @@ describe('Ramp integration', () => {
       const params = Object.fromEntries(new URLSearchParams(qs));
       params.hostApiKey.should.equal('apiKey4');
       params.selectedCountryCode.should.equal('US');
-      params.offrampAsset.should.equal('BTC_BTC');
       params.enabledFlows.should.equal('OFFRAMP');
       params.defaultFlow.should.equal('OFFRAMP');
-      params.swapAmount.should.equal('1000000');
-      params.defaultAsset.should.equal('BTC_BTC');
       params.useSendCryptoCallback.should.equal('true');
-      params.useSendCryptoCallbackVersion.should.equal('1');
+      params.enabledCryptoAssets.should.equal('BTC_BTC');
+      params.inAsset.should.equal('BTC_BTC');
+      params.inAssetValue.should.equal('1000000');
 
       // timestamp must exist and be numeric
       params.timestamp.should.match(/^\d+$/);


### PR DESCRIPTION
Description
Ramp deprecated the legacy per-flow search params in favor of a unified format.
Ref: https://docs.rampnetwork.com/search-params-migration
Older app versions still send the legacy fields, so we translate them into the new unified params here to keep those requests working going forward. If a newer client already sends the new params, those take precedence.

Changelog
In this PR, the old parameters are modified for the new format, and those that are no longer supported are removed, to avoid errors in the integration. (The `useSendCryptoCallbackVersion: 1` param was removed, as it was causing errors in Offramp integration.)