### PR TITLE
Bump default pbkdf2 iterations

### DIFF
--- a/bitcore-test.config.json
+++ b/bitcore-test.config.json
@@ -132,7 +132,7 @@
           ],
           "providers": [
             {
-              "host": "base-sepolia.drpc.org",
+              "host": "sepolia.base.org",
               "protocol": "https",
               "port": "",
               "dataType": "combined"

--- a/packages/bitcore-cli/test/create.test.ts
+++ b/packages/bitcore-cli/test/create.test.ts
@@ -9,7 +9,7 @@ import { Wallet } from '../src/wallet';
 import { startTssWallets, TssTransform } from './tssCoordinator';
 
 describe('Create', function() {
-  this.timeout(Math.max(this['_timeout'] || 0, 5000));
+  this.timeout(Math.max(this['_timeout'] || 0, 10000));
 
   const { KEYSTROKES, WALLETS, OUTPUT_END_SEQ } = helpers.CONSTANTS;
   const { CLI_EXEC, CLI_OPTS, COMMON_OPTS, TEMP_DIR } = WALLETS;

--- a/packages/bitcore-wallet-client/src/lib/api.ts
+++ b/packages/bitcore-wallet-client/src/lib/api.ts
@@ -156,10 +156,6 @@ export class API extends EventEmitter {
     log.setLevel(this.logLevel);
   }
 
-  static privateKeyEncryptionOpts = {
-    iter: 10000
-  };
-
   initNotifications(cb) {
     log.warn('DEPRECATED: use initialize() instead.');
     this.initialize({}, cb);

--- a/packages/bitcore-wallet-client/src/lib/common/encryption.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/encryption.ts
@@ -3,7 +3,7 @@
 import crypto from 'crypto';
 import sjcl from 'sjcl';
 
-const PBKDF2_ITERATIONS = 1000;
+const PBKDF2_ITERATIONS = 600_000;
 const DEFAULT_KEY_SIZE = 256; // bits
 const ALGORITHM = ks => `aes-${ks || DEFAULT_KEY_SIZE}-gcm`;
 const AUTH_TAG_LENGTH = 16; // 128 bits

--- a/packages/bitcore-wallet-client/src/lib/common/encryption.ts
+++ b/packages/bitcore-wallet-client/src/lib/common/encryption.ts
@@ -139,11 +139,16 @@ class EncryptionClass {
   }
 
   decryptWithPassword(data: string | IEncrypted, password: string) {
+    let json: IEncrypted;
     try {
-      const json = typeof data === 'string' ? JSON.parse(data) : data;
+      json = typeof data === 'string' ? JSON.parse(data) : data;
       const key = crypto.pbkdf2Sync(password, Buffer.from(json.salt, 'base64'), json.iter, json.ks / 8, 'sha256');
       return this._baseDecrypt(json, key);
     } catch (err) {
+      // sjcl is VERY slow and was only used when iter were low, so we should avoid using it for large iterations (e.g. 600k)
+      if (json?.iter > 100_000) {
+        throw err;
+      }
       try {
         return sjcl.decrypt(password, data);
       } catch {

--- a/packages/bitcore-wallet-client/test/encryption.test.ts
+++ b/packages/bitcore-wallet-client/test/encryption.test.ts
@@ -1,10 +1,17 @@
 import * as chai from 'chai';
+import sinon from 'sinon';
 import sjcl from 'sjcl';
 import { Encryption } from '../src/lib/common/encryption';
 
 const should = chai.should();
 
 describe('Encryption', function() {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   it('should encrypt and decrypt object data with a password', function() {
     const password = 'testPassword';
     const data = { message: 'Hello, World!' };
@@ -31,19 +38,103 @@ describe('Encryption', function() {
   });
 
   it('should decrypt data encrypted with old sjcl using base64 key (backward compat)', function() {
+    sandbox.spy(sjcl, 'decrypt');
+    sandbox.stub(Encryption, '_baseDecrypt').throws(new Error('Native decryption failed'));
+
     const base64Key = 'ezDRS2NRchMJLf1IWtjL5A==';
     const message = JSON.stringify({ walletPrivKey: 'some-private-key' });
     const sjclKey = sjcl.codec.base64.toBits(base64Key);
     const ct = sjcl.encrypt(sjclKey, message, { ks: 128, iter: 1 });
     const decrypted = Encryption.decryptWithKey(ct, base64Key);
     decrypted.toString().should.equal(message);
+    sjcl.decrypt.callCount.should.equal(1);
   });
 
   it('should decrypt data encrypted with old sjcl using password string (backward compat)', function() {
+    sandbox.spy(sjcl, 'decrypt');
+    sandbox.stub(Encryption, '_baseDecrypt').throws(new Error('Native decryption failed'));
+
     const password = 'testPassword';
     const data = 'xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu';
     const ct = sjcl.encrypt(password, data);
     const decrypted = Encryption.decryptWithPassword(ct, password);
     decrypted.toString().should.equal(data);
+    sjcl.decrypt.callCount.should.equal(1);
+  });
+
+  describe('encryptWithPassword', function() {
+    it('should encrypt with defaults', function() {
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const encrypted = Encryption.encryptWithPassword(data, password);
+      should.exist(encrypted.ct);
+      should.exist(encrypted.iter);
+      encrypted.iter.should.equal(600_000);
+    });
+
+    it('should encrypt with a specific iter', function() {
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const encrypted = Encryption.encryptWithPassword(data, password, { iter: 123_456 });
+      should.exist(encrypted.ct);
+      should.exist(encrypted.iter);
+      encrypted.iter.should.equal(123_456);
+    });
+  });
+
+  describe('decryptWithPassword', function() {
+    const sandbox = sinon.createSandbox();
+    
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should try sjcl if native fails', function() {
+      sandbox.spy(sjcl, 'decrypt');
+      sandbox.stub(Encryption, '_baseDecrypt').throws(new Error('Native decryption failed'));
+
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const ct = sjcl.encrypt(password, data);
+
+      const decrypted = Encryption.decryptWithPassword(ct, password);
+      decrypted.toString().should.equal(data);
+      sjcl.decrypt.callCount.should.equal(1);
+    });
+
+    it('should not try sjcl if native fails and iter > 10,000', function() {
+      sandbox.spy(sjcl, 'decrypt');
+      sandbox.stub(Encryption, '_baseDecrypt').throws(new Error('Native decryption failed'));
+
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const encrypted = Encryption.encryptWithPassword(data, password);
+      encrypted.iter.should.be.greaterThan(10_000);
+      
+      (() => Encryption.decryptWithPassword(encrypted, password)).should.throw('Native decryption failed');
+      sjcl.decrypt.callCount.should.equal(0);
+    });
+
+    it('should decrypt with native', function() {
+      sandbox.spy(sjcl, 'decrypt');
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const encrypted = '{"iv":"29s7Pzi0BGPpjO44","v":1,"ts":128,"mode":"gcm","adata":"","cipher":"aes","ct":"9KK6+Ay5Uy8qfI37eMDJuCdZGDYj3s5ju2dJupc=","iter":600000,"ks":256,"salt":"xu2SC59dLsrE9ZrDQ/R7gw=="}';
+
+      const decrypted = Encryption.decryptWithPassword(encrypted, password);
+      decrypted.toString().should.equal(data);
+      sjcl.decrypt.callCount.should.equal(0);
+    });
+
+    it('should decrypt with native and non-default iter', function() {
+      sandbox.spy(sjcl, 'decrypt');
+      const password = 'testPassword';
+      const data = 'Hello, World!';
+      const encrypted = '{"iv":"fKtogNpAtH/+mmwx","v":1,"ts":128,"mode":"gcm","adata":"","cipher":"aes","ct":"PZXQtwsFTpSnMSJx6SZJZOB8od9+WFfxLuZXsmA=","iter":123456,"ks":256,"salt":"l06qGURs2jidgny984uLQg=="}';
+
+      const decrypted = Encryption.decryptWithPassword(encrypted, password);
+      decrypted.toString().should.equal(data);
+      sjcl.decrypt.callCount.should.equal(0);
+    });
   });
 });


### PR DESCRIPTION
### Description
The current pbkdf2 iterations are lower than the OWASP recommended number. This can be overridden anyway but better to have a sensible number as default. Ideally, we'd migrate to something like Argon2id, but this is better than nothing in the meantime.

### Changelog

* Bump `PBKDF2_ITERATIONS` to OWASP recommended 600,000 iterations for SHA-256.

### Testing Notes
All tests should pass. No breaking changes here. All previously encrypted payloads should work as before.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.