### PR TITLE
fix: use forwarded deviceIp for web-context MoonPay buy payment URLs

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
@@ -190,6 +190,8 @@ export class MoonpayService {
   }
 
   moonpayGetSignedPaymentUrl(req): { urlWithSignature: string } {
+    // moonpayGetKeys deletes env/context from the body, so read context first
+    const isWebContext = req.body.context === 'web';
     const keys = this.moonpayGetKeys(req);
     const SECRET_KEY = keys.SECRET_KEY;
     const API_KEY = keys.API_KEY;
@@ -225,15 +227,28 @@ export class MoonpayService {
     if (req.body.paymentMethod) qs.push('paymentMethod=' + encodeURIComponent(req.body.paymentMethod));
     if (req.body.areFeesIncluded) qs.push('areFeesIncluded=' + encodeURIComponent(req.body.areFeesIncluded));
 
-    const deviceIp = Utils.getIpFromReq(req);
-    if (!deviceIp) {
+    // Web requests are proxied through the bitpay backend, so the IP on this
+    // request belongs to that server, not the customer. The proxy captures the
+    // customer's public IP and forwards it as deviceIp. Web credentials are only
+    // held by the proxy, so the forwarded value is trusted for that context only.
+    // If the proxy does not forward an IP, omit allowedIpAddress rather than
+    // signing an IP the customer will never match.
+    let deviceIp = isWebContext ? req.body.deviceIp : Utils.getIpFromReq(req);
+    if (!deviceIp && !isWebContext) {
       throw new ClientError('Could not determine device IP address');
     }
-    const allowedIpAddress: string = Bitcore.crypto.Hash.sha256hmac(
-      Buffer.from(deviceIp),
-      Buffer.from(SECRET_KEY)
-    ).toString('base64');
-    qs.push('allowedIpAddress=' + encodeURIComponent(allowedIpAddress));
+    if (deviceIp) {
+      // Canonicalize before hashing: HMAC is byte-exact and MoonPay hashes the
+      // plain IPv4 it observes, while dual-stack sockets report IPv4 clients as
+      // IPv4-mapped IPv6 (::ffff:1.2.3.4) - strip the prefix so both sides
+      // hash the same string
+      deviceIp = String(deviceIp).trim().replace(/^::ffff:/i, '');
+      const allowedIpAddress: string = Bitcore.crypto.Hash.sha256hmac(
+        Buffer.from(deviceIp),
+        Buffer.from(SECRET_KEY)
+      ).toString('base64');
+      qs.push('allowedIpAddress=' + encodeURIComponent(allowedIpAddress));
+    }
 
     const URL_SEARCH: string = `?${qs.join('&')}`;
 

--- a/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
@@ -292,6 +292,36 @@ describe('Moonpay integration', () => {
       }
     });
 
+    it('should hash the forwarded deviceIp instead of the request IP for web context', () => {
+      req.body.context = 'web';
+      req.body.deviceIp = '203.0.113.42';
+      const data = server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      data.urlWithSignature.should.equal('widgetApi4?apiKey=apiKey4&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&allowedIpAddress=HkPyqsZMUzAgsEx27Tlz%2B5XfZHaH0fSfWV%2FMKR7JAPc%3D&signature=B%2Bw0TTQiy8%2Ffq6QeoeSf4dKpdPHZ%2F2EnBB1S4UotNGM%3D');
+    });
+
+    it('should canonicalize IPv4-mapped IPv6 deviceIp before hashing', () => {
+      req.body.context = 'web';
+      req.body.deviceIp = '::ffff:203.0.113.42';
+      const data = server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      data.urlWithSignature.should.equal('widgetApi4?apiKey=apiKey4&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&allowedIpAddress=HkPyqsZMUzAgsEx27Tlz%2B5XfZHaH0fSfWV%2FMKR7JAPc%3D&signature=B%2Bw0TTQiy8%2Ffq6QeoeSf4dKpdPHZ%2F2EnBB1S4UotNGM%3D');
+    });
+
+    it('should omit allowedIpAddress for web context when no deviceIp is forwarded', () => {
+      req.body.context = 'web';
+      const data = server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      data.urlWithSignature.should.equal('widgetApi4?apiKey=apiKey4&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&signature=13Q%2BET1UQLnCqCyg3stDAN4%2FTQ8QB009LcuAP1y6B%2FI%3D');
+    });
+
+    it('should ignore a body deviceIp for non-web context and use the request IP', () => {
+      req.body.deviceIp = '203.0.113.42';
+      const data = server.externalServices.moonpay.moonpayGetSignedPaymentUrl(req);
+      should.exist(data.urlWithSignature);
+      data.urlWithSignature.should.equal('widgetApi2?apiKey=apiKey2&currencyCode=btc&walletAddress=bitcoin%3A123123&baseCurrencyCode=usd&baseCurrencyAmount=500&externalTransactionId=123123&redirectURL=bitpay%3A%2F%2Fmoonpay&allowedIpAddress=CN35SFB5PKS4vkiZ4CglTxRgTAaUHBLGZcenAw6gHEY%3D&signature=3XxjRX3EMj2RNaoAwgOwFBOiVTXsgAS7C50uJf9SsvM%3D');
+    });
+
     it('should return error if there is some missing arguments', () => {
       delete req.body.currencyCode;
       try {


### PR DESCRIPTION
### Description
Fixes BitPay web Buy via MoonPay dropping to 0 starting ~July 10 (internal ticket B1-3576). Sell and the app Buy flow were unaffected.

`4e698ca5b` implemented MoonPay's on-ramp security upgrade, binding each signed widget URL to the customer's public IP via the `allowedIpAddress` param (HMAC of the IP that requested the URL). Web buy requests don't come from the customer's device, though — they're proxied through the bitpay.com backend (frontend proxy wallet), so BWS hashed the proxy server's IP. Every web Buy URL was IP-locked to that server, and MoonPay's widget rejected the session for 100% of web users. The app flow was unaffected because the device calls BWS directly, and sell URL generation never included `allowedIpAddress`.

https://git.b-pay.net/bitpay/bitpay/-/merge_requests/11570

This PR has a companion bitpay MR that forwards the customer's real public IP (Cloudflare `cf-connecting-ip`) as `deviceIp` in the signed payment URL request. MoonPay's integration guide explicitly requires the true client IP behind the proxy/CDN and warns against using a server-side address.

### Changelog

* `moonpayGetSignedPaymentUrl`: for web-context requests, hash the `deviceIp` forwarded by the bitpay.com proxy instead of the BWS request IP. The forwarded value is trusted only for the web context, since web credentials are held exclusively by the proxy; app-context requests ignore a body `deviceIp` and behave exactly as before.
* If a web-context request has no `deviceIp` (proxy not yet updated), omit `allowedIpAddress` from the URL rather than sign an IP the customer can never match — the param is optional per MoonPay, so deploying this change alone restores web Buy immediately; the companion bitpay MR then re-enables the IP lock with the correct customer IP.
* Canonicalize the IP before hashing (trim, strip IPv4-mapped IPv6 `::ffff:` prefix) — HMAC is byte-exact and MoonPay hashes the plain IPv4 it observes.
* Tests: 4 new cases covering forwarded-IP hashing for web (using the `productionWeb` keys), IPv4-mapped IPv6 canonicalization, omission of `allowedIpAddress` when web sends no `deviceIp`, and that non-web context ignores a body `deviceIp`.

### Testing Notes

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
