### PR TITLE
[BWS] Feat: webhooks support for external services

### DIFF
--- a/packages/bitcore-wallet-service/bws.example.config.js
+++ b/packages/bitcore-wallet-service/bws.example.config.js
@@ -227,6 +227,8 @@ module.exports = {
   //     sellWidgetApi: 'https://sell.moonpay.com',
   //     secretKey: 'moonpay_production_secret_key_here',
   //     secretKeyEmbedded: 'moonpay_production_secret_key_embedded_here',
+  //     webhookSecretKey: 'moonpay_production_webhook_secret_key_here',
+  //     webhookSecretKeyEmbedded: 'moonpay_production_webhook_secret_key_embedded_here',
   //   },
   //   sandboxWeb: {
   //     apiKey: 'moonpay_sandbox_web_api_key_here',
@@ -244,17 +246,20 @@ module.exports = {
   //   }
   // },
   // ramp: {
+  //   webhookCallbackBaseUrl: 'https://bws.bitpay.com/bws/api',
   //   sandbox: {
   //     apiKey: 'ramp_sandbox_api_key_here',
   //     api: 'https://api.demo.rampnetwork.com/api',
   //     widgetApi: 'https://app.demo.rampnetwork.com/',
   //     signingKey: 'ramp_sandbox_signing_key_here',
+  //     webhookSigningKey: 'ramp_sandbox_webhook_signing_key_here',
   //   },
   //   production: {
   //     apiKey: 'ramp_production_api_key_here',
   //     api: 'https://api.rampnetwork.com/api',
   //     widgetApi: 'https://app.rampnetwork.com/',
   //     signingKey: 'ramp_production_signing_key_here',
+  //     webhookSigningKey: 'ramp_production_webhook_signing_key_here',
   //   },
   //   sandboxWeb: {
   //     apiKey: 'ramp_sandbox_web_api_key_here',
@@ -299,6 +304,7 @@ module.exports = {
   //     appProviderId: 'simplex_provider_id_here',
   //     appSellRefId: 'simplex_sell_ref_id_here',
   //     publicKey: 'simplex_sandbox_public_key_here',
+  //     publicKeyWebhook: 'simplex_sandbox_webhook_public_key_here',
   //   },
   //   production: {
   //     apiKey: 'simplex_production_api_key_here',
@@ -307,6 +313,7 @@ module.exports = {
   //     appProviderId: 'simplex_provider_id_here',
   //     appSellRefId: 'simplex_sell_ref_id_here',
   //     publicKey: 'simplex_public_key_here',
+  //     publicKeyWebhook: 'simplex_production_webhook_public_key_here',
   //   },
   //   sandboxWeb: {
   //     apiKey: 'simplex_sandbox_web_api_key_here',
@@ -405,6 +412,10 @@ module.exports = {
   // moralis: {
   //   apiKey: 'moralis_api_key_here',
   //   whitelist: []
+  // },
+  // braze: {
+  //   bwsTrackEventApiKey: 'braze_bws_track_event_api_key_here',
+  //   bwsTrackEventApi: 'https://rest.iad-05.braze.com'
   // },
   // To use email notifications uncomment this:
   // emailOpts: {

--- a/packages/bitcore-wallet-service/src/config.ts
+++ b/packages/bitcore-wallet-service/src/config.ts
@@ -302,6 +302,8 @@ const Config = (): any => {
     //     sellWidgetApi: 'https://sell.moonpay.com',
     //     secretKey: 'moonpay_production_secret_key_here',
     //     secretKeyEmbedded: 'moonpay_production_secret_key_embedded_here',
+    //     webhookSecretKey: 'moonpay_production_webhook_secret_key_here',
+    //     webhookSecretKeyEmbedded: 'moonpay_production_webhook_secret_key_embedded_here',
     //   },
     //   sandboxWeb: {
     //     apiKey: 'moonpay_sandbox_web_api_key_here',
@@ -319,17 +321,20 @@ const Config = (): any => {
     //   }
     // },
     // ramp: {
+    //   webhookCallbackBaseUrl: 'https://bws.bitpay.com/bws/api',
     //   sandbox: {
     //     apiKey: 'ramp_sandbox_api_key_here',
     //     api: 'https://api.demo.ramp.network/api',
     //     widgetApi: 'https://app.demo.ramp.network/',
     //     signingKey: 'ramp_sandbox_signing_key_here',
+    //     webhookSigningKey: 'ramp_sandbox_webhook_signing_key_here',
     //   },
     //   production: {
     //     apiKey: 'ramp_production_api_key_here',
     //     api: 'https://api.ramp.network/api',
     //     widgetApi: 'https://app.ramp.network/',
     //     signingKey: 'ramp_production_signing_key_here',
+    //     webhookSigningKey: 'ramp_production_webhook_signing_key_here',
     //   },
     //   sandboxWeb: {
     //     apiKey: 'ramp_sandbox_web_api_key_here',
@@ -374,6 +379,7 @@ const Config = (): any => {
     //     appProviderId: 'simplex_provider_id_here',
     //     appSellRefId: 'simplex_sell_ref_id_here',
     //     publicKey: 'simplex_sandbox_public_key_here',
+    //     publicKeyWebhook: 'simplex_sandbox_webhook_public_key_here',
     //   },
     //   production: {
     //     apiKey: 'simplex_production_api_key_here',
@@ -382,6 +388,7 @@ const Config = (): any => {
     //     appProviderId: 'simplex_provider_id_here',
     //     appSellRefId: 'simplex_sell_ref_id_here',
     //     publicKey: 'simplex_public_key_here',
+    //     publicKeyWebhook: 'simplex_production_webhook_public_key_here',
     //   },
     //   sandboxWeb: {
     //     apiKey: 'simplex_sandbox_web_api_key_here',
@@ -482,6 +489,10 @@ const Config = (): any => {
     // moralis: {
     //   apiKey: 'moralis_api_key_here',
     //   whitelist: []
+    // },
+    // braze: {
+    //   bwsTrackEventApiKey: 'braze_bws_track_event_api_key_here',
+    //   bwsTrackEventApi: 'https://rest.iad-05.braze.com'
     // },
   };
 

--- a/packages/bitcore-wallet-service/src/externalservices/banxa.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/banxa.ts
@@ -3,6 +3,8 @@ import * as _ from 'lodash';
 import * as request from 'request';
 import config from '../config';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class BanxaService {
@@ -261,5 +263,80 @@ export class BanxaService {
         }
       );
     });
+  }
+
+  /**
+   * Handles incoming Banxa webhook events.
+   * Banxa signs each webhook with HMAC-SHA256. Header format:
+   *   Authorization: Bearer {API_KEY}:{SIGNATURE}:{NONCE}
+   * Signature is computed over: POST\n{WEBHOOK_PATH}\n{NONCE}\n{RAW_BODY}
+   * https://docs.banxa.com/products/hosted-checkout/docs/transaction-lifecycle/webhooks
+   *
+   * WEBHOOK_PATH must be the full URI path of this endpoint as registered in the
+   * Banxa dashboard (including any proxy prefix, e.g. /bws/api/v1/service/banxa/webhook).
+   * Configure it per env in config.banxa[env].webhookPath.
+   *
+   * The environment is determined by which configured key verifies the signature
+   * (separate URLs/keys per env in the dashboard), not by the request.
+   */
+  banxaHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.banxa) throw new Error('Banxa missing credentials');
+
+    const secretKeys: { key: string; env: string; webhookPath: string }[] = [
+      { key: config.banxa.production?.secretKey, env: 'production', webhookPath: (config.banxa.production as any)?.webhookPath || '/v1/service/banxa/webhook' },
+      { key: config.banxa.sandbox?.secretKey, env: 'sandbox', webhookPath: (config.banxa.sandbox as any)?.webhookPath || '/v1/service/banxa/webhook' }
+    ].filter(k => !!k.key);
+
+    let env = 'production';
+    if (secretKeys.length) {
+      const authHeader = req.headers['authorization'] as string;
+      if (!authHeader) {
+        throw new Error('Banxa webhook missing Authorization header');
+      }
+      try {
+        // Strip 'Bearer ' prefix
+        const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : authHeader;
+        const parts = token.split(':');
+        if (parts.length !== 3) throw new Error('Invalid Banxa Authorization header format');
+        const [, receivedSig, nonce] = parts;
+        const rawBody: string = (req as any).rawBody ?? JSON.stringify(req.body);
+        const given = Buffer.from(receivedSig, 'hex');
+        const matched = secretKeys.find(({ key, webhookPath }) => {
+          const signingString = `POST\n${webhookPath}\n${nonce}\n${rawBody}`;
+          const expected = crypto.createHmac('sha256', key).update(signingString).digest();
+          return expected.length === given.length && crypto.timingSafeEqual(expected, given);
+        });
+        if (!matched) {
+          throw new Error('Banxa webhook signature mismatch');
+        }
+        env = matched.env;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('Banxa webhook signature error: %s', errMsg);
+        throw new Error('Banxa webhook signature verification failed');
+      }
+    } else {
+      logger.warn('Banxa webhook: no secretKey configured, skipping signature verification');
+    }
+
+    const body = req.body || {};
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'banxa',
+      externalId: body.order_id,
+      status: body.status || '',
+      eventName: body.order_type,
+      createdAt: body.created_at || body.status_date,
+      fiatAmount: body.fiat_amount != null ? Number(body.fiat_amount) : undefined,
+      fiatCurrency: body.fiat_currency,
+      cryptoAmount: body.crypto_amount != null ? Number(body.crypto_amount) : undefined,
+      cryptoCurrency: body.crypto_coin,
+      paymentMethod: body.payment_method,
+      userId: body.external_id,
+      rawPayload: body,
+      env
+    });
+
+    return { event };
   }
 }

--- a/packages/bitcore-wallet-service/src/externalservices/banxa.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/banxa.ts
@@ -198,6 +198,14 @@ export class BanxaService {
       }
       delete req.body.payment_method;
 
+      // Banxa's webhook payload doesn't carry any partner-supplied user identifier
+      // `meta_data` is a free-form string Banxa echoes back (as `metadata`) on the
+      // webhook
+      if (req.body.userId && !req.body.meta_data) {
+        req.body.meta_data = req.body.userId;
+      }
+      delete req.body.userId;
+
       const UriPath = '/orders';
       const URL: string = API + UriPath;
       const auth = this.getBanxaSignature('post', UriPath, API_KEY, SECRET_KEY, req.body);
@@ -283,8 +291,8 @@ export class BanxaService {
     if (!config.banxa) throw new Error('Banxa missing credentials');
 
     const secretKeys: { key: string; env: string; webhookPath: string }[] = [
-      { key: config.banxa.production?.secretKey, env: 'production', webhookPath: (config.banxa.production as any)?.webhookPath || '/v1/service/banxa/webhook' },
-      { key: config.banxa.sandbox?.secretKey, env: 'sandbox', webhookPath: (config.banxa.sandbox as any)?.webhookPath || '/v1/service/banxa/webhook' }
+      { key: (config.banxa.production as any)?.webhookSecretKey || config.banxa.production?.secretKey, env: 'production', webhookPath: (config.banxa.production as any)?.webhookPath || '/v1/service/banxa/webhook' },
+      { key: (config.banxa.sandbox as any)?.webhookSecretKey || config.banxa.sandbox?.secretKey, env: 'sandbox', webhookPath: (config.banxa.sandbox as any)?.webhookPath || '/v1/service/banxa/webhook' }
     ].filter(k => !!k.key);
 
     let env = 'production';
@@ -325,14 +333,20 @@ export class BanxaService {
       partner: 'banxa',
       externalId: body.order_id,
       status: body.status || '',
-      eventName: body.order_type,
-      createdAt: body.created_at || body.status_date,
+      eventName: body.status,
+      createdAt: body.created_at,
+      // Banxa docs recommend order_id + status as the dedup key; updated_at is
+      // also used here for out-of-order detection.
+      updatedAt: body.updated_at,
+      deliveryVersion: body.updated_at,
       fiatAmount: body.fiat_amount != null ? Number(body.fiat_amount) : undefined,
       fiatCurrency: body.fiat_currency,
       cryptoAmount: body.crypto_amount != null ? Number(body.crypto_amount) : undefined,
       cryptoCurrency: body.crypto_coin,
       paymentMethod: body.payment_method,
-      userId: body.external_id,
+      // `metadata` is what we ask Banxa to echo back for the meta_data sent at
+      // order creation (see banxaCreateOrder).
+      userId: typeof body.metadata === 'string' ? body.metadata : undefined,
       rawPayload: body,
       env
     });

--- a/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
@@ -1,8 +1,11 @@
+import * as crypto from 'crypto';
 import { BitcoreLib as Bitcore } from '@bitpay-labs/crypto-wallet-core';
 import * as request from 'request';
 import config from '../config';
 import { Utils } from '../lib/common/utils';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class MoonpayService {
@@ -543,5 +546,81 @@ export class MoonpayService {
         }
       );
     });
