### PR TITLE
BWS: Transak use forwarded deviceIp as x-user-ip for web-context 

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/transak.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/transak.ts
@@ -36,8 +36,27 @@ export class TransakService {
     return keys;
   }
 
+  // Web requests are proxied through the bitpay backend, so the IP on the
+  // request belongs to that server, not the customer. The proxy captures the
+  // customer's public IP and forwards it as deviceIp. Web credentials are only
+  // held by the proxy, so the forwarded value is trusted for that context only.
+  // Falls back to the request IP so web calls keep working until the proxy
+  // change that forwards deviceIp is deployed.
+  // Must be called before transakGetKeys, which strips context from the body.
+  private transakGetUserIp(req): string {
+    const isWebContext = req.body?.context === 'web';
+    let userIp = (isWebContext && req.body.deviceIp) || Utils.getIpFromReq(req);
+    if (userIp) {
+      // Canonicalize IPv4-mapped IPv6 (dual-stack sockets report IPv4 clients as
+      // ::ffff:1.2.3.4) so Transak sees a plain IPv4 address.
+      userIp = String(userIp).trim().replace(/^::ffff:/i, '');
+    }
+    return userIp || '';
+  }
+
   transakGetAccessToken(req): Promise<any> {
     return new Promise((resolve, reject) => {
+      const userIp = this.transakGetUserIp(req);
       let keys;
       try {
         keys = this.transakGetKeys(req);
@@ -52,7 +71,7 @@ export class TransakService {
         'Content-Type': 'application/json',
         'api-secret': SECRET_KEY,
         'x-api-key': API_KEY,
-        'x-user-ip': Utils.getIpFromReq(req),
+        'x-user-ip': userIp,
       };
 
       const body = {
@@ -220,6 +239,7 @@ export class TransakService {
 
       const requiredParams = req.body.context === 'web' ? ['accessToken'] : appRequiredParams;
       const referrerDomain = req.body.referrerDomain ?? req.body.context === 'web' ? 'bitpay.com' : 'bitpay';
+      const userIp = this.transakGetUserIp(req);
       let keys;
       try {
         keys = this.transakGetKeys(req, false);
@@ -238,12 +258,14 @@ export class TransakService {
         'Content-Type': 'application/json',
         'access-token': req.body.accessToken,
         'x-api-key': API_KEY,
-        'x-user-ip': Utils.getIpFromReq(req),
+        'x-user-ip': userIp,
       };
 
+      const widgetBody = { ...req.body };
+      delete widgetBody.deviceIp;
       const body = {
         widgetParams: {
-          ...req.body,
+          ...widgetBody,
           apiKey: API_KEY,
           referrerDomain,
         },

--- a/packages/bitcore-wallet-service/test/integration/externalservices/transak.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/transak.test.ts
@@ -94,6 +94,20 @@ describe('Transak integration', () => {
       should.exist(data);
     });
 
+    it('should forward the deviceIp as x-user-ip for web context', async () => {
+      let capturedHeaders;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedHeaders = opts.headers;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.body.context = 'web';
+      req.body.deviceIp = '203.0.113.42';
+      await server.externalServices.transak.transakGetAccessToken(req);
+      capturedHeaders['x-user-ip'].should.equal('203.0.113.42');
+    });
+
     it('should return error if post returns error', async () => {
       const fakeRequest2 = {
         post: (_url, _opts, _cb) => { return _cb(new Error('Error'), null); },
@@ -331,6 +345,76 @@ describe('Transak integration', () => {
       } catch (err) {
         err.message.should.equal('Transak\'s request missing arguments');
       }
+    });
+
+    it('should forward the deviceIp as x-user-ip for web context', async () => {
+      let capturedHeaders;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedHeaders = opts.headers;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.body.context = 'web';
+      req.body.deviceIp = '203.0.113.42';
+      await server.externalServices.transak.transakGetSignedPaymentUrl(req);
+      capturedHeaders['x-user-ip'].should.equal('203.0.113.42');
+    });
+
+    it('should canonicalize an IPv4-mapped IPv6 deviceIp for web context', async () => {
+      let capturedHeaders;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedHeaders = opts.headers;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.body.context = 'web';
+      req.body.deviceIp = '::ffff:203.0.113.42';
+      await server.externalServices.transak.transakGetSignedPaymentUrl(req);
+      capturedHeaders['x-user-ip'].should.equal('203.0.113.42');
+    });
+
+    it('should not leak deviceIp into the widgetParams sent to Transak', async () => {
+      let capturedBody;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedBody = opts.body;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.body.context = 'web';
+      req.body.deviceIp = '203.0.113.42';
+      await server.externalServices.transak.transakGetSignedPaymentUrl(req);
+      should.not.exist(capturedBody.widgetParams.deviceIp);
+    });
+
+    it('should ignore a body deviceIp for non-web context and use the request IP', async () => {
+      let capturedHeaders;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedHeaders = opts.headers;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.headers['x-forwarded-for'] = '198.51.100.7';
+      req.body.deviceIp = '203.0.113.42';
+      await server.externalServices.transak.transakGetSignedPaymentUrl(req);
+      capturedHeaders['x-user-ip'].should.equal('198.51.100.7');
+    });
+
+    it('should fall back to the request IP for web context when deviceIp is not forwarded', async () => {
+      let capturedHeaders;
+      server.externalServices.transak.request = {
+        post: (_url, opts, cb) => {
+          capturedHeaders = opts.headers;
+          return cb(null, { body: 'data' });
+        },
+      };
+      req.body.context = 'web';
+      req.headers['x-forwarded-for'] = '198.51.100.7';
+      await server.externalServices.transak.transakGetSignedPaymentUrl(req);
+      capturedHeaders['x-user-ip'].should.equal('198.51.100.7');
     });
 
     it('should return error if post returns error', async () => {


### PR DESCRIPTION
### Description
Production web Buy flows for Transak fail with "Invalid or expired session" when the widget opens. Transak's mandatory security changes pin each widget session to the `x-user-ip` it was created with, but web requests are proxied through the bitpay backend, so BWS was sending that server's IP instead of the customer's. Sandbox is unaffected because Transak relaxes IP checks there.

### Changelog

* Add `transakGetUserIp` helper: web context uses the proxy-forwarded `deviceIp` (same pattern as the MoonPay fix in 2f16b1299), app context keeps using the request IP.
* Use it for `x-user-ip` in `transakGetAccessToken` and `transakGetSignedPaymentUrl`.
* Fall back to the request IP when `deviceIp` is not forwarded, so BWS can deploy before the bitpay server change.
* Canonicalize IPv4-mapped IPv6 addresses (`::ffff:1.2.3.4` → `1.2.3.4`).
* Strip `deviceIp` from the `widgetParams` sent to Transak.

### Testing Notes
Run `npx mocha --require ts-node/register test/integration/externalservices/transak.test.ts` in `packages/bitcore-wallet-service` — includes new tests for deviceIp forwarding, canonicalization, non-web behavior, the missing-deviceIp fallback, and widgetParams exclusion. Full production verification requires the paired bitpay server change that forwards `deviceIp`, deployed to a Transak-whitelisted host.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.
