### PR TITLE
[BWS] Types: New params in the typing of external services config

### DIFF
--- a/packages/bitcore-wallet-service/src/types/externalservices.d.ts
+++ b/packages/bitcore-wallet-service/src/types/externalservices.d.ts
@@ -3,13 +3,17 @@ interface ExchangeConfig {
   removed?: boolean;
   disabledTitle?: string;
   disabledMessage?: string;
-  config?: any;
+  config?: {
+    paymentMethods?: PaymentMethodsConfig;
+    [key: string]: any; // Other partner-specific configuration properties can be added here
+  };
 }
 
 export interface BuyCryptoConfig {
   disabled?: boolean;
   disabledTitle?: string;
   disabledMessage?: string;
+  paymentMethods?: PaymentMethodsConfig;
   banxa?: ExchangeConfig;
   moonpay?: ExchangeConfig;
   ramp?: ExchangeConfig;
@@ -23,6 +27,7 @@ export interface SellCryptoConfig {
   disabled?: boolean;
   disabledTitle?: string;
   disabledMessage?: string;
+  paymentMethods?: PaymentMethodsConfig;
   moonpay?: ExchangeConfig;
 }
 
@@ -33,6 +38,29 @@ export interface SwapCryptoConfig {
   changelly?: ExchangeConfig;
   thorswap?: ExchangeConfig;
 }
+
+export type PaymentMethodKey =
+  | 'ach'
+  | 'applePay'
+  | 'cashApp'
+  | 'creditCard'
+  | 'debitCard'
+  | 'googlePay'
+  | 'sepaBankTransfer'
+  | 'gbpBankTransfer'
+  | 'other'
+  | 'paypal'
+  | 'pisp'
+  | 'pix'
+  | 'venmo';
+
+export interface PaymentMethodConfig {
+  disabled?: boolean;
+}
+
+export type PaymentMethodsConfig = {
+  [key in PaymentMethodKey]?: PaymentMethodConfig;
+};
 
 export interface ExternalServicesConfig {
   buyCrypto?: BuyCryptoConfig;


### PR DESCRIPTION
### Description
New parameters have been added to the external services config typing, which are handled within the app to disable payment methods.

### Changelog

The general and partner-specific `paymentMethods` config were simply added to the existing Types.