+  }
+
+  /**
+   * Handles incoming MoonPay webhook events.
+   * MoonPay signs requests with HMAC-SHA256. Header: Moonpay-Signature-V2
+   * Format: t=<timestamp>,s=<signature>
+   * Signed string: timestamp + '.' + rawBody
+   * https://dev.moonpay.com/api-reference/widget/webhooks/signature
+   */
+  moonpayHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.moonpay) throw new Error('MoonPay missing credentials');
+
+    const secretKeys: { key: string; isEmbedded: boolean }[] = [
+      { key: config.moonpay.production?.webhookSecretKey, isEmbedded: false },
+      { key: config.moonpay.production?.webhookSecretKeyEmbedded, isEmbedded: true }
+    ].filter(k => !!k.key);
+
+    let isEmbedded: boolean | undefined;
+    if (secretKeys.length) {
+      const signatureHeader = req.headers['moonpay-signature-v2'] as string;
+      if (!signatureHeader) {
+        throw new Error('MoonPay webhook missing Moonpay-Signature-V2 header');
+      }
+      try {
+        // Parse: t=timestamp,s=signature
+        const parts: Record<string, string> = {};
+        for (const part of signatureHeader.split(',')) {
+          const [k, v] = part.split('=');
+          if (k && v !== undefined) parts[k] = v;
+        }
+        if (!parts.t || !parts.s) throw new Error('Invalid Moonpay-Signature-V2 header');
+
+        // signed_payload = timestamp + '.' + rawBody
+        const rawBody: string = (req as any).rawBody ?? JSON.stringify(req.body);
+        const signedPayload = `${parts.t}.${rawBody}`;
+        const given = Buffer.from(parts.s, 'hex');
+        const matched = secretKeys.find(({ key }) => {
+          const expected = crypto.createHmac('sha256', key).update(signedPayload).digest();
+          return expected.length === given.length && crypto.timingSafeEqual(expected, given);
+        });
+        if (!matched) {
+          throw new Error('MoonPay webhook signature mismatch');
+        }
+        isEmbedded = matched.isEmbedded;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('MoonPay webhook signature error: %s', errMsg);
+        throw new Error('MoonPay webhook signature verification failed');
+      }
+    } else {
+      logger.warn('MoonPay webhook: no webhookSecretKey configured, skipping signature verification');
+    }
+
+    const body = req.body || {};
+    const data = body.data || {};
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'moonpay',
+      externalId: data.id,
+      status: data.status || '',
+      eventName: body.type,
+      createdAt: data.createdAt,
+      fiatAmount: data.baseCurrencyAmount != null ? Number(data.baseCurrencyAmount) : undefined,
+      fiatCurrency: data.baseCurrency?.code?.toUpperCase(),
+      cryptoAmount: data.quoteCurrencyAmount != null ? Number(data.quoteCurrencyAmount) : undefined,
+      cryptoCurrency: data.currency?.code?.toUpperCase(),
+      paymentMethod: data.paymentMethod,
+      walletAddress: data.walletAddress,
+      walletAddressTag: data.walletAddressTag,
+      userId: data.externalCustomerId || body.externalCustomerId,
+      rawPayload: body,
+      env: 'production',
+      isEmbedded
+    });
+
+    return { event };
   }
 }

--- a/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/moonpay.ts
@@ -602,12 +602,27 @@ export class MoonpayService {
     const body = req.body || {};
     const data = body.data || {};
 
+    // MoonPay documents deduplication on type + data.id + data.updatedAt, so a
+    // delivery missing any of them cannot be stored under a stable key.
+    if (typeof body.type !== 'string' || !body.type) {
+      throw new Error('MoonPay webhook missing event type');
+    }
+    if (typeof data.id !== 'string' || !data.id) {
+      throw new Error('MoonPay webhook missing transaction id');
+    }
+    if (typeof data.updatedAt !== 'string' || Number.isNaN(Date.parse(data.updatedAt))) {
+      throw new Error('MoonPay webhook missing valid updatedAt');
+    }
+
     const event = OnrampWebhookEvent.create({
       partner: 'moonpay',
       externalId: data.id,
+      externalTransactionId: data.externalTransactionId,
       status: data.status || '',
       eventName: body.type,
       createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+      deliveryVersion: data.updatedAt,
       fiatAmount: data.baseCurrencyAmount != null ? Number(data.baseCurrencyAmount) : undefined,
       fiatCurrency: data.baseCurrency?.code?.toUpperCase(),
       cryptoAmount: data.quoteCurrencyAmount != null ? Number(data.quoteCurrencyAmount) : undefined,

--- a/packages/bitcore-wallet-service/src/externalservices/ramp.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/ramp.ts
@@ -3,6 +3,8 @@ import * as request from 'request';
 import config from '../config';
 import { Utils } from '../lib/common/utils';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class RampService {
@@ -275,4 +277,94 @@ export class RampService {
       );
     });
   }
+
+  /**
+   * Handles incoming Ramp webhook events.
+   * Ramp sends purchase/sale events via HTTP POST to webhookStatusUrl /
+   * offrampWebhookV3Url. https://docs.rampnetwork.com/webhooks
+   *
+   * Ramp signs every webhook with an ECDSA (secp256k1) key + SHA-256 digest.
+   * The message is the request body serialized deterministically (keys sorted
+   * alphabetically, no whitespace - fast-json-stable-stringify), NOT the raw body.
+   * The X-Body-Signature header is the base64 DER-encoded signature.
+   * Ramp publishes separate public keys for production and demo (sandbox), so the
+   * environment is determined by which configured key verifies the signature.
+   *
+   * Buy payload:  { type: 'CREATED'|'RELEASED'|'RETURNED', purchase: RampPurchase }
+   * Sell payload: { type: 'CREATED'|'RELEASED'|'EXPIRED', mode: 'OFFRAMP', payload: RampSale }
+   */
+  rampHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.ramp) throw new Error('Ramp missing credentials');
+
+    const publicKeys: { key: string; env: string }[] = [
+      { key: (config.ramp.production as any)?.webhookSigningKey, env: 'production' },
+      { key: (config.ramp.sandbox as any)?.webhookSigningKey, env: 'sandbox' }
+    ].filter(k => !!k.key);
+
+    const body = req.body || {};
+
+    let env = 'production';
+    if (publicKeys.length) {
+      const sigHeader = req.headers['x-body-signature'] as string;
+      if (!sigHeader) {
+        throw new Error('Ramp webhook missing X-Body-Signature header');
+      }
+      try {
+        // The signed message is the stable-stringified JSON body (sorted keys, no whitespace)
+        const message = Buffer.from(stableStringify(body), 'utf8');
+        const sig = Buffer.from(sigHeader, 'base64');
+        // Signature is DER-encoded (crypto.verify's default dsaEncoding)
+        const matched = publicKeys.find(({ key }) => crypto.verify('sha256', message, key, sig));
+        if (!matched) {
+          throw new Error('Ramp webhook signature mismatch');
+        }
+        env = matched.env;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('Ramp webhook signature error: %s', errMsg);
+        throw new Error('Ramp webhook signature verification failed');
+      }
+    } else {
+      logger.warn('Ramp webhook: no webhookSigningKey configured, skipping signature verification');
+    }
+
+    // Buy events carry the tx in body.purchase; sell (offramp) events in body.payload
+    const isSell = body.mode === 'OFFRAMP' || !!body.payload;
+    const item = (isSell ? body.payload : body.purchase) || {};
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'ramp',
+      externalId: item.id,
+      status: item.status || body.type || '',
+      eventName: body.type,
+      createdAt: item.createdAt,
+      fiatAmount: isSell
+        ? (item.fiat?.amount != null ? Number(item.fiat.amount) : undefined)
+        : (item.fiatValue != null ? Number(item.fiatValue) : undefined),
+      fiatCurrency: isSell ? item.fiat?.currencySymbol : item.fiatCurrency,
+      cryptoAmount: isSell
+        ? (item.crypto?.amount != null ? Number(item.crypto.amount) : undefined)
+        : (item.cryptoAmount != null ? Number(item.cryptoAmount) : undefined),
+      cryptoCurrency: isSell ? item.crypto?.assetInfo?.symbol : item.asset?.symbol,
+      paymentMethod: isSell ? item.fiat?.payoutMethod : item.paymentMethodType,
+      walletAddress: item.receiverAddress,
+      userId: item.purchaseViewToken || item.saleViewToken, // per-tx secret for follow-up lookups
+      rawPayload: body,
+      env
+    });
+
+    return { event };
+  }
+}
+
+/**
+ * Deterministic JSON serialization equivalent to fast-json-stable-stringify:
+ * object keys sorted alphabetically (recursively), no whitespace.
+ * Ramp signs webhook bodies over this representation.
+ */
+function stableStringify(obj: any): string {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(item => stableStringify(item === undefined ? null : item)).join(',')}]`;
+  const keys = Object.keys(obj).filter(k => obj[k] !== undefined).sort();
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
 }

--- a/packages/bitcore-wallet-service/src/externalservices/ramp.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/ramp.ts
@@ -176,6 +176,19 @@ export class RampService {
     const outAssetValue = req.body.outAssetValue ?? (isOfframp ? req.body.fiatValue : req.body.swapAmount);
     if (outAssetValue) qs.push('outAssetValue=' + encodeURIComponent(outAssetValue));
 
+    // Custom query param appended to the webhook
+    // callback URL, which Ramp echoes back verbatim on the actual webhook call.
+    // https://docs.rampnetwork.com/webhooks#passing-custom-parameters-to-webhooks
+    const webhookCallbackBaseUrl: string | undefined = config.ramp.webhookCallbackBaseUrl;
+    if (req.body.userId && webhookCallbackBaseUrl) {
+      const userIdParam = 'userId=' + encodeURIComponent(req.body.userId);
+      const webhookStatusUrl = `${webhookCallbackBaseUrl}/v1/service/ramp/webhook?${userIdParam}`;
+      // TODO: We don't currently use the offrampWebhookV3Url, but we may want to in the future. If so, uncomment the lines below.
+      // const offrampWebhookV3Url = `${webhookCallbackBaseUrl}/v1/service/ramp/offramp-webhook?${userIdParam}`;
+      qs.push('webhookStatusUrl=' + encodeURIComponent(webhookStatusUrl));
+      // qs.push('offrampWebhookV3Url=' + encodeURIComponent(offrampWebhookV3Url));
+    }
+
     const queryString = qs.join('&');
 
     // Add timestamp and sign
@@ -287,8 +300,8 @@ export class RampService {
    * The message is the request body serialized deterministically (keys sorted
    * alphabetically, no whitespace - fast-json-stable-stringify), NOT the raw body.
    * The X-Body-Signature header is the base64 DER-encoded signature.
-   * Ramp publishes separate public keys for production and demo (sandbox), so the
-   * environment is determined by which configured key verifies the signature.
+   * Environment is determined by which key verifies the signature.
+   * Ramp's own published public keys: webhookSigningKey
    *
    * Buy payload:  { type: 'CREATED'|'RELEASED'|'RETURNED', purchase: RampPurchase }
    * Sell payload: { type: 'CREATED'|'RELEASED'|'EXPIRED', mode: 'OFFRAMP', payload: RampSale }
@@ -299,33 +312,29 @@ export class RampService {
     const publicKeys: { key: string; env: string }[] = [
       { key: (config.ramp.production as any)?.webhookSigningKey, env: 'production' },
       { key: (config.ramp.sandbox as any)?.webhookSigningKey, env: 'sandbox' }
-    ].filter(k => !!k.key);
+    ];
 
     const body = req.body || {};
 
     let env = 'production';
-    if (publicKeys.length) {
-      const sigHeader = req.headers['x-body-signature'] as string;
-      if (!sigHeader) {
-        throw new Error('Ramp webhook missing X-Body-Signature header');
+    const sigHeader = req.headers['x-body-signature'] as string;
+    if (!sigHeader) {
+      throw new Error('Ramp webhook missing X-Body-Signature header');
+    }
+    try {
+      // The signed message is the stable-stringified JSON body (sorted keys, no whitespace)
+      const message = Buffer.from(stableStringify(body), 'utf8');
+      const sig = Buffer.from(sigHeader, 'base64');
+      // Signature is DER-encoded (crypto.verify's default dsaEncoding)
+      const matched = publicKeys.find(({ key }) => crypto.verify('sha256', message, key, sig));
+      if (!matched) {
+        throw new Error('Ramp webhook signature mismatch');
       }
-      try {
-        // The signed message is the stable-stringified JSON body (sorted keys, no whitespace)
-        const message = Buffer.from(stableStringify(body), 'utf8');
-        const sig = Buffer.from(sigHeader, 'base64');
-        // Signature is DER-encoded (crypto.verify's default dsaEncoding)
-        const matched = publicKeys.find(({ key }) => crypto.verify('sha256', message, key, sig));
-        if (!matched) {
-          throw new Error('Ramp webhook signature mismatch');
-        }
-        env = matched.env;
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
-        logger.warn('Ramp webhook signature error: %s', errMsg);
-        throw new Error('Ramp webhook signature verification failed');
-      }
-    } else {
-      logger.warn('Ramp webhook: no webhookSigningKey configured, skipping signature verification');
+      env = matched.env;
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+      logger.warn('Ramp webhook signature error: %s', errMsg);
+      throw new Error('Ramp webhook signature verification failed');
     }
 
     // Buy events carry the tx in body.purchase; sell (offramp) events in body.payload
@@ -338,6 +347,10 @@ export class RampService {
       status: item.status || body.type || '',
       eventName: body.type,
       createdAt: item.createdAt,
+      // RampPurchase/RampSale both document an updatedAt field, used as the
+      // delivery version key for idempotency/out-of-order detection.
+      updatedAt: item.updatedAt,
+      deliveryVersion: item.updatedAt,
       fiatAmount: isSell
         ? (item.fiat?.amount != null ? Number(item.fiat.amount) : undefined)
         : (item.fiatValue != null ? Number(item.fiatValue) : undefined),
@@ -348,7 +361,12 @@ export class RampService {
       cryptoCurrency: isSell ? item.crypto?.assetInfo?.symbol : item.asset?.symbol,
       paymentMethod: isSell ? item.fiat?.payoutMethod : item.paymentMethodType,
       walletAddress: item.receiverAddress,
-      userId: item.purchaseViewToken || item.saleViewToken, // per-tx secret for follow-up lookups
+      // NOTE: Ramp does not send user details in webhooks (privacy policy).
+      // userId comes from the userId query param we
+      // ourselves append to webhookStatusUrl/offrampWebhookV3Url when
+      // requesting the signed widget URL (see rampGetSignedPaymentUrl) - Ramp
+      // echoes it back verbatim on this call.
+      userId: typeof req.query?.userId === 'string' ? req.query.userId : undefined,
       rawPayload: body,
       env
     });

--- a/packages/bitcore-wallet-service/src/externalservices/sardine.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/sardine.ts
@@ -240,10 +240,8 @@ export class SardineService {
 
   /**
    * Handles incoming Sardine webhook events.
-   * NOTE: the Sardine on/off-ramp docs do not document any signature header
-   * (https://docs.payments.sardine.ai/integration_guides/onofframps/webhooks).
-   * If a webhookSecret is configured and an X-Sardine-Signature header is present,
-   * we verify it as HMAC-SHA256 over the raw body. Confirm the exact scheme with
+   * Docs: https://docs.payments.sardine.ai/integration_guides/onofframps/webhooks.
+   * TODO: Confirm the exact scheme with
    * Sardine before relying on it.
    *
    * Payload contains order status updates (draft, expired, declined, processing,
@@ -281,7 +279,8 @@ export class SardineService {
     }
 
     const body = req.body || {};
-    // Sardine order payload fields (from GET /v1/orders response shape)
+    // Sardine order payload fields, per the documented Order object shape
+    // (GET /v1/orders/{orderId} response, see api_reference/onramp):
     const order = body.order || body;
 
     const event = OnrampWebhookEvent.create({
@@ -290,8 +289,8 @@ export class SardineService {
       status: order.status || body.eventType || '',
       eventName: body.eventType,
       createdAt: order.createdAt,
-      fiatAmount: order.fiatAmount != null ? Number(order.fiatAmount) : undefined,
-      fiatCurrency: order.currency,
+      fiatAmount: order.total != null ? Number(order.total) : undefined,
+      fiatCurrency: order.fiatCurrency,
       cryptoCurrency: order.assetType || order.cryptoCurrency,
       userId: order.userId || order.externalUserId,
       rawPayload: body,

--- a/packages/bitcore-wallet-service/src/externalservices/sardine.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/sardine.ts
@@ -1,6 +1,9 @@
+import * as crypto from 'crypto';
 import * as request from 'request';
 import config from '../config';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class SardineService {
@@ -233,5 +236,68 @@ export class SardineService {
         }
       );
     });
+  }
+
+  /**
+   * Handles incoming Sardine webhook events.
+   * NOTE: the Sardine on/off-ramp docs do not document any signature header
+   * (https://docs.payments.sardine.ai/integration_guides/onofframps/webhooks).
+   * If a webhookSecret is configured and an X-Sardine-Signature header is present,
+   * we verify it as HMAC-SHA256 over the raw body. Confirm the exact scheme with
+   * Sardine before relying on it.
+   *
+   * Payload contains order status updates (draft, expired, declined, processing,
+   * processed, complete).
+   */
+  sardineHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.sardine) throw new Error('Sardine missing credentials');
+
+    const webhookSecrets: { key: string; env: string }[] = [
+      { key: (config.sardine.production as any)?.webhookSecret, env: 'production' },
+      { key: (config.sardine.sandbox as any)?.webhookSecret, env: 'sandbox' }
+    ].filter(k => !!k.key);
+
+    let env = 'production';
+    const sigHeader = req.headers['x-sardine-signature'] as string | undefined;
+    if (sigHeader && webhookSecrets.length) {
+      try {
+        const rawBody: string = (req as any).rawBody ?? JSON.stringify(req.body);
+        const given = Buffer.from(sigHeader, 'hex');
+        const matched = webhookSecrets.find(({ key }) => {
+          const expected = crypto.createHmac('sha256', key).update(rawBody).digest();
+          return expected.length === given.length && crypto.timingSafeEqual(expected, given);
+        });
+        if (!matched) {
+          throw new Error('Sardine webhook signature mismatch');
+        }
+        env = matched.env;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('Sardine webhook signature error: %s', errMsg);
+        throw new Error('Sardine webhook signature verification failed');
+      }
+    } else {
+      logger.warn('Sardine webhook: signature not verified (header present: %s, secret configured: %s)', !!sigHeader, !!webhookSecrets.length);
+    }
+
+    const body = req.body || {};
+    // Sardine order payload fields (from GET /v1/orders response shape)
+    const order = body.order || body;
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'sardine',
+      externalId: order.id || order.orderId,
+      status: order.status || body.eventType || '',
+      eventName: body.eventType,
+      createdAt: order.createdAt,
+      fiatAmount: order.fiatAmount != null ? Number(order.fiatAmount) : undefined,
+      fiatCurrency: order.currency,
+      cryptoCurrency: order.assetType || order.cryptoCurrency,
+      userId: order.userId || order.externalUserId,
+      rawPayload: body,
+      env
+    });
+
+    return { event };
   }
 }

--- a/packages/bitcore-wallet-service/src/externalservices/simplex.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/simplex.ts
@@ -1,8 +1,11 @@
+import * as crypto from 'crypto';
 import * as request from 'request';
 import Uuid from 'uuid';
 import config from '../config';
 import { Utils } from '../lib/common/utils';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class SimplexService {
@@ -277,5 +280,79 @@ export class SimplexService {
         }
       );
     });
+  }
+
+  /**
+   * Handles incoming Simplex webhook events.
+   * Simplex signs each request with a RS256 JWT in the X-Signature-SHA256 header.
+   * The JWT expires after 5 minutes to prevent replay attacks.
+   * https://integrations.simplex.com/docs/webhooks
+   *
+   * Sandbox and production use different public keys, so the environment is
+   * determined by which configured key verifies the JWT, not by the request.
+   */
+  simplexHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.simplex) throw new Error('Simplex missing credentials');
+
+    const publicKeys: { key: string; env: string }[] = [
+      { key: config.simplex.production?.publicKeyWebhook, env: 'production' },
+      { key: config.simplex.sandbox?.publicKeyWebhook, env: 'sandbox' }
+    ].filter(k => !!k.key);
+
+    let env = 'production';
+    if (publicKeys.length) {
+      const signature = req.headers['x-signature-sha256'] as string;
+      if (!signature) {
+        throw new Error('Simplex webhook missing X-Signature-SHA256 header');
+      }
+      try {
+        // Verify RS256 JWT: split into header.payload.signature parts
+        const parts = signature.split('.');
+        if (parts.length !== 3) throw new Error('Invalid JWT format');
+        const signingInput = `${parts[0]}.${parts[1]}`;
+        const sig = Buffer.from(parts[2], 'base64url');
+        const matched = publicKeys.find(({ key }) => {
+          const verifier = crypto.createVerify('RSA-SHA256');
+          verifier.update(signingInput);
+          return verifier.verify(key, sig);
+        });
+        if (!matched) {
+          throw new Error('Simplex webhook signature mismatch');
+        }
+        const jwtPayload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+        if (jwtPayload?.exp != null && jwtPayload.exp * 1000 < Date.now()) {
+          throw new Error('Simplex webhook JWT expired');
+        }
+        env = matched.env;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('Simplex webhook signature error: %s', errMsg);
+        throw new Error('Simplex webhook signature verification failed');
+      }
+    } else {
+      logger.warn('Simplex webhook: no publicKeyWebhook configured, skipping signature verification');
+    }
+
+    const body = req.body || {};
+    const payment = body.payment || {};
+    const fiatAmount = payment.fiat_total_amount?.amount;
+    const fiatCurrency = payment.fiat_total_amount?.currency;
+    const cryptoCurrency = payment.requested_digital_amount?.currency;
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'simplex',
+      externalId: payment.id || body.event_id,
+      status: body.name || '',
+      eventName: body.name,
+      createdAt: payment.created_at || body.timestamp,
+      fiatAmount: fiatAmount != null ? Number(fiatAmount) : undefined,
+      fiatCurrency,
+      cryptoCurrency,
+      userId: payment.user_id,
+      rawPayload: body,
+      env
+    });
+
+    return { event };
   }
 }

--- a/packages/bitcore-wallet-service/src/externalservices/simplex.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/simplex.ts
@@ -344,6 +344,7 @@ export class SimplexService {
       externalId: payment.id || body.event_id,
       status: body.name || '',
       eventName: body.name,
+      deliveryVersion: body.event_id, // Simplex docs: "Use event_id for idempotency"
       createdAt: payment.created_at || body.timestamp,
       fiatAmount: fiatAmount != null ? Number(fiatAmount) : undefined,
       fiatCurrency,

--- a/packages/bitcore-wallet-service/src/externalservices/transak.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/transak.ts
@@ -7,8 +7,22 @@ import { logger } from '../lib/logger';
 import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
+interface CachedAccessToken {
+  token: string;
+  expiresAt: number; // epoch ms
+}
+
+const ACCESS_TOKEN_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
 export class TransakService {
   request: any = request;
+
+  // In-memory cache of Partner Access Tokens used ONLY to verify webhook JWTs.
+  // Docs: https://docs.transak.com/guides/how-to-decrypt-webhook-payload), the
+  // webhook `data` JWT must be verified with the Partner Access Token
+  // (returned by POST /partners/api/v2/refresh-token), not a static secret.
+  // Tokens are valid ~7 days.
+  private webhookAccessTokenCache: Partial<Record<'sandbox' | 'production', CachedAccessToken>> = {};
 
   private transakGetKeys(req, cleanBody: boolean = true) {
     if (!config.transak) throw new Error('Transak missing credentials');
@@ -55,6 +69,66 @@ export class TransakService {
       userIp = String(userIp).trim().replace(/^::ffff:/i, '');
     }
     return userIp || '';
+  }
+
+  // Calls POST to obtain/refresh the Partner Access Token that verifies webhook JWTs.
+  private transakFetchAccessTokenForEnv(env: 'sandbox' | 'production'): Promise<CachedAccessToken> {
+    return new Promise((resolve, reject) => {
+      if (!config.transak?.[env]) return reject(new Error(`Transak missing ${env} credentials`));
+
+      const API = config.transak[env].api;
+      const API_KEY = config.transak[env].apiKey;
+      const SECRET_KEY = config.transak[env].secretKey;
+
+      const headers = {
+        'Content-Type': 'application/json',
+        'api-secret': SECRET_KEY,
+        'x-api-key': API_KEY
+      };
+      const body = { apiKey: API_KEY };
+      const URL: string = API + '/partners/api/v2/refresh-token';
+
+      this.request.post(
+        URL,
+        {
+          headers,
+          body,
+          json: true
+        },
+        (err, data) => {
+          if (err) {
+            return reject(err.body ? err.body : err);
+          }
+          const res = data.body ? data.body : data;
+          const accessToken: string | undefined = res?.data?.accessToken;
+          const expiresAtSecs: number | undefined = res?.data?.expiresAt;
+          if (!accessToken) {
+            return reject(new Error(`Transak refresh-token response missing accessToken (env=${env})`));
+          }
+          resolve({
+            token: accessToken,
+            expiresAt: expiresAtSecs ? expiresAtSecs * 1000 : Date.now() + 60 * 1000
+          });
+        }
+      );
+    });
+  }
+
+  // Returns a cached, still-valid Partner Access Token for the given env,
+  // refreshing it first if missing/expired.
+  private async transakGetWebhookAccessToken(env: 'sandbox' | 'production'): Promise<string | undefined> {
+    const cached = this.webhookAccessTokenCache[env];
+    if (cached && cached.expiresAt - ACCESS_TOKEN_REFRESH_MARGIN_MS > Date.now()) {
+      return cached.token;
+    }
+    try {
+      const fresh = await this.transakFetchAccessTokenForEnv(env);
+      this.webhookAccessTokenCache[env] = fresh;
+      return fresh.token;
+    } catch (err) {
+      logger.warn('Transak webhook: failed to refresh access token for env=%s: %o', env, err);
+      return undefined;
+    }
   }
 
   transakGetAccessToken(req): Promise<any> {
@@ -339,24 +413,15 @@ export class TransakService {
    * Handles incoming Transak webhook events.
    * The payload data field is a signed HS256 JWT. https://docs.transak.com/features/webhooks
    *
-   * NOTE: per Transak docs the JWT should be verified with the Partner Access Token
-   * (the token returned by /partners/api/v2/refresh-token), which rotates. We first
-   * try the configured static secretKey for each env; if real webhooks fail to
-   * verify, this needs to be switched to a cached access token.
+   * the JWT must be verified with the Partner Access Token https://docs.transak.com/guides/how-to-decrypt-webhook-payload,
    *
-   * The environment is determined by which configured key verifies the JWT,
+   * The env is determined by which env's access token verifies the JWT,
    * not by the request.
    *
-   * Decoded payload: { webhookData: { id, status, fiatCurrency, fiatAmount,
-   *   cryptoCurrency, userId, createdAt, ... }, eventID }
+   * Decoded payload docs: https://docs.transak.com/api/public/get-webhooks
    */
-  transakHandleWebhook(req): { event: OnrampWebhookEvent } {
+  async transakHandleWebhook(req): Promise<{ event: OnrampWebhookEvent }> {
     if (!config.transak) throw new Error('Transak missing credentials');
-
-    const secretKeys: { key: string; env: string }[] = [
-      { key: config.transak.production?.secretKey, env: 'production' },
-      { key: config.transak.sandbox?.secretKey, env: 'sandbox' }
-    ].filter(k => !!k.key);
 
     const jwtToken: string | undefined = req.body?.data;
     if (!jwtToken || typeof jwtToken !== 'string') {
@@ -367,13 +432,19 @@ export class TransakService {
       throw new Error('Invalid JWT format');
     }
 
+    const envsToTry: ('production' | 'sandbox')[] = ['production', 'sandbox'].filter(e => !!config.transak[e]) as any;
+    const fetchedTokens = await Promise.all(envsToTry.map(e => this.transakGetWebhookAccessToken(e)));
+    const verificationKeys: { key: string; env: string }[] = envsToTry
+      .map((e, i) => ({ key: fetchedTokens[i], env: e }))
+      .filter(k => !!k.key) as { key: string; env: string }[];
+
     let env = 'production';
-    if (secretKeys.length) {
+    if (verificationKeys.length) {
       try {
         // Verify HS256 JWT manually using Node crypto (no external library needed)
         const signingInput = `${parts[0]}.${parts[1]}`;
         const given = Buffer.from(parts[2], 'base64url');
-        const matched = secretKeys.find(({ key }) => {
+        const matched = verificationKeys.find(({ key }) => {
           const expected = crypto.createHmac('sha256', key).update(signingInput).digest();
           return expected.length === given.length && crypto.timingSafeEqual(expected, given);
         });
@@ -387,7 +458,7 @@ export class TransakService {
         throw new Error('Transak webhook signature verification failed');
       }
     } else {
-      logger.warn('Transak webhook: no secretKey configured, skipping signature verification');
+      logger.warn('Transak webhook: no access token available for any env, skipping signature verification');
     }
 
     let webhookData: any = {};
@@ -406,9 +477,16 @@ export class TransakService {
       status: webhookData.status || '',
       eventName: eventID,
       createdAt: webhookData.createdAt,
+      // webhookData.updatedAt is the last time this order's state changed at
+      // Transak - used as the delivery version key for idempotency/out-of-order detection.
+      updatedAt: webhookData.updatedAt,
+      deliveryVersion: webhookData.updatedAt,
       fiatAmount: webhookData.fiatAmount != null ? Number(webhookData.fiatAmount) : undefined,
       fiatCurrency: webhookData.fiatCurrency,
+      cryptoAmount: webhookData.cryptoAmount != null ? Number(webhookData.cryptoAmount) : undefined,
       cryptoCurrency: webhookData.cryptoCurrency,
+      paymentMethod: webhookData.paymentOptionId,
+      walletAddress: webhookData.walletAddress,
       userId: webhookData.userId,
       rawPayload: req.body || {},
       env

--- a/packages/bitcore-wallet-service/src/externalservices/transak.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/transak.ts
@@ -1,7 +1,10 @@
+import * as crypto from 'crypto';
 import * as request from 'request';
 import config from '../config';
 import { Utils } from '../lib/common/utils';
 import { ClientError } from '../lib/errors/clienterror';
+import { logger } from '../lib/logger';
+import { OnrampWebhookEvent } from '../lib/model/onrampWebhookEvent';
 import { checkRequired } from '../lib/server';
 
 export class TransakService {
@@ -330,5 +333,87 @@ export class TransakService {
         }
       );
     });
+  }
+
+  /**
+   * Handles incoming Transak webhook events.
+   * The payload data field is a signed HS256 JWT. https://docs.transak.com/features/webhooks
+   *
+   * NOTE: per Transak docs the JWT should be verified with the Partner Access Token
+   * (the token returned by /partners/api/v2/refresh-token), which rotates. We first
+   * try the configured static secretKey for each env; if real webhooks fail to
+   * verify, this needs to be switched to a cached access token.
+   *
+   * The environment is determined by which configured key verifies the JWT,
+   * not by the request.
+   *
+   * Decoded payload: { webhookData: { id, status, fiatCurrency, fiatAmount,
+   *   cryptoCurrency, userId, createdAt, ... }, eventID }
+   */
+  transakHandleWebhook(req): { event: OnrampWebhookEvent } {
+    if (!config.transak) throw new Error('Transak missing credentials');
+
+    const secretKeys: { key: string; env: string }[] = [
+      { key: config.transak.production?.secretKey, env: 'production' },
+      { key: config.transak.sandbox?.secretKey, env: 'sandbox' }
+    ].filter(k => !!k.key);
+
+    const jwtToken: string | undefined = req.body?.data;
+    if (!jwtToken || typeof jwtToken !== 'string') {
+      throw new Error('Transak webhook missing JWT data field');
+    }
+    const parts = jwtToken.split('.');
+    if (parts.length !== 3) {
+      throw new Error('Invalid JWT format');
+    }
+
+    let env = 'production';
+    if (secretKeys.length) {
+      try {
+        // Verify HS256 JWT manually using Node crypto (no external library needed)
+        const signingInput = `${parts[0]}.${parts[1]}`;
+        const given = Buffer.from(parts[2], 'base64url');
+        const matched = secretKeys.find(({ key }) => {
+          const expected = crypto.createHmac('sha256', key).update(signingInput).digest();
+          return expected.length === given.length && crypto.timingSafeEqual(expected, given);
+        });
+        if (!matched) {
+          throw new Error('Transak webhook JWT signature mismatch');
+        }
+        env = matched.env;
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : typeof err === 'string' ? err : JSON.stringify(err);
+        logger.warn('Transak webhook JWT error: %s', errMsg);
+        throw new Error('Transak webhook signature verification failed');
+      }
+    } else {
+      logger.warn('Transak webhook: no secretKey configured, skipping signature verification');
+    }
+
+    let webhookData: any = {};
+    let eventID: string | undefined;
+    try {
+      const decoded = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+      webhookData = decoded.webhookData || {};
+      eventID = decoded.eventID;
+    } catch {
+      throw new Error('Transak webhook JWT payload is not valid JSON');
+    }
+
+    const event = OnrampWebhookEvent.create({
+      partner: 'transak',
+      externalId: webhookData.id,
+      status: webhookData.status || '',
+      eventName: eventID,
+      createdAt: webhookData.createdAt,
+      fiatAmount: webhookData.fiatAmount != null ? Number(webhookData.fiatAmount) : undefined,
+      fiatCurrency: webhookData.fiatCurrency,
+      cryptoCurrency: webhookData.cryptoCurrency,
+      userId: webhookData.userId,
+      rawPayload: req.body || {},
+      env
+    });
+
+    return { event };
   }
 }

--- a/packages/bitcore-wallet-service/src/lib/braze.ts
+++ b/packages/bitcore-wallet-service/src/lib/braze.ts
@@ -2,6 +2,7 @@ import * as request from 'request';
 import config from '../config';
 import { logger } from './logger';
 
+const TRACK_EVENT_TIMEOUT_MS = 3000;
 export interface BrazeTrackEvent {
   externalId: string;
   name: string;
@@ -52,11 +53,22 @@ class BrazeService {
             Authorization: 'Bearer ' + apiKey
           },
           body,
-          json: true
+          json: true,
+          timeout: TRACK_EVENT_TIMEOUT_MS
         },
-        (err, _res, data) => {
+        (err, res, data) => {
+          const statusCode = res?.statusCode;
           if (err) {
             logger.warn('Braze trackEvent request failed (event=%s): %o', event.name, err);
+          } else if (!statusCode || statusCode < 200 || statusCode >= 300) {
+            const redactApiKey = (message: any, apiKey: string): string =>
+              String(message ?? '').split(apiKey).join('[redacted]');
+            logger.warn(
+              'Braze trackEvent rejected with HTTP %s (event=%s): %s',
+              statusCode,
+              event.name,
+              redactApiKey(data?.message, apiKey)
+            );
           } else if (data?.errors?.length) {
             logger.warn('Braze trackEvent returned errors (event=%s): %o', event.name, data.errors);
           }

--- a/packages/bitcore-wallet-service/src/lib/braze.ts
+++ b/packages/bitcore-wallet-service/src/lib/braze.ts
@@ -1,0 +1,70 @@
+import * as request from 'request';
+import config from '../config';
+import { logger } from './logger';
+
+export interface BrazeTrackEvent {
+  externalId: string;
+  name: string;
+  time?: string; // ISO8601, defaults to now
+  properties?: Record<string, any>;
+}
+
+/**
+ * Minimal client for the Braze REST API "track" endpoint, used to log custom
+ * events against a user profile (https://www.braze.com/docs/api/endpoints/user_data/post_user_track/).
+ */
+class BrazeService {
+  request: any = request;
+
+  /**
+   * Fire-and-forget: never rejects. Callers should not await this before
+   * responding to time-sensitive requests (e.g. partner webhooks).
+   */
+  trackEvent(event: BrazeTrackEvent): Promise<void> {
+    return new Promise(resolve => {
+      const url: string | undefined = config.braze?.bwsTrackEventApi;
+      const apiKey: string | undefined = config.braze?.bwsTrackEventApiKey;
+      if (!url || !apiKey) {
+        logger.warn('Braze trackEvent skipped: bwsTrackEventApi/bwsTrackEventApiKey not configured');
+        return resolve();
+      }
+      if (!event.externalId) {
+        logger.debug('Braze trackEvent skipped: missing externalId (event=%s)', event.name);
+        return resolve();
+      }
+
+      const body = {
+        events: [
+          {
+            external_id: event.externalId,
+            name: event.name,
+            time: event.time || new Date().toISOString(),
+            properties: event.properties || {}
+          }
+        ]
+      };
+
+      this.request.post(
+        url + '/users/track',
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer ' + apiKey
+          },
+          body,
+          json: true
+        },
+        (err, _res, data) => {
+          if (err) {
+            logger.warn('Braze trackEvent request failed (event=%s): %o', event.name, err);
+          } else if (data?.errors?.length) {
+            logger.warn('Braze trackEvent returned errors (event=%s): %o', event.name, data.errors);
+          }
+          return resolve();
+        }
+      );
+    });
+  }
+}
+
+export const brazeService = new BrazeService();

--- a/packages/bitcore-wallet-service/src/lib/expressapp.ts
+++ b/packages/bitcore-wallet-service/src/lib/expressapp.ts
@@ -19,6 +19,7 @@ import { registerTransactionRoutes } from './routes/transactions';
 import { TssRouter } from './routes/tss';
 import { registerWalletDataRoutes } from './routes/walletdata';
 import { registerWalletRoutes } from './routes/wallets';
+import { registerWebhookRoutes } from './routes/webhooks';
 import { WalletService } from './server';
 
 export class ExpressApp {
@@ -127,6 +128,11 @@ export class ExpressApp {
     registerMoralisRoutes(router, {
       getServer,
       getServerWithAuth,
+      returnError
+    });
+
+    registerWebhookRoutes(router, {
+      getServer,
       returnError
     });
 

--- a/packages/bitcore-wallet-service/src/lib/model/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/index.ts
@@ -1,5 +1,6 @@
 export { Address } from './address';
 export { Copayer } from './copayer';
+export { IOnrampWebhookEvent, OnrampWebhookEvent } from './onrampWebhookEvent';
 export { Advertisement } from './advertisement';
 export { Email } from './email';
 export { INotification, Notification } from './notification';

--- a/packages/bitcore-wallet-service/src/lib/model/index.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/index.ts
@@ -1,6 +1,11 @@
 export { Address } from './address';
 export { Copayer } from './copayer';
-export { IOnrampWebhookEvent, OnrampWebhookEvent } from './onrampWebhookEvent';
+export {
+  IOnrampWebhookEvent,
+  IStoredOnrampWebhookEvent,
+  IStoreOnrampWebhookEventResult,
+  OnrampWebhookEvent
+} from './onrampWebhookEvent';
 export { Advertisement } from './advertisement';
 export { Email } from './email';
 export { INotification, Notification } from './notification';

--- a/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
@@ -81,7 +81,7 @@ export class OnrampWebhookEvent implements IOnrampWebhookEvent {
 /** Shape persisted in the onramp_webhook_events collection. */
 export interface IStoredOnrampWebhookEvent extends Omit<
   IOnrampWebhookEvent,
-  'eventName' | 'rawPayload' | 'deliveryVersion' | 'walletAddress' | 'walletAddressTag'
+  'eventName' | 'rawPayload' | 'deliveryVersion'
 > {
   _id: string;
   eventName: string;
@@ -92,4 +92,5 @@ export interface IStoreOnrampWebhookEventResult {
   inserted: boolean;
   id: string;
   event: IStoredOnrampWebhookEvent;
+  isStale: boolean;
 }

--- a/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
@@ -1,0 +1,67 @@
+export interface IOnrampWebhookEvent {
+  partner: string;       // 'simplex' | 'moonpay' | 'ramp' | 'transak' | 'banxa' | 'sardine'
+  externalId: string;    // transaction/order/payment ID from partner
+  status: string;        // raw status string from partner
+  eventName?: string;    // event type/name if available (e.g. 'ORDER_COMPLETED', 'transaction_updated')
+  createdAt?: string;    // ISO timestamp from partner payload
+  fiatAmount?: number;
+  fiatCurrency?: string;
+  cryptoAmount?: number;   // amount of crypto (quoteCurrencyAmount)
+  cryptoCurrency?: string;
+  paymentMethod?: string;
+  walletAddress?: string;
+  walletAddressTag?: string;
+  userId?: string;       // external customer/user ID from partner
+  rawPayload: object;    // full raw payload stored for reconciliation/debugging
+  receivedAt: number;    // epoch ms when received
+  env: string;           // 'sandbox' | 'production'
+  isEmbedded?: boolean;  // true if the event comes from the embedded flow (verified with the embedded webhook key)
+}
+
+export class OnrampWebhookEvent implements IOnrampWebhookEvent {
+  partner: string;
+  externalId: string;
+  status: string;
+  eventName?: string;
+  createdAt?: string;
+  fiatAmount?: number;
+  fiatCurrency?: string;
+  cryptoAmount?: number;
+  cryptoCurrency?: string;
+  paymentMethod?: string;
+  walletAddress?: string;
+  walletAddressTag?: string;
+  userId?: string;
+  rawPayload: object;
+  receivedAt: number;
+  env: string;
+  isEmbedded?: boolean;
+
+  static create(opts: Partial<IOnrampWebhookEvent>): OnrampWebhookEvent {
+    const x = new OnrampWebhookEvent();
+    x.partner = opts.partner;
+    x.externalId = opts.externalId;
+    x.status = opts.status;
+    x.eventName = opts.eventName;
+    x.createdAt = opts.createdAt;
+    x.fiatAmount = opts.fiatAmount;
+    x.fiatCurrency = opts.fiatCurrency;
+    x.cryptoAmount = opts.cryptoAmount;
+    x.cryptoCurrency = opts.cryptoCurrency;
+    x.paymentMethod = opts.paymentMethod;
+    x.walletAddress = opts.walletAddress;
+    x.walletAddressTag = opts.walletAddressTag;
+    x.userId = opts.userId;
+    x.rawPayload = opts.rawPayload || {};
+    x.receivedAt = opts.receivedAt || Date.now();
+    x.env = opts.env || 'production';
+    x.isEmbedded = opts.isEmbedded;
+    return x;
+  }
+
+  static fromObj(obj: any): OnrampWebhookEvent {
+    const x = new OnrampWebhookEvent();
+    Object.assign(x, obj);
+    return x;
+  }
+}

--- a/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/onrampWebhookEvent.ts
@@ -4,6 +4,12 @@ export interface IOnrampWebhookEvent {
   status: string;        // raw status string from partner
   eventName?: string;    // event type/name if available (e.g. 'ORDER_COMPLETED', 'transaction_updated')
   createdAt?: string;    // ISO timestamp from partner payload
+  updatedAt?: string;    // ISO timestamp of this transaction state at the partner
+  // Tells two deliveries of the same transaction apart. Each partner documents
+  // a different one (moonpay: updatedAt, simplex: event_id, banxa: status);
+  // defaults to status when the handler sets none.
+  deliveryVersion?: string;
+  externalTransactionId?: string;
   fiatAmount?: number;
   fiatCurrency?: string;
   cryptoAmount?: number;   // amount of crypto (quoteCurrencyAmount)
@@ -12,7 +18,7 @@ export interface IOnrampWebhookEvent {
   walletAddress?: string;
   walletAddressTag?: string;
   userId?: string;       // external customer/user ID from partner
-  rawPayload: object;    // full raw payload stored for reconciliation/debugging
+  rawPayload: object;    // original payload available to the webhook processor
   receivedAt: number;    // epoch ms when received
   env: string;           // 'sandbox' | 'production'
   isEmbedded?: boolean;  // true if the event comes from the embedded flow (verified with the embedded webhook key)
@@ -24,6 +30,9 @@ export class OnrampWebhookEvent implements IOnrampWebhookEvent {
   status: string;
   eventName?: string;
   createdAt?: string;
+  updatedAt?: string;
+  deliveryVersion?: string;
+  externalTransactionId?: string;
   fiatAmount?: number;
   fiatCurrency?: string;
   cryptoAmount?: number;
@@ -44,6 +53,9 @@ export class OnrampWebhookEvent implements IOnrampWebhookEvent {
     x.status = opts.status;
     x.eventName = opts.eventName;
     x.createdAt = opts.createdAt;
+    x.updatedAt = opts.updatedAt;
+    x.deliveryVersion = opts.deliveryVersion;
+    x.externalTransactionId = opts.externalTransactionId;
     x.fiatAmount = opts.fiatAmount;
     x.fiatCurrency = opts.fiatCurrency;
     x.cryptoAmount = opts.cryptoAmount;
@@ -64,4 +76,20 @@ export class OnrampWebhookEvent implements IOnrampWebhookEvent {
     Object.assign(x, obj);
     return x;
   }
+}
+
+/** Shape persisted in the onramp_webhook_events collection. */
+export interface IStoredOnrampWebhookEvent extends Omit<
+  IOnrampWebhookEvent,
+  'eventName' | 'rawPayload' | 'deliveryVersion' | 'walletAddress' | 'walletAddressTag'
+> {
+  _id: string;
+  eventName: string;
+  expiresAt: Date;      // TTL index anchor; the delivery log is not kept forever
+}
+
+export interface IStoreOnrampWebhookEventResult {
+  inserted: boolean;
+  id: string;
+  event: IStoredOnrampWebhookEvent;
 }

--- a/packages/bitcore-wallet-service/src/lib/routes/setup.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/setup.ts
@@ -44,11 +44,18 @@ export function setupAppMiddleware(app: express.Express, opts) {
   const POST_LIMIT = 1024 * 100;
   const POST_LIMIT_LARGE = 2 * 1024 * 1024;
 
+  // Capture raw body for webhook routes (needed for HMAC signature verification)
+  const captureRawBody = (req: any, _res: any, buf: Buffer) => {
+    if (req.path?.includes('/webhook')) {
+      req.rawBody = buf.toString('utf8');
+    }
+  };
+
   app.use((req, res, next) => {
     if (req.path.includes('/txproposals') || req.path.includes('/tss/')) {
-      return express.json({ limit: POST_LIMIT_LARGE })(req, res, next);
+      return express.json({ limit: POST_LIMIT_LARGE, verify: captureRawBody })(req, res, next);
     } else {
-      return express.json({ limit: POST_LIMIT })(req, res, next);
+      return express.json({ limit: POST_LIMIT, verify: captureRawBody })(req, res, next);
     }
   });
 

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -10,15 +10,25 @@ interface RouteContext {
 }
 
 /**
- * Shared handler: parse/verify event via service handler, log it, respond 200.
- * Invalid payloads/signatures get a 400 so the partner knows it was rejected.
+ * Shared handler: parse/verify event via service handler, log it, optionally
+ * store it, respond 200.
+ * Invalid signatures and payloads that cannot be keyed get a 400; a storage
+ * outage gets a 503 so the partner retries the delivery.
+ * Never rejects: any unexpected error falls through to a 500 so the partner
+ * always gets a response instead of hanging until it times out.
+ *
+ * storeEvent (when provided) must run BEFORE the Braze track call: partners
+ * can (and do) redeliver the same event, so we only want to emit analytics
+ * once per unique delivery. If storeEvent reports `inserted: false`, this was
+ * already handled before (a duplicate/retry) and tracking is skipped.
  */
-function handleWebhook(
+async function handleWebhook(
   req: express.Request,
   res: express.Response,
   partner: string,
-  parseEvent: () => { event: OnrampWebhookEvent }
-) {
+  parseEvent: () => { event: OnrampWebhookEvent },
+  storeEvent?: (event: OnrampWebhookEvent) => Promise<{ inserted: boolean } | undefined>
+): Promise<express.Response> {
   let event: OnrampWebhookEvent;
   try {
     ({ event } = parseEvent());
@@ -28,30 +38,60 @@ function handleWebhook(
     return res.status(400).json({ error: (err as Error).message });
   }
 
-  logger.info(`[webhook:${partner}] Received event externalId=%s status=%s`, event?.externalId, event?.status);
+  try {
+    logger.info(`[webhook:${partner}] Received event externalId=%s status=%s`, event?.externalId, event?.status);
 
-  // Fire-and-forget: analytics tracking must never block or fail the webhook ack.
-  brazeService
-    .trackEvent({
-      externalId: event?.userId,
-      name: 'onramp_webhook_received',
-      properties: {
-        partner: event?.partner,
-        status: event?.status,
-        eventName: event?.eventName,
-        externalId: event?.externalId,
-        fiatAmount: event?.fiatAmount,
-        fiatCurrency: event?.fiatCurrency,
-        cryptoAmount: event?.cryptoAmount,
-        cryptoCurrency: event?.cryptoCurrency,
-        paymentMethod: event?.paymentMethod,
-        env: event?.env,
-        isEmbedded: event?.isEmbedded
+    // Persist first (if applicable) so we know whether this delivery was
+    // already handled before deciding whether to emit analytics for it.
+    let isDuplicate = false;
+    if (storeEvent) {
+      try {
+        const result = await storeEvent(event);
+        isDuplicate = result?.inserted === false;
+        if (isDuplicate) {
+          logger.info(`[webhook:${partner}] Duplicate delivery detected, skipping Braze tracking externalId=%s`, event?.externalId);
+        }
+      } catch (err) {
+        logger.error(`[webhook:${partner}] Failed to store event: %o`, err);
+        if ((err as any)?.invalidPayload) {
+          return res.status(400).json({ error: (err as Error).message });
+        }
+        return res.status(503).json({ error: 'Webhook storage temporarily unavailable' });
       }
-    })
-    .catch(err => logger.warn(`[webhook:${partner}] Braze tracking failed: %o`, err));
+    }
 
-  return res.status(200).json({ ok: true });
+    if (!isDuplicate) {
+      // Fire-and-forget: analytics tracking must never block or fail the webhook ack.
+      brazeService
+        .trackEvent({
+          externalId: event?.userId,
+          name: 'onramp_webhook_received',
+          properties: {
+            partner: event?.partner,
+            status: event?.status,
+            eventName: event?.eventName,
+            externalId: event?.externalId,
+            fiatAmount: event?.fiatAmount,
+            fiatCurrency: event?.fiatCurrency,
+            cryptoAmount: event?.cryptoAmount,
+            cryptoCurrency: event?.cryptoCurrency,
+            paymentMethod: event?.paymentMethod,
+            env: event?.env,
+            isEmbedded: event?.isEmbedded
+          }
+        })
+        .catch(err => logger.warn(`[webhook:${partner}] Braze tracking failed: %o`, err));
+    }
+
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    // Safety net: guarantees a response even if something above throws
+    // unexpectedly (e.g. a bug in a fire-and-forget call), instead of leaving
+    // an unhandled rejection and the partner request hanging.
+    logger.error(`[webhook:${partner}] Unexpected error handling webhook: %o`, err);
+    if (res.headersSent) return res;
+    return res.status(500).json({ error: 'Internal error handling webhook' });
+  }
 }
 
 export function registerWebhookRoutes(router: express.Router, context: RouteContext) {
@@ -64,10 +104,10 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/simplex/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'simplex',
       () => server.externalServices.simplex.simplexHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:simplex] Unhandled error: %o', err));
   });
 
   /**
@@ -77,10 +117,11 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/moonpay/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'moonpay',
-      () => server.externalServices.moonpay.moonpayHandleWebhook(req)
-    );
+      () => server.externalServices.moonpay.moonpayHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
+    ).catch(err => logger.error('[webhook:moonpay] Unhandled error: %o', err));
   });
 
   /**
@@ -90,10 +131,10 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/ramp/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'ramp',
       () => server.externalServices.ramp.rampHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:ramp] Unhandled error: %o', err));
   });
 
   /**
@@ -103,10 +144,10 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/ramp/offramp-webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'ramp',
       () => server.externalServices.ramp.rampHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:ramp] Unhandled error: %o', err));
   });
 
   /**
@@ -116,10 +157,10 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/transak/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'transak',
       () => server.externalServices.transak.transakHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:transak] Unhandled error: %o', err));
   });
 
   /**
@@ -129,10 +170,10 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/banxa/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'banxa',
       () => server.externalServices.banxa.banxaHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:banxa] Unhandled error: %o', err));
   });
 
   /**
@@ -142,9 +183,9 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/sardine/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
-    handleWebhook(
+    return handleWebhook(
       req, res, 'sardine',
       () => server.externalServices.sardine.sardineHandleWebhook(req)
-    );
+    ).catch(err => logger.error('[webhook:sardine] Unhandled error: %o', err));
   });
 }

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -29,12 +29,12 @@ async function handleWebhook(
   req: express.Request,
   res: express.Response,
   partner: string,
-  parseEvent: () => { event: OnrampWebhookEvent },
+  parseEvent: () => { event: OnrampWebhookEvent } | Promise<{ event: OnrampWebhookEvent }>,
   storeEvent?: (event: OnrampWebhookEvent) => Promise<{ inserted: boolean; isStale?: boolean } | undefined>
 ): Promise<express.Response> {
   let event: OnrampWebhookEvent;
   try {
-    ({ event } = parseEvent());
+    ({ event } = await parseEvent());
   } catch (err) {
     logger.error(`[webhook:${partner}] Failed to process payload: %o`, err);
     // Return 400 so partner knows the payload was rejected (e.g. bad signature)
@@ -111,7 +111,8 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
     if (!server) return;
     return handleWebhook(
       req, res, 'simplex',
-      () => server.externalServices.simplex.simplexHandleWebhook(req)
+      () => server.externalServices.simplex.simplexHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:simplex] Unhandled error: %o', err));
   });
 
@@ -138,7 +139,8 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
     if (!server) return;
     return handleWebhook(
       req, res, 'ramp',
-      () => server.externalServices.ramp.rampHandleWebhook(req)
+      () => server.externalServices.ramp.rampHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:ramp] Unhandled error: %o', err));
   });
 
@@ -151,20 +153,23 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
     if (!server) return;
     return handleWebhook(
       req, res, 'ramp',
-      () => server.externalServices.ramp.rampHandleWebhook(req)
+      () => server.externalServices.ramp.rampHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:ramp] Unhandled error: %o', err));
   });
 
   /**
    * POST /v1/service/transak/webhook
-   * Transak order event. Payload data field is a HS256 JWT signed with SECRET_KEY.
+   * Transak order event. Payload data field is a HS256 JWT signed with the
+   * Partner Access Token (rotates, cached per env in TransakService).
    */
   router.post('/v1/service/transak/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
     return handleWebhook(
       req, res, 'transak',
-      () => server.externalServices.transak.transakHandleWebhook(req)
+      () => server.externalServices.transak.transakHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:transak] Unhandled error: %o', err));
   });
 
@@ -183,14 +188,15 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
 
   /**
    * POST /v1/service/sardine/webhook
-   * Sardine order event. Optionally secured with HMAC-SHA256 in X-Sardine-Signature.
+   * Sardine order event.
    */
   router.post('/v1/service/sardine/webhook', (req, res) => {
     const server = getServer(req, res);
     if (!server) return;
     return handleWebhook(
       req, res, 'sardine',
-      () => server.externalServices.sardine.sardineHandleWebhook(req)
+      () => server.externalServices.sardine.sardineHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:sardine] Unhandled error: %o', err));
   });
 }

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -20,14 +20,17 @@ interface RouteContext {
  * storeEvent (when provided) must run BEFORE the Braze track call: partners
  * can (and do) redeliver the same event, so we only want to emit analytics
  * once per unique delivery. If storeEvent reports `inserted: false`, this was
- * already handled before (a duplicate/retry) and tracking is skipped.
+ * already handled before (a duplicate/retry) and tracking is skipped. If it
+ * reports `isStale: true`, a newer state for the same transaction was already
+ * recorded (the partner delivered events out of order) and tracking is
+ * skipped too, so a late/older update never overwrites newer state downstream.
  */
 async function handleWebhook(
   req: express.Request,
   res: express.Response,
   partner: string,
   parseEvent: () => { event: OnrampWebhookEvent },
-  storeEvent?: (event: OnrampWebhookEvent) => Promise<{ inserted: boolean } | undefined>
+  storeEvent?: (event: OnrampWebhookEvent) => Promise<{ inserted: boolean; isStale?: boolean } | undefined>
 ): Promise<express.Response> {
   let event: OnrampWebhookEvent;
   try {
@@ -47,9 +50,9 @@ async function handleWebhook(
     if (storeEvent) {
       try {
         const result = await storeEvent(event);
-        isDuplicate = result?.inserted === false;
+        isDuplicate = result?.inserted === false || result?.isStale === true;
         if (isDuplicate) {
-          logger.info(`[webhook:${partner}] Duplicate delivery detected, skipping Braze tracking externalId=%s`, event?.externalId);
+          logger.info(`[webhook:${partner}] Duplicate or stale/out-of-order delivery detected, skipping Braze tracking externalId=%s`, event?.externalId);
         }
       } catch (err) {
         logger.error(`[webhook:${partner}] Failed to store event: %o`, err);
@@ -65,7 +68,7 @@ async function handleWebhook(
       brazeService
         .trackEvent({
           externalId: event?.userId,
-          name: 'onramp_webhook_received',
+          name: 'BWS - ONRAMP Webhook Received',
           properties: {
             partner: event?.partner,
             status: event?.status,
@@ -76,6 +79,8 @@ async function handleWebhook(
             cryptoAmount: event?.cryptoAmount,
             cryptoCurrency: event?.cryptoCurrency,
             paymentMethod: event?.paymentMethod,
+            walletAddress: event?.walletAddress,
+            walletAddressTag: event?.walletAddressTag,
             env: event?.env,
             isEmbedded: event?.isEmbedded
           }

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { brazeService } from '../braze';
 import { logger } from '../logger';
 import { OnrampWebhookEvent } from '../model/onrampWebhookEvent';
 import type * as Types from '../../types/expressapp';
@@ -28,6 +29,28 @@ function handleWebhook(
   }
 
   logger.info(`[webhook:${partner}] Received event externalId=%s status=%s`, event?.externalId, event?.status);
+
+  // Fire-and-forget: analytics tracking must never block or fail the webhook ack.
+  brazeService
+    .trackEvent({
+      externalId: event?.userId,
+      name: 'onramp_webhook_received',
+      properties: {
+        partner: event?.partner,
+        status: event?.status,
+        eventName: event?.eventName,
+        externalId: event?.externalId,
+        fiatAmount: event?.fiatAmount,
+        fiatCurrency: event?.fiatCurrency,
+        cryptoAmount: event?.cryptoAmount,
+        cryptoCurrency: event?.cryptoCurrency,
+        paymentMethod: event?.paymentMethod,
+        env: event?.env,
+        isEmbedded: event?.isEmbedded
+      }
+    })
+    .catch(err => logger.warn(`[webhook:${partner}] Braze tracking failed: %o`, err));
+
   return res.status(200).json({ ok: true });
 }
 

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -182,7 +182,8 @@ export function registerWebhookRoutes(router: express.Router, context: RouteCont
     if (!server) return;
     return handleWebhook(
       req, res, 'banxa',
-      () => server.externalServices.banxa.banxaHandleWebhook(req)
+      () => server.externalServices.banxa.banxaHandleWebhook(req),
+      event => server.storage.storeOnrampWebhookEvent({ event })
     ).catch(err => logger.error('[webhook:banxa] Unhandled error: %o', err));
   });
 

--- a/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/webhooks.ts
@@ -1,0 +1,127 @@
+import express from 'express';
+import { logger } from '../logger';
+import { OnrampWebhookEvent } from '../model/onrampWebhookEvent';
+import type * as Types from '../../types/expressapp';
+
+interface RouteContext {
+  getServer: Types.GetServerFn;
+  returnError: Types.ReturnErrorFn;
+}
+
+/**
+ * Shared handler: parse/verify event via service handler, log it, respond 200.
+ * Invalid payloads/signatures get a 400 so the partner knows it was rejected.
+ */
+function handleWebhook(
+  req: express.Request,
+  res: express.Response,
+  partner: string,
+  parseEvent: () => { event: OnrampWebhookEvent }
+) {
+  let event: OnrampWebhookEvent;
+  try {
+    ({ event } = parseEvent());
+  } catch (err) {
+    logger.error(`[webhook:${partner}] Failed to process payload: %o`, err);
+    // Return 400 so partner knows the payload was rejected (e.g. bad signature)
+    return res.status(400).json({ error: (err as Error).message });
+  }
+
+  logger.info(`[webhook:${partner}] Received event externalId=%s status=%s`, event?.externalId, event?.status);
+  return res.status(200).json({ ok: true });
+}
+
+export function registerWebhookRoutes(router: express.Router, context: RouteContext) {
+  const { getServer } = context;
+
+  /**
+   * POST /v1/service/simplex/webhook
+   * Simplex payment event webhook. Secured with RS256 JWT in X-Signature-SHA256.
+   */
+  router.post('/v1/service/simplex/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'simplex',
+      () => server.externalServices.simplex.simplexHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/moonpay/webhook
+   * MoonPay buy/sell transaction event. Secured with HMAC-SHA256 in moonpay-signature-v2.
+   */
+  router.post('/v1/service/moonpay/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'moonpay',
+      () => server.externalServices.moonpay.moonpayHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/ramp/webhook
+   * Ramp buy (purchase) event. Configured via webhookStatusUrl in the Ramp widget.
+   */
+  router.post('/v1/service/ramp/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'ramp',
+      () => server.externalServices.ramp.rampHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/ramp/offramp-webhook
+   * Ramp sell (offramp) event. Configured via offrampWebhookV3Url in the Ramp widget.
+   */
+  router.post('/v1/service/ramp/offramp-webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'ramp',
+      () => server.externalServices.ramp.rampHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/transak/webhook
+   * Transak order event. Payload data field is a HS256 JWT signed with SECRET_KEY.
+   */
+  router.post('/v1/service/transak/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'transak',
+      () => server.externalServices.transak.transakHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/banxa/webhook
+   * Banxa order status event. Secured with HMAC-SHA256 in Authorization header.
+   */
+  router.post('/v1/service/banxa/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'banxa',
+      () => server.externalServices.banxa.banxaHandleWebhook(req)
+    );
+  });
+
+  /**
+   * POST /v1/service/sardine/webhook
+   * Sardine order event. Optionally secured with HMAC-SHA256 in X-Sardine-Signature.
+   */
+  router.post('/v1/service/sardine/webhook', (req, res) => {
+    const server = getServer(req, res);
+    if (!server) return;
+    handleWebhook(
+      req, res, 'sardine',
+      () => server.externalServices.sardine.sardineHandleWebhook(req)
+    );
+  });
+}

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -11,6 +11,9 @@ import {
   Advertisement,
   Copayer,
   Email,
+  IOnrampWebhookEvent,
+  IStoreOnrampWebhookEventResult,
+  IStoredOnrampWebhookEvent,
   Notification,
   Preferences,
   PushNotificationSub,
@@ -42,13 +45,36 @@ const collections = {
   TX_CONFIRMATION_SUBS: 'tx_confirmation_subs',
   LOCKS: 'locks',
   TSS_KEYGEN: 'tss_keygen',
-  TSS_SIGN: 'tss_sign'
+  TSS_SIGN: 'tss_sign',
+  ONRAMP_WEBHOOK_EVENTS: 'onramp_webhook_events'
 };
 
 const Defaults = Common.Defaults;
 const Utils = Common.Utils;
 
 const ObjectID = mongodb.ObjectID;
+const ONRAMP_WEBHOOK_EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+
+const requireOnrampValue = (value: string | undefined, name: string): string => {
+  if (typeof value !== 'string' || !value.trim()) {
+    // Flagged so the route answers 400 instead of 503: no amount of partner
+    // retries will add a field the payload never carried.
+    const err: any = new Error(`Missing onramp webhook ${name}`);
+    err.invalidPayload = true;
+    throw err;
+  }
+  return value;
+};
+
+const requireOnrampIdPart = (value: string | undefined, name: string) => {
+  return encodeURIComponent(requireOnrampValue(value, name));
+};
+
+const onrampDocumentId = (prefix: string, parts: Array<{ name: string; value: string }>) => {
+  return [prefix, ...parts.map(part => requireOnrampIdPart(part.value, part.name))].join(':');
+};
+
+const isDuplicateKeyError = (err: any) => err && err.code === 11000;
 
 const objectIdDate = function(date) {
   return Math.floor(date / 1000).toString(16) + '0000000000000000';
@@ -169,6 +195,15 @@ export class Storage {
     db.collection(collections.TSS_SIGN).createIndex({
       id: 1
     }, { unique: true });
+    db.collection(collections.ONRAMP_WEBHOOK_EVENTS).createIndex({
+      partner: 1,
+      env: 1,
+      externalId: 1,
+      updatedAt: -1
+    });
+    db.collection(collections.ONRAMP_WEBHOOK_EVENTS).createIndex({
+      expiresAt: 1
+    }, { expireAfterSeconds: 0 });
   }
 
   connect(opts, cb) {
@@ -1922,6 +1957,59 @@ export class Storage {
 
   async removeTssSigSession({ id }: { id: string }) {
     return this.db.collection(collections.TSS_SIGN).deleteOne({ id }, { w: 1 });
+  }
+
+  /**
+   * Persists a webhook delivery keyed by (partner, env, eventName, externalId,
+   * deliveryVersion) so retried deliveries are idempotent: a duplicate insert
+   * (same _id) is detected via the unique key violation (E11000) and the
+   * previously stored event is returned instead of throwing.
+   */
+  async storeOnrampWebhookEvent({ event }: {
+    event: IOnrampWebhookEvent;
+  }): Promise<IStoreOnrampWebhookEventResult> {
+    if (!this.db) throw new Error('Storage not ready');
+
+    const eventName = requireOnrampValue(event.eventName, 'eventName');
+    const deliveryVersion = requireOnrampValue(event.deliveryVersion ?? event.status, 'deliveryVersion');
+    const id = onrampDocumentId('onramp-webhook', [
+      { name: 'provider', value: event.partner },
+      { name: 'env', value: event.env },
+      { name: 'eventName', value: eventName },
+      { name: 'transactionId', value: event.externalId },
+      { name: 'deliveryVersion', value: deliveryVersion }
+    ]);
+    const receivedAt = Number.isFinite(event.receivedAt) ? event.receivedAt : Date.now();
+    const storedEvent: IStoredOnrampWebhookEvent = {
+      _id: id,
+      partner: event.partner,
+      externalId: event.externalId,
+      status: event.status,
+      eventName,
+      receivedAt,
+      expiresAt: new Date(receivedAt + ONRAMP_WEBHOOK_EVENT_RETENTION_MS),
+      env: event.env,
+      ...(event.createdAt !== undefined && { createdAt: event.createdAt }),
+      ...(event.updatedAt !== undefined && { updatedAt: event.updatedAt }),
+      ...(event.externalTransactionId !== undefined && { externalTransactionId: event.externalTransactionId }),
+      ...(event.fiatAmount !== undefined && { fiatAmount: event.fiatAmount }),
+      ...(event.fiatCurrency !== undefined && { fiatCurrency: event.fiatCurrency }),
+      ...(event.cryptoAmount !== undefined && { cryptoAmount: event.cryptoAmount }),
+      ...(event.cryptoCurrency !== undefined && { cryptoCurrency: event.cryptoCurrency }),
+      ...(event.paymentMethod !== undefined && { paymentMethod: event.paymentMethod }),
+      ...(event.userId !== undefined && { userId: event.userId }),
+      ...(event.isEmbedded !== undefined && { isEmbedded: event.isEmbedded })
+    };
+
+    try {
+      await this.db.collection(collections.ONRAMP_WEBHOOK_EVENTS).insertOne(storedEvent);
+      return { inserted: true, id, event: storedEvent };
+    } catch (err) {
+      if (!isDuplicateKeyError(err)) throw err;
+      const existing = await this.db.collection(collections.ONRAMP_WEBHOOK_EVENTS).findOne({ _id: id });
+      if (!existing) throw err;
+      return { inserted: false, id, event: existing as IStoredOnrampWebhookEvent };
+    }
   }
 
 }

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -53,7 +53,7 @@ const Defaults = Common.Defaults;
 const Utils = Common.Utils;
 
 const ObjectID = mongodb.ObjectID;
-const ONRAMP_WEBHOOK_EVENT_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const ONRAMP_WEBHOOK_EVENT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 const requireOnrampValue = (value: string | undefined, name: string): string => {
   if (typeof value !== 'string' || !value.trim()) {
@@ -1997,18 +1997,37 @@ export class Storage {
       ...(event.cryptoAmount !== undefined && { cryptoAmount: event.cryptoAmount }),
       ...(event.cryptoCurrency !== undefined && { cryptoCurrency: event.cryptoCurrency }),
       ...(event.paymentMethod !== undefined && { paymentMethod: event.paymentMethod }),
+      ...(event.walletAddress !== undefined && { walletAddress: event.walletAddress }),
+      ...(event.walletAddressTag !== undefined && { walletAddressTag: event.walletAddressTag }),
       ...(event.userId !== undefined && { userId: event.userId }),
       ...(event.isEmbedded !== undefined && { isEmbedded: event.isEmbedded })
     };
 
+    console.log(`Storing onramp webhook event ${eventName} for partner ${event.partner} with id ${id} storedEvent:`, JSON.stringify(storedEvent));
+
     try {
       await this.db.collection(collections.ONRAMP_WEBHOOK_EVENTS).insertOne(storedEvent);
-      return { inserted: true, id, event: storedEvent };
+      let isStale = false;
+      if (storedEvent.updatedAt) {
+        const newer = await this.db.collection(collections.ONRAMP_WEBHOOK_EVENTS).findOne(
+          {
+            partner: event.partner,
+            env: event.env,
+            externalId: event.externalId,
+            _id: { $ne: id },
+            updatedAt: { $gt: storedEvent.updatedAt }
+          },
+          { projection: { _id: 1 } }
+        );
+        isStale = !!newer;
+      }
+
+      return { inserted: true, id, event: storedEvent, isStale };
     } catch (err) {
       if (!isDuplicateKeyError(err)) throw err;
       const existing = await this.db.collection(collections.ONRAMP_WEBHOOK_EVENTS).findOne({ _id: id });
       if (!existing) throw err;
-      return { inserted: false, id, event: existing as IStoredOnrampWebhookEvent };
+      return { inserted: false, id, event: existing as IStoredOnrampWebhookEvent, isStale: false };
     }
   }
 

--- a/packages/bitcore-wallet-service/test/integration/externalservices/banxa.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/banxa.test.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import 'chai/register-should';
+import * as crypto from 'crypto';
 import util from 'util';
 import { WalletService } from '../../../src/lib/server';
 import * as TestData from '../../testdata';
@@ -364,6 +365,114 @@ describe('Banxa integration', () => {
 
       try {
         await server.externalServices.banxa.banxaGetOrder(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Banxa missing credentials');
+      }
+    });
+  });
+
+  describe('#banxaHandleWebhook', () => {
+    let body;
+    const webhookPath = '/v1/service/banxa/webhook';
+
+    function banxaAuthHeader(secret, apiKey, nonce, rawBody) {
+      const signingString = `POST\n${webhookPath}\n${nonce}\n${rawBody}`;
+      const sig = crypto.createHmac('sha256', secret).update(signingString).digest('hex');
+      return `Bearer ${apiKey}:${sig}:${nonce}`;
+    }
+
+    beforeEach(() => {
+      body = {
+        order_id: 'order1',
+        status: 'complete',
+        order_type: 'CRYPTO-BUY',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:05:00Z',
+        fiat_amount: '100',
+        fiat_currency: 'USD',
+        crypto_amount: '0.002',
+        crypto_coin: 'BTC',
+        payment_method: 'card',
+        metadata: 'user1'
+      };
+      req = { headers: {}, body };
+    });
+
+    it('should verify and parse a valid webhook payload', () => {
+      const nonce = Date.now().toString();
+      req.headers['authorization'] = banxaAuthHeader('secretKey2', 'apiKey2', nonce, JSON.stringify(body));
+      const { event } = server.externalServices.banxa.banxaHandleWebhook(req);
+      event.partner.should.equal('banxa');
+      event.externalId.should.equal('order1');
+      event.status.should.equal('complete');
+      event.eventName.should.equal('complete');
+      event.createdAt.should.equal('2024-01-01T00:00:00Z');
+      event.updatedAt.should.equal('2024-01-01T00:05:00Z');
+      event.deliveryVersion.should.equal('2024-01-01T00:05:00Z');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoAmount.should.equal(0.002);
+      event.cryptoCurrency.should.equal('BTC');
+      event.paymentMethod.should.equal('card');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+    });
+
+    it('should prefer metadata over external_id for userId when both are present', () => {
+      body.metadata = 'user2';
+      const nonce = Date.now().toString();
+      req.headers['authorization'] = banxaAuthHeader('secretKey2', 'apiKey2', nonce, JSON.stringify(body));
+      const { event } = server.externalServices.banxa.banxaHandleWebhook(req);
+      event.userId.should.equal('user2');
+    });
+
+    it('should verify against a distinct webhookSecretKey when configured', () => {
+      config.banxa.production.webhookSecretKey = 'distinctWebhookSecret';
+      const nonce = Date.now().toString();
+      req.headers['authorization'] = banxaAuthHeader('distinctWebhookSecret', 'apiKey2', nonce, JSON.stringify(body));
+      const { event } = server.externalServices.banxa.banxaHandleWebhook(req);
+      event.env.should.equal('production');
+    });
+
+    it('should resolve env to sandbox when the sandbox key matches', () => {
+      const nonce = Date.now().toString();
+      req.headers['authorization'] = banxaAuthHeader('secretKey1', 'apiKey1', nonce, JSON.stringify(body));
+      const { event } = server.externalServices.banxa.banxaHandleWebhook(req);
+      event.env.should.equal('sandbox');
+    });
+
+    it('should throw if the signature does not match', () => {
+      const nonce = Date.now().toString();
+      req.headers['authorization'] = banxaAuthHeader('wrongSecret', 'apiKey2', nonce, JSON.stringify(body));
+      try {
+        server.externalServices.banxa.banxaHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Banxa webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the Authorization header is missing', () => {
+      try {
+        server.externalServices.banxa.banxaHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Banxa webhook missing Authorization header');
+      }
+    });
+
+    it('should skip verification and still parse if no secretKey is configured', () => {
+      config.banxa.production.secretKey = undefined;
+      config.banxa.sandbox.secretKey = undefined;
+      const { event } = server.externalServices.banxa.banxaHandleWebhook(req);
+      event.externalId.should.equal('order1');
+    });
+
+    it('should return error if banxa is commented in config', () => {
+      config.banxa = undefined;
+      try {
+        server.externalServices.banxa.banxaHandleWebhook(req);
         should.fail('should have thrown');
       } catch (err) {
         err.message.should.equal('Banxa missing credentials');

--- a/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/moonpay.test.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import 'chai/register-should';
+import * as crypto from 'crypto';
 import util from 'util';
 import { WalletService } from '../../../src/lib/server';
 import * as TestData from '../../testdata';
@@ -754,6 +755,138 @@ describe('Moonpay integration', () => {
         should.fail('should have thrown');
       } catch (err) {
         err.message.should.equal('Moonpay missing credentials');
+      }
+    });
+  });
+
+  describe('#moonpayHandleWebhook', () => {
+    const webhookSecret = 'moonpayWebhookSecret1';
+    let body;
+
+    function moonpaySignatureHeader(secret, ts, rawBody) {
+      const sig = crypto.createHmac('sha256', secret).update(`${ts}.${rawBody}`).digest('hex');
+      return `t=${ts},s=${sig}`;
+    }
+
+    beforeEach(() => {
+      config.moonpay.production.webhookSecretKey = webhookSecret;
+      body = {
+        type: 'transaction_updated',
+        externalCustomerId: 'user1',
+        data: {
+          id: 'tx1',
+          status: 'completed',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:05:00.000Z',
+          baseCurrencyAmount: 100,
+          baseCurrency: { code: 'usd' },
+          quoteCurrencyAmount: 0.002,
+          currency: { code: 'btc' },
+          paymentMethod: 'credit_debit_card',
+          walletAddress: 'bc1qxyz',
+          walletAddressTag: 'tag1',
+          externalCustomerId: 'user1'
+        }
+      };
+      req = { headers: {}, body };
+    });
+
+    it('should verify and parse a valid webhook payload', () => {
+      const ts = Date.now();
+      req.headers['moonpay-signature-v2'] = moonpaySignatureHeader(webhookSecret, ts, JSON.stringify(body));
+      const { event } = server.externalServices.moonpay.moonpayHandleWebhook(req);
+      event.partner.should.equal('moonpay');
+      event.externalId.should.equal('tx1');
+      event.status.should.equal('completed');
+      event.eventName.should.equal('transaction_updated');
+      event.updatedAt.should.equal('2024-01-01T00:05:00.000Z');
+      event.deliveryVersion.should.equal('2024-01-01T00:05:00.000Z');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoAmount.should.equal(0.002);
+      event.cryptoCurrency.should.equal('BTC');
+      event.walletAddress.should.equal('bc1qxyz');
+      event.walletAddressTag.should.equal('tag1');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+      event.isEmbedded.should.equal(false);
+    });
+
+    it('should mark the event as embedded when verified with the embedded secret', () => {
+      const embeddedSecret = 'moonpayEmbeddedSecret1';
+      config.moonpay.production.webhookSecretKeyEmbedded = embeddedSecret;
+      const ts = Date.now();
+      req.headers['moonpay-signature-v2'] = moonpaySignatureHeader(embeddedSecret, ts, JSON.stringify(body));
+      const { event } = server.externalServices.moonpay.moonpayHandleWebhook(req);
+      event.isEmbedded.should.equal(true);
+    });
+
+    it('should throw if the signature does not match', () => {
+      const ts = Date.now();
+      req.headers['moonpay-signature-v2'] = moonpaySignatureHeader('wrongSecret', ts, JSON.stringify(body));
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the signature header is missing while a secret is configured', () => {
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay webhook missing Moonpay-Signature-V2 header');
+      }
+    });
+
+    it('should skip verification and still parse if no webhookSecretKey is configured', () => {
+      delete config.moonpay.production.webhookSecretKey;
+      const { event } = server.externalServices.moonpay.moonpayHandleWebhook(req);
+      event.externalId.should.equal('tx1');
+    });
+
+    it('should throw if event type is missing', () => {
+      delete config.moonpay.production.webhookSecretKey;
+      delete req.body.type;
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay webhook missing event type');
+      }
+    });
+
+    it('should throw if transaction id is missing', () => {
+      delete config.moonpay.production.webhookSecretKey;
+      delete req.body.data.id;
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay webhook missing transaction id');
+      }
+    });
+
+    it('should throw if updatedAt is missing or invalid', () => {
+      delete config.moonpay.production.webhookSecretKey;
+      req.body.data.updatedAt = 'not-a-date';
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay webhook missing valid updatedAt');
+      }
+    });
+
+    it('should return error if moonpay is commented in config', () => {
+      config.moonpay = undefined;
+      try {
+        server.externalServices.moonpay.moonpayHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('MoonPay missing credentials');
       }
     });
   });

--- a/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/ramp.test.ts
@@ -21,6 +21,36 @@ const { privateKey: privDer } = crypto.generateKeyPairSync('ed25519', {
   },
 });
 
+// Separate secp256k1 keypair used to sign/verify webhook payloads (Ramp uses
+// ECDSA + SHA-256 for webhooks, unlike the Ed25519 key used for widget URL signing above).
+const { privateKey: rampWebhookPrivateKey, publicKey: rampWebhookPublicKey } = crypto.generateKeyPairSync('ec', {
+  namedCurve: 'secp256k1',
+  publicKeyEncoding: {
+    type: 'spki',
+    format: 'pem',
+  },
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'pem',
+  },
+});
+
+/**
+ * Deterministic JSON serialization equivalent to fast-json-stable-stringify,
+ * mirroring the one used internally by ramp.ts to sign webhook bodies.
+ */
+function stableStringify(obj: any): string {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(item => stableStringify(item === undefined ? null : item)).join(',')}]`;
+  const keys = Object.keys(obj).filter(k => obj[k] !== undefined).sort();
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+function signRampBody(body: any, privateKey: string): string {
+  const message = Buffer.from(stableStringify(body), 'utf8');
+  return crypto.sign('sha256', message, privateKey).toString('base64');
+}
+
 describe('Ramp integration', () => {
   let server;
   let wallet;
@@ -593,6 +623,112 @@ describe('Ramp integration', () => {
 
       try {
         await server.externalServices.ramp.rampGetSellTransactionDetails(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Ramp missing credentials');
+      }
+    });
+  });
+
+  describe('#rampHandleWebhook', () => {
+    beforeEach(() => {
+      config.ramp.production.webhookSigningKey = rampWebhookPublicKey;
+      config.ramp.sandbox.webhookSigningKey = rampWebhookPublicKey;
+    });
+
+    it('should verify and parse a valid buy (purchase) webhook payload', () => {
+      const body = {
+        type: 'RELEASED',
+        purchase: {
+          id: 'purchase1',
+          status: 'RELEASED',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:05:00.000Z',
+          fiatValue: 100,
+          fiatCurrency: 'USD',
+          cryptoAmount: '2000000',
+          asset: { symbol: 'BTC' },
+          paymentMethodType: 'CARD',
+          receiverAddress: 'bc1qxyz'
+        }
+      };
+      const signature = signRampBody(body, rampWebhookPrivateKey);
+      req = { headers: { 'x-body-signature': signature }, query: { userId: 'user1' }, body };
+      const { event } = server.externalServices.ramp.rampHandleWebhook(req);
+      event.partner.should.equal('ramp');
+      event.externalId.should.equal('purchase1');
+      event.status.should.equal('RELEASED');
+      event.eventName.should.equal('RELEASED');
+      event.updatedAt.should.equal('2024-01-01T00:05:00.000Z');
+      event.deliveryVersion.should.equal('2024-01-01T00:05:00.000Z');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoAmount.should.equal(2000000);
+      event.cryptoCurrency.should.equal('BTC');
+      event.paymentMethod.should.equal('CARD');
+      event.walletAddress.should.equal('bc1qxyz');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+    });
+
+    it('should verify and parse a valid sell (offramp) webhook payload', () => {
+      const body = {
+        type: 'RELEASED',
+        mode: 'OFFRAMP',
+        payload: {
+          id: 'sale1',
+          status: 'RELEASED',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:05:00.000Z',
+          fiat: { amount: 100, currencySymbol: 'USD', payoutMethod: 'BANK_TRANSFER' },
+          crypto: { amount: 0.002, assetInfo: { symbol: 'BTC' } },
+          receiverAddress: 'bc1qxyz'
+        }
+      };
+      const signature = signRampBody(body, rampWebhookPrivateKey);
+      req = { headers: { 'x-body-signature': signature }, query: {}, body };
+      const { event } = server.externalServices.ramp.rampHandleWebhook(req);
+      event.externalId.should.equal('sale1');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoAmount.should.equal(0.002);
+      event.cryptoCurrency.should.equal('BTC');
+      event.paymentMethod.should.equal('BANK_TRANSFER');
+      should.not.exist(event.userId);
+    });
+
+    it('should throw if the signature does not match', () => {
+      const body = { type: 'RELEASED', purchase: { id: 'purchase1' } };
+      const { privateKey: otherKey } = crypto.generateKeyPairSync('ec', {
+        namedCurve: 'secp256k1',
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+      });
+      const signature = signRampBody(body, otherKey);
+      req = { headers: { 'x-body-signature': signature }, query: {}, body };
+      try {
+        server.externalServices.ramp.rampHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Ramp webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the X-Body-Signature header is missing', () => {
+      req = { headers: {}, query: {}, body: { type: 'RELEASED', purchase: { id: 'purchase1' } } };
+      try {
+        server.externalServices.ramp.rampHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Ramp webhook missing X-Body-Signature header');
+      }
+    });
+
+    it('should return error if ramp is commented in config', () => {
+      config.ramp = undefined;
+      req = { headers: {}, query: {}, body: {} };
+      try {
+        server.externalServices.ramp.rampHandleWebhook(req);
         should.fail('should have thrown');
       } catch (err) {
         err.message.should.equal('Ramp missing credentials');

--- a/packages/bitcore-wallet-service/test/integration/externalservices/sardine.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/sardine.test.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import 'chai/register-should';
+import * as crypto from 'crypto';
 import util from 'util';
 import { WalletService } from '../../../src/lib/server';
 import * as TestData from '../../testdata';
@@ -343,6 +344,96 @@ describe('Sardine integration', () => {
       config.sardine = undefined;
       try {
         await server.externalServices.sardine.sardineGetOrdersDetails(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Sardine missing credentials');
+      }
+    });
+  });
+
+  describe('#sardineHandleWebhook', () => {
+    const webhookSecret = 'sardineWebhookSecret1';
+    let body;
+
+    beforeEach(() => {
+      config.sardine.production.webhookSecret = webhookSecret;
+      body = {
+        eventType: 'processed',
+        order: {
+          id: 'order1',
+          status: 'Processed',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          fiatCurrency: 'USD',
+          total: 100,
+          assetType: 'BTC',
+          userId: 'user1'
+        }
+      };
+      req = { headers: {}, body };
+    });
+
+    it('should verify and parse a valid webhook payload', () => {
+      const rawBody = JSON.stringify(body);
+      const sig = crypto.createHmac('sha256', webhookSecret).update(rawBody).digest('hex');
+      req.headers['x-sardine-signature'] = sig;
+      const { event } = server.externalServices.sardine.sardineHandleWebhook(req);
+      event.partner.should.equal('sardine');
+      event.externalId.should.equal('order1');
+      event.status.should.equal('Processed');
+      event.eventName.should.equal('processed');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoCurrency.should.equal('BTC');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+    });
+
+    it('should parse a flat (non-nested) payload when there is no order wrapper', () => {
+      delete config.sardine.production.webhookSecret;
+      req.body = {
+        id: 'order2',
+        status: 'complete',
+        createdAt: '2024-01-02T00:00:00.000Z',
+        fiatCurrency: 'EUR',
+        total: 50,
+        cryptoCurrency: 'ETH',
+        externalUserId: 'user2'
+      };
+      const { event } = server.externalServices.sardine.sardineHandleWebhook(req);
+      event.externalId.should.equal('order2');
+      event.fiatCurrency.should.equal('EUR');
+      event.cryptoCurrency.should.equal('ETH');
+      event.userId.should.equal('user2');
+    });
+
+    it('should throw if the signature does not match', () => {
+      const rawBody = JSON.stringify(body);
+      const sig = crypto.createHmac('sha256', 'wrongSecret').update(rawBody).digest('hex');
+      req.headers['x-sardine-signature'] = sig;
+      try {
+        server.externalServices.sardine.sardineHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Sardine webhook signature verification failed');
+      }
+    });
+
+    it('should not throw and skip verification if the signature header is missing, even with a secret configured', () => {
+      const { event } = server.externalServices.sardine.sardineHandleWebhook(req);
+      event.externalId.should.equal('order1');
+    });
+
+    it('should not throw and skip verification if no webhookSecret is configured', () => {
+      delete config.sardine.production.webhookSecret;
+      req.headers['x-sardine-signature'] = 'some-signature';
+      const { event } = server.externalServices.sardine.sardineHandleWebhook(req);
+      event.externalId.should.equal('order1');
+    });
+
+    it('should return error if sardine is commented in config', () => {
+      config.sardine = undefined;
+      try {
+        server.externalServices.sardine.sardineHandleWebhook(req);
         should.fail('should have thrown');
       } catch (err) {
         err.message.should.equal('Sardine missing credentials');

--- a/packages/bitcore-wallet-service/test/integration/externalservices/simplex.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/simplex.test.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import 'chai/register-should';
+import * as crypto from 'crypto';
 import util from 'util';
 import { WalletService } from '../../../src/lib/server';
 import * as TestData from '../../testdata';
@@ -9,6 +10,21 @@ import helpers from '../helpers';
 import config from '../../../src/config';
 
 const should = chai.should();
+
+// RSA keypair used to sign/verify the Simplex webhook JWT (X-Signature-SHA256).
+const { privateKey: simplexPrivateKey, publicKey: simplexPublicKey } = crypto.generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+});
+
+function buildSimplexJwt(privateKey: string, exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  const signingInput = `${header}.${payload}`;
+  const signature = crypto.createSign('RSA-SHA256').update(signingInput).sign(privateKey).toString('base64url');
+  return `${signingInput}.${signature}`;
+}
 
 describe('Simplex integration', () => {
   let server;
@@ -379,6 +395,93 @@ describe('Simplex integration', () => {
     it('should work properly if req is OK', async () => {
       const data = await server.externalServices.simplex.simplexGetEvents(req);
       should.exist(data);
+    });
+  });
+
+  describe('#simplexHandleWebhook', () => {
+    let body;
+
+    beforeEach(() => {
+      config.simplex.production.publicKeyWebhook = simplexPublicKey;
+      body = {
+        name: 'wallet_status_changed',
+        event_id: 'evt1',
+        payment: {
+          id: 'payment1',
+          created_at: '2024-01-01T00:00:00.000Z',
+          fiat_total_amount: { amount: '100', currency: 'USD' },
+          requested_digital_amount: { currency: 'BTC' },
+          user_id: 'user1'
+        }
+      };
+      req = { headers: {}, body };
+    });
+
+    it('should verify and parse a valid webhook payload', () => {
+      const exp = Math.floor(Date.now() / 1000) + 300;
+      req.headers['x-signature-sha256'] = buildSimplexJwt(simplexPrivateKey, exp);
+      const { event } = server.externalServices.simplex.simplexHandleWebhook(req);
+      event.partner.should.equal('simplex');
+      event.externalId.should.equal('payment1');
+      event.status.should.equal('wallet_status_changed');
+      event.deliveryVersion.should.equal('evt1');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoCurrency.should.equal('BTC');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+    });
+
+    it('should throw if the JWT is expired', () => {
+      const exp = Math.floor(Date.now() / 1000) - 60;
+      req.headers['x-signature-sha256'] = buildSimplexJwt(simplexPrivateKey, exp);
+      try {
+        server.externalServices.simplex.simplexHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Simplex webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the signature does not match', () => {
+      const { privateKey: otherKey } = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' }
+      });
+      const exp = Math.floor(Date.now() / 1000) + 300;
+      req.headers['x-signature-sha256'] = buildSimplexJwt(otherKey, exp);
+      try {
+        server.externalServices.simplex.simplexHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Simplex webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the signature header is missing while a public key is configured', () => {
+      try {
+        server.externalServices.simplex.simplexHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Simplex webhook missing X-Signature-SHA256 header');
+      }
+    });
+
+    it('should skip verification and still parse if no publicKeyWebhook is configured', () => {
+      delete config.simplex.production.publicKeyWebhook;
+      const { event } = server.externalServices.simplex.simplexHandleWebhook(req);
+      event.externalId.should.equal('payment1');
+    });
+
+    it('should return error if simplex is commented in config', () => {
+      config.simplex = undefined;
+      try {
+        server.externalServices.simplex.simplexHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Simplex missing credentials');
+      }
     });
   });
 });

--- a/packages/bitcore-wallet-service/test/integration/externalservices/transak.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/transak.test.ts
@@ -2,6 +2,7 @@
 
 import * as chai from 'chai';
 import 'chai/register-should';
+import * as crypto from 'crypto';
 import util from 'util';
 import { WalletService } from '../../../src/lib/server';
 import * as TestData from '../../testdata';
@@ -488,6 +489,118 @@ describe('Transak integration', () => {
         should.fail('should have thrown');
       } catch (err) {
         err.message.should.equal('Transak\'s request missing arguments');
+      }
+    });
+  });
+
+  describe('#transakHandleWebhook', () => {
+    const accessTokenSecret = 'transakAccessTokenSecret1';
+    let body;
+
+    function buildTransakJwt(payload, secret) {
+      const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+      const payloadEncoded = Buffer.from(JSON.stringify(payload)).toString('base64url');
+      const signingInput = `${header}.${payloadEncoded}`;
+      const signature = crypto.createHmac('sha256', secret).update(signingInput).digest('base64url');
+      return `${signingInput}.${signature}`;
+    }
+
+    function fakeRefreshTokenRequest(secret) {
+      return {
+        post: (_url, _opts, cb) => cb(null, {
+          body: { data: { accessToken: secret, expiresAt: Math.floor(Date.now() / 1000) + 7 * 24 * 3600 } }
+        }),
+      };
+    }
+
+    beforeEach(() => {
+      server.externalServices.transak.request = fakeRefreshTokenRequest(accessTokenSecret);
+      const webhookData = {
+        id: 'order1',
+        status: 'COMPLETED',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:05:00.000Z',
+        fiatAmount: 100,
+        fiatCurrency: 'USD',
+        cryptoAmount: 0.002,
+        cryptoCurrency: 'BTC',
+        paymentOptionId: 'usd_bank_transfer',
+        walletAddress: 'bc1qxyz',
+        userId: 'user1'
+      };
+      body = { data: buildTransakJwt({ webhookData, eventID: 'ORDER_COMPLETED' }, accessTokenSecret) };
+      req = { headers: {}, body };
+    });
+
+    it('should verify and parse a valid webhook payload', async () => {
+      const { event } = await server.externalServices.transak.transakHandleWebhook(req);
+      event.partner.should.equal('transak');
+      event.externalId.should.equal('order1');
+      event.status.should.equal('COMPLETED');
+      event.eventName.should.equal('ORDER_COMPLETED');
+      event.updatedAt.should.equal('2024-01-01T00:05:00.000Z');
+      event.deliveryVersion.should.equal('2024-01-01T00:05:00.000Z');
+      event.fiatAmount.should.equal(100);
+      event.fiatCurrency.should.equal('USD');
+      event.cryptoAmount.should.equal(0.002);
+      event.cryptoCurrency.should.equal('BTC');
+      event.paymentMethod.should.equal('usd_bank_transfer');
+      event.walletAddress.should.equal('bc1qxyz');
+      event.userId.should.equal('user1');
+      event.env.should.equal('production');
+    });
+
+    it('should cache the access token and not call refresh-token again on a second webhook', async () => {
+      let callCount = 0;
+      server.externalServices.transak.request = {
+        post: (_url, _opts, cb) => {
+          callCount++;
+          return cb(null, { body: { data: { accessToken: accessTokenSecret, expiresAt: Math.floor(Date.now() / 1000) + 7 * 24 * 3600 } } });
+        },
+      };
+      await server.externalServices.transak.transakHandleWebhook(req);
+      const firstCallCount = callCount;
+      firstCallCount.should.be.greaterThan(0);
+      await server.externalServices.transak.transakHandleWebhook(req);
+      callCount.should.equal(firstCallCount);
+    });
+
+    it('should throw if the JWT signature does not match', async () => {
+      req.body = { data: buildTransakJwt({ webhookData: { id: 'order1' }, eventID: 'ORDER_COMPLETED' }, 'wrongSecret') };
+      try {
+        await server.externalServices.transak.transakHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Transak webhook signature verification failed');
+      }
+    });
+
+    it('should throw if the JWT data field is missing', async () => {
+      req.body = {};
+      try {
+        await server.externalServices.transak.transakHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Transak webhook missing JWT data field');
+      }
+    });
+
+    it('should skip verification and still parse if refresh-token fails for both envs', async () => {
+      server.externalServices.transak.request = {
+        post: (_url, _opts, cb) => cb(new Error('network error'), null),
+      };
+      const { event } = await server.externalServices.transak.transakHandleWebhook(req);
+      should.exist(event);
+      event.externalId.should.equal('order1');
+    });
+
+    it('should return error if transak is commented in config', async () => {
+      config.transak = undefined;
+      try {
+        await server.externalServices.transak.transakHandleWebhook(req);
+        should.fail('should have thrown');
+      } catch (err) {
+        err.message.should.equal('Transak missing credentials');
       }
     });
   });


### PR DESCRIPTION
### Description
Ticket Reference: [RN-2714](https://bitpayprod.atlassian.net/browse/RN-2714)

This PR adds webhook endpoints for all six partners so BWS can react to status changes (processing, completed, failed, refunded, etc.) in real time instead of relying purely on client-side polling, while guarding against the usual webhook pitfalls: unverified senders, duplicate/retried deliveries, and out-of-order delivery.

Webhook processing will be rolled out gradually: Not all endpoints will be operational immediately. Initially, we will enable the Moonpay webhook endpoint until we verify that everything is working as expected with this single partner. (Until we enable webhooks in the configuration of each external service, the endpoints will not receive traffic.) Then we will continue with the other partners, one by one, until all are operational simultaneously.
The first thing we will do upon receiving a call is check that it is not a duplicate or out-of-order status and then send an event to Braze (a requirement of the marketing team). Any additional processing that needs to be done will be added in the future in another PR.

### Changelog
* Added `POST /v1/service/{partner}/webhook` routes in a new `src/lib/routes/webhooks.ts`, with a shared handler that verifies the signature, persists the event, and always responds so the partner doesn't retry unnecessarily.
* Implemented per-partner signature verification against each partner's documented scheme:
  * **MoonPay**: HMAC-SHA256 (`Moonpay-Signature-V2: t=...,s=...`), with support for both the standard and embedded webhook secrets.
  * **Simplex**: RS256 JWT in `X-Signature-SHA256`, including expiry (`exp`) enforcement.
  * **Ramp**: ECDSA (secp256k1/SHA-256) signature over a deterministic (`fast-json-stable-stringify`-equivalent) serialization of the body, sent in `X-Body-Signature`.
  * **Banxa**: HMAC-SHA256 over `POST\n{path}\n{nonce}\n{body}`, sent via `Authorization: Bearer {apiKey}:{signature}:{nonce}`.
  * **Sardine**: HMAC-SHA256 via `X-Sardine-Signature`.
  * **Transak**: HS256 JWT verified against the partner's Access Token (`POST /partners/api/v2/refresh-token`), now fetched and cached per environment instead of a static secret.
* Added idempotency/deduplication for webhook deliveries: a new `onramp_webhook_events` collection (`storage.ts`) keyed by a deterministic id (partner + env + event + externalId + delivery version), so retried deliveries from a partner are safely ignored.
* Added out-of-order delivery detection, reusing the same collection/index to detect when a partner delivers an older status after a newer one and skip re-processing it.
* Added a minimal Braze REST client (`src/lib/braze.ts`) that fires a "BWS - ONRAMP Webhook Received" track event per unique delivery (skipped for duplicates/stale events and when no user id is available).
* Added a mechanism for Ramp to correlate webhooks back to a BitPay user: since Ramp never includes user details in its webhook payloads, BWS now appends a `userId` query param to the signed `webhookStatusUrl`/`offrampWebhookV3Url` it generates, which Ramp echoes back on the webhook call.
* Added `OnrampWebhookEvent` model (`src/lib/model/onrampWebhookEvent.ts`) as the common shape used across all partners' webhook handlers and storage.
* Added new config fields (`bws.example.config.js` / `config.ts`) for webhook secrets/signing keys per partner and environment.
* Added unit tests (`test/integration/externalservices/*.test.ts`) covering signature verification (valid/invalid/missing signature, missing secret configured), payload parsing, and error handling for each partner's new `*HandleWebhook` method.

### Testing Notes
* Each partner's webhook secret/signing key needs to be configured (see `bws.example.config.js`) for signature verification to be enforced; if left unset, verification is skipped with a warning logged (useful for local testing without real credentials, but should be set in staging/production).
* Unit tests (`npm test` in `packages/bitcore-wallet-service`) exercise the signature verification and field-mapping logic per partner in isolation, including duplicate/invalid-signature/missing-header/missing-config edge cases.

<hr style="border-width:3px">