### PR TITLE
Fix unauthorized wallet join via alternate public-key fields

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/model/copayer.ts
+++ b/packages/bitcore-wallet-service/src/lib/model/copayer.ts
@@ -54,6 +54,7 @@ export class Copayer {
   isMarketingStaff?: boolean;
 
   static xPubToCopayerId(coin, xpub) {
+    $.checkArgument(xpub, 'Missing xPubKey for copayer id derivation');
     const str = coin == Defaults.COIN ? xpub : coin + xpub;
     const hash = sjcl.hash.sha256.hash(str);
     return sjcl.codec.hex.fromBits(hash);

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1144,9 +1144,15 @@ export class WalletService implements IWalletService {
         if (err) return cb(err);
         if (!wallet) return cb(Errors.NOT_AUTHORIZED);
 
-        const xPubKey = wallet.copayers.find(c => c.id === opts.copayerId).xPubKey;
+        // Malformed historical copayer state must fail closed at this boundary,
+        // never escape as an uncaught exception.
+        const target = wallet.copayers.find(c => c.id === opts.copayerId);
+        if (!target?.xPubKey) return cb(Errors.NOT_AUTHORIZED);
 
-        if (!this._verifyRequestPubKey(opts.requestPubKey, opts.signature, xPubKey)) {
+        try {
+          const isValid = this._verifyRequestPubKey(opts.requestPubKey, opts.signature, target.xPubKey);
+          if (!isValid) return cb(Errors.NOT_AUTHORIZED);
+        } catch (e) {
           return cb(Errors.NOT_AUTHORIZED);
         }
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1216,9 +1216,17 @@ export class WalletService implements IWalletService {
     }
     if (!Utils.checkValueInCollection(opts.chain, Constants.CHAINS)) return cb(new ClientError('Invalid coin'));
 
+    // SECURITY: xPubKey is required for every join, including hardwareSourcePublicKey/
+    // clientDerivedPublicKey ones. Copayer.xPubToCopayerId() (called below both for the TSS
+    // participant check and inside Copayer.create()) hashes opts.xPubKey directly; passing it
+    // undefined throws for the default coin and produces a colliding constant hash for every
+    // other coin. bitcore-wallet-client's only join path (_doJoinWallet) always sends a real
+    // xPubKey regardless of these two fields, so this doesn't restrict any flow this repo's
+    // own client exercises - see the TSS-participant comment below for how that was confirmed.
+    if (!checkRequired(opts, ['xPubKey'], cb)) return;
+
     let xPubKey;
     if (!opts.hardwareSourcePublicKey && !opts.clientDerivedPublicKey) {
-      if (!checkRequired(opts, ['xPubKey'], cb)) return;
       try {
         xPubKey = Bitcore_[opts.chain].HDPublicKey(opts.xPubKey);
       } catch {
@@ -1235,10 +1243,25 @@ export class WalletService implements IWalletService {
         if (err) return cb(err);
         if (!wallet) return cb(Errors.WALLET_NOT_FOUND);
 
-        if ((opts.hardwareSourcePublicKey || opts.clientDerivedPublicKey) && !opts.tssKeyId) {
-          this._addCopayerToWallet(wallet, opts, cb);
-          return;
-        }
+        // SECURITY: do not add a shortcut here that calls _addCopayerToWallet() before the
+        // copayerSignature check (and, for TSS wallets, the participant check) below has run.
+        // This method used to return early into _addCopayerToWallet() whenever
+        // hardwareSourcePublicKey or clientDerivedPublicKey was present, which let anyone who
+        // knew a joinable walletId join as a real copayer without proving knowledge of the
+        // wallet secret - and, for TSS wallets, without ever being checked against the key
+        // generation session's participant list. bitcore-wallet-client's only join path
+        // (api.ts#_doJoinWallet) always sends a real xPubKey and computes a real
+        // copayerSignature regardless of these two fields - for a TSS join, that xPubKey is
+        // the copayer's ordinary seed-derived auth key, distinct from the TSS common-keychain
+        // pubkey carried in clientDerivedPublicKey, and it's what the join secret is checked
+        // against and what keySession.participants below is keyed on - so there is no
+        // legitimate flow in this repo's own client that needs to skip verification here.
+        // (xPubKey is also required unconditionally a few lines up, so opts.xPubKey can't be
+        // undefined by the time any of this runs.) Every join, hardware, TSS, or plain
+        // multisig, must go through the same checks below. TSS wallets get their own
+        // participant check further down, gated on the wallet's persisted wallet.tssKeyId;
+        // never gate it on an opts.tssKeyId instead - join requests never carry one, so that
+        // condition is always true and the gate would be a no-op.
 
         if (this._upgradeNeeded(UPGRADES.BCH_bwc_$lt_8_3_multisig, { chain: opts.chain, n: wallet.n })) {
           return cb(Errors.UPGRADE_NEEDED.withMessage('BWC clients < 8.3 are no longer supported for multisig BCH wallets.'));
@@ -1255,7 +1278,10 @@ export class WalletService implements IWalletService {
           return cb(new ClientError('The wallet you are trying to join was created for a different chain'));
         }
 
-        if (!Utils.compareNetworks(wallet.network, xPubKey.network.name, wallet.chain)) {
+        // xPubKey is only parsed above when neither hardwareSourcePublicKey nor
+        // clientDerivedPublicKey was supplied (that block skips HDPublicKey parsing for
+        // key formats it doesn't apply to) - guard the network check accordingly.
+        if (xPubKey && !Utils.compareNetworks(wallet.network, xPubKey.network.name, wallet.chain)) {
           return cb(new ClientError('The wallet you are trying to join was created for a different network'));
         }
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1216,9 +1216,9 @@ export class WalletService implements IWalletService {
     // end-to-end identity protocol rather than a local identity fallback.
     // SECURITY: xPubKey is required for every join, including hardwareSourcePublicKey/
     // clientDerivedPublicKey ones. Copayer.xPubToCopayerId() (called below both for the TSS
-    // participant check and inside Copayer.create()) hashes opts.xPubKey directly; passing it
-    // undefined throws for the default coin and produces a colliding constant hash for every
-    // other coin. bitcore-wallet-client's only join path (_doJoinWallet) always sends a real
+    // participant check and inside Copayer.create()) now throws on a missing xpub for every
+    // coin (see its own guard), so an xPubKey-less join can no longer derive a copayer id at
+    // all. bitcore-wallet-client's only join path (_doJoinWallet) always sends a real
     // xPubKey regardless of these two fields, so this doesn't restrict any flow this repo's
     // own client exercises - see the TSS-participant comment below for how that was confirmed.
     if (!checkRequired(opts, ['walletId', 'name', 'requestPubKey', 'copayerSignature', 'xPubKey'], cb)) return;

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1144,8 +1144,6 @@ export class WalletService implements IWalletService {
         if (err) return cb(err);
         if (!wallet) return cb(Errors.NOT_AUTHORIZED);
 
-        // Malformed historical copayer state must fail closed at this boundary,
-        // never escape as an uncaught exception.
         const target = wallet.copayers.find(c => c.id === opts.copayerId);
         if (!target?.xPubKey) return cb(Errors.NOT_AUTHORIZED);
 
@@ -1213,15 +1211,6 @@ export class WalletService implements IWalletService {
    * @param {boolean} [opts.dryRun] Simulate the action but do not change server state.
    */
   joinWallet(opts, cb) {
-    if (!checkRequired(opts, ['walletId', 'name', 'requestPubKey', 'copayerSignature'], cb)) return;
-    if (!opts.name) return cb(new ClientError('Invalid copayer name'));
-
-    opts.coin = opts.coin || Defaults.COIN;
-    if (!opts.chain) {
-      opts.chain = opts.coin; // chain === coin for stored clients
-    }
-    if (!Utils.checkValueInCollection(opts.chain, Constants.CHAINS)) return cb(new ClientError('Invalid coin'));
-
     // xPubKey is the canonical copayer identity in the current protocol. Alternate public-key
     // fields are ancillary metadata; supporting an xPubKey-less copayer requires a versioned
     // end-to-end identity protocol rather than a local identity fallback.
@@ -1232,9 +1221,18 @@ export class WalletService implements IWalletService {
     // other coin. bitcore-wallet-client's only join path (_doJoinWallet) always sends a real
     // xPubKey regardless of these two fields, so this doesn't restrict any flow this repo's
     // own client exercises - see the TSS-participant comment below for how that was confirmed.
-    if (!checkRequired(opts, ['xPubKey'], cb)) return;
+    if (!checkRequired(opts, ['walletId', 'name', 'requestPubKey', 'copayerSignature', 'xPubKey'], cb)) return;
+    if (!opts.name) return cb(new ClientError('Invalid copayer name'));
+
+    opts.coin = opts.coin || Defaults.COIN;
+    if (!opts.chain) {
+      opts.chain = opts.coin; // chain === coin for stored clients
+    }
+    if (!Utils.checkValueInCollection(opts.chain, Constants.CHAINS)) return cb(new ClientError('Invalid coin'));
 
     // xPubKey is parsed and validated for every join; ancillary fields never suppress it.
+    // A future update will re-add conditional logic which allows opts.hardwareSourcePublicKey
+    // or opts.clientDerivedPublicKey to circumvent this requirement
     let xPubKey;
     try {
       xPubKey = Bitcore_[opts.chain].HDPublicKey(opts.xPubKey);
@@ -1251,25 +1249,9 @@ export class WalletService implements IWalletService {
         if (err) return cb(err);
         if (!wallet) return cb(Errors.WALLET_NOT_FOUND);
 
-        // SECURITY: do not add a shortcut here that calls _addCopayerToWallet() before the
-        // copayerSignature check (and, for TSS wallets, the participant check) below has run.
-        // This method used to return early into _addCopayerToWallet() whenever
-        // hardwareSourcePublicKey or clientDerivedPublicKey was present, which let anyone who
-        // knew a joinable walletId join as a real copayer without proving knowledge of the
-        // wallet secret - and, for TSS wallets, without ever being checked against the key
-        // generation session's participant list. bitcore-wallet-client's only join path
-        // (api.ts#_doJoinWallet) always sends a real xPubKey and computes a real
-        // copayerSignature regardless of these two fields - for a TSS join, that xPubKey is
-        // the copayer's ordinary seed-derived auth key, distinct from the TSS common-keychain
-        // pubkey carried in clientDerivedPublicKey, and it's what the join secret is checked
-        // against and what keySession.participants below is keyed on - so there is no
-        // legitimate flow in this repo's own client that needs to skip verification here.
-        // (xPubKey is also required unconditionally a few lines up, so opts.xPubKey can't be
-        // undefined by the time any of this runs.) Every join, hardware, TSS, or plain
-        // multisig, must go through the same checks below. TSS wallets get their own
-        // participant check further down, gated on the wallet's persisted wallet.tssKeyId;
-        // never gate it on an opts.tssKeyId instead - join requests never carry one, so that
-        // condition is always true and the gate would be a no-op.
+        // SECURITY: opts.hardwareSourcePublicKey or opts.clientDerivedPublicKey may not
+        // circumvent the required checks below. A future update may enable either to replace xPubKey
+        // That is currently not supported
 
         if (this._upgradeNeeded(UPGRADES.BCH_bwc_$lt_8_3_multisig, { chain: opts.chain, n: wallet.n })) {
           return cb(Errors.UPGRADE_NEEDED.withMessage('BWC clients < 8.3 are no longer supported for multisig BCH wallets.'));

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1228,16 +1228,15 @@ export class WalletService implements IWalletService {
     // own client exercises - see the TSS-participant comment below for how that was confirmed.
     if (!checkRequired(opts, ['xPubKey'], cb)) return;
 
+    // xPubKey is parsed and validated for every join; ancillary fields never suppress it.
     let xPubKey;
-    if (!opts.hardwareSourcePublicKey && !opts.clientDerivedPublicKey) {
-      try {
-        xPubKey = Bitcore_[opts.chain].HDPublicKey(opts.xPubKey);
-      } catch {
-        return cb(new ClientError('Invalid extended public key'));
-      }
-      if (xPubKey.network == null) {
-        return cb(new ClientError('Invalid extended public key'));
-      }
+    try {
+      xPubKey = Bitcore_[opts.chain].HDPublicKey(opts.xPubKey);
+    } catch {
+      return cb(new ClientError('Invalid extended public key'));
+    }
+    if (xPubKey.network == null) {
+      return cb(new ClientError('Invalid extended public key'));
     }
 
     this.walletId = opts.walletId;
@@ -1281,10 +1280,7 @@ export class WalletService implements IWalletService {
           return cb(new ClientError('The wallet you are trying to join was created for a different chain'));
         }
 
-        // xPubKey is only parsed above when neither hardwareSourcePublicKey nor
-        // clientDerivedPublicKey was supplied (that block skips HDPublicKey parsing for
-        // key formats it doesn't apply to) - guard the network check accordingly.
-        if (xPubKey && !Utils.compareNetworks(wallet.network, xPubKey.network.name, wallet.chain)) {
+        if (!Utils.compareNetworks(wallet.network, xPubKey.network.name, wallet.chain)) {
           return cb(new ClientError('The wallet you are trying to join was created for a different network'));
         }
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -1216,6 +1216,9 @@ export class WalletService implements IWalletService {
     }
     if (!Utils.checkValueInCollection(opts.chain, Constants.CHAINS)) return cb(new ClientError('Invalid coin'));
 
+    // xPubKey is the canonical copayer identity in the current protocol. Alternate public-key
+    // fields are ancillary metadata; supporting an xPubKey-less copayer requires a versioned
+    // end-to-end identity protocol rather than a local identity fallback.
     // SECURITY: xPubKey is required for every join, including hardwareSourcePublicKey/
     // clientDerivedPublicKey ones. Copayer.xPubToCopayerId() (called below both for the TSS
     // participant check and inside Copayer.create()) hashes opts.xPubKey directly; passing it

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -3171,6 +3171,112 @@ describe('Wallet service', function() {
         });
       });
     });
+
+    describe('#add access with historical copayer state', function() {
+      beforeEach(async function() {
+        ({ server, wallet } = await helpers.createAndJoinWallet(1, 1));
+      });
+
+      function snapshotState(cb) {
+        server.storage.db.collection(Storage.collections.WALLETS).findOne(
+          { id: wallet.id },
+          (err, walletDoc) => {
+            if (err) return cb(err);
+            server.storage.db.collection(Storage.collections.COPAYERS_LOOKUP).findOne(
+              { copayerId: opts.copayerId },
+              (err2, lookupDoc) => {
+                if (err2) return cb(err2);
+                return cb(null, {
+                  wallet: JSON.parse(JSON.stringify(walletDoc)),
+                  lookup: JSON.parse(JSON.stringify(lookupDoc))
+                });
+              }
+            );
+          }
+        );
+      }
+
+      function mutateWalletDoc(mutation, cb) {
+        server.storage.db.collection(Storage.collections.WALLETS).findOne(
+          { id: wallet.id },
+          (err, walletDoc) => {
+            if (err) return cb(err);
+            mutation(walletDoc);
+            server.storage.db.collection(Storage.collections.WALLETS).replaceOne(
+              { id: wallet.id },
+              walletDoc,
+              cb
+            );
+          }
+        );
+      }
+
+      it('should return NOT_AUTHORIZED when the target copayer is missing from the wallet', function(done) {
+        mutateWalletDoc(doc => {
+          doc.copayers = doc.copayers.filter(c => c.id !== opts.copayerId);
+        }, (err) => {
+          should.not.exist(err);
+          snapshotState((err, before) => {
+            should.not.exist(err);
+            ws.addAccess(opts, (err, res) => {
+              err.should.be.instanceof(ClientError);
+              err.code.should.equal('NOT_AUTHORIZED');
+              should.not.exist(res);
+              snapshotState((err, after) => {
+                should.not.exist(err);
+                // The rejected attempt must not have persisted anything: no new access key, no other state change.
+                after.should.deep.equal(before);
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it('should return NOT_AUTHORIZED when the target copayer has no xPubKey', function(done) {
+        mutateWalletDoc(doc => {
+          delete doc.copayers[0].xPubKey;
+        }, (err) => {
+          should.not.exist(err);
+          snapshotState((err, before) => {
+            should.not.exist(err);
+            ws.addAccess(opts, (err, res) => {
+              err.should.be.instanceof(ClientError);
+              err.code.should.equal('NOT_AUTHORIZED');
+              should.not.exist(res);
+              snapshotState((err, after) => {
+                should.not.exist(err);
+                // The rejected attempt must not have persisted anything: no new access key, no other state change.
+                after.should.deep.equal(before);
+                done();
+              });
+            });
+          });
+        });
+      });
+
+      it('should return NOT_AUTHORIZED when the target copayer has a malformed xPubKey', function(done) {
+        mutateWalletDoc(doc => {
+          doc.copayers[0].xPubKey = 'invalid';
+        }, (err) => {
+          should.not.exist(err);
+          snapshotState((err, before) => {
+            should.not.exist(err);
+            ws.addAccess(opts, (err, res) => {
+              err.should.be.instanceof(ClientError);
+              err.code.should.equal('NOT_AUTHORIZED');
+              should.not.exist(res);
+              snapshotState((err, after) => {
+                should.not.exist(err);
+                // The rejected attempt must not have persisted anything: no new access key, no other state change.
+                after.should.deep.equal(before);
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('#getBalance', function() {

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -11,6 +11,7 @@ import { WalletService, UPGRADES } from '../../src/lib/server';
 import { Storage } from '../../src/lib/storage';
 import { Common } from '../../src/lib/common';
 import * as Model from '../../src/lib/model';
+import { TssKeyGenModel } from '../../src/lib/model/tsskeygen';
 import { BCHAddressTranslator } from '../../src/lib/bchaddresstranslator';
 import * as TestData from '../testdata';
 import helpers from './helpers';
@@ -1135,6 +1136,165 @@ describe('Wallet service', function() {
         });
       });
 
+      it('should fail to join with wrong signature even when hardwareSourcePublicKey is present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.name = 'me2'; // invalidates the signature, same as the plain wrong-signature case above
+        copayerOpts.hardwareSourcePublicKey = 'attacker-controlled-hw-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(result);
+          should.exist(err);
+          err.message.should.equal('Bad request');
+          // The rejected join must not have persisted a copayer despite carrying
+          // hardwareSourcePublicKey - a regression that returns an error but still adds the
+          // copayer would pass the assertions above alone.
+          server.getWallet({}, function(err, wallet) {
+            should.not.exist(err);
+            wallet.copayers.length.should.equal(0);
+            done();
+          });
+        });
+      });
+
+      it('should fail to join with wrong signature even when clientDerivedPublicKey is present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.name = 'me2'; // invalidates the signature, same as the plain wrong-signature case above
+        copayerOpts.clientDerivedPublicKey = 'attacker-controlled-client-derived-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(result);
+          should.exist(err);
+          err.message.should.equal('Bad request');
+          // Same persisted-state guard as the hardwareSourcePublicKey case above.
+          server.getWallet({}, function(err, wallet) {
+            should.not.exist(err);
+            wallet.copayers.length.should.equal(0);
+            done();
+          });
+        });
+      });
+
+      it('should join existing wallet with a valid signature and hardwareSourcePublicKey present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.hardwareSourcePublicKey = 'legit-hw-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          should.exist(result.copayerId);
+          server.getWallet({}, function(err, wallet) {
+            should.not.exist(err);
+            wallet.copayers.length.should.equal(1);
+            const copayer = wallet.copayers[0];
+            copayer.id.should.equal(result.copayerId);
+            copayer.hardwareSourcePublicKey.should.equal('legit-hw-pubkey');
+            done();
+          });
+        });
+      });
+
+      it('should join existing wallet with a valid signature and clientDerivedPublicKey present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.clientDerivedPublicKey = 'legit-client-derived-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          should.exist(result.copayerId);
+          server.getWallet({}, function(err, wallet) {
+            should.not.exist(err);
+            wallet.copayers.length.should.equal(1);
+            const copayer = wallet.copayers[0];
+            copayer.id.should.equal(result.copayerId);
+            copayer.clientDerivedPublicKey.should.equal('legit-client-derived-pubkey');
+            done();
+          });
+        });
+      });
+
+      it('should cleanly reject a hardwareSourcePublicKey join with no xPubKey at all, instead of crashing', function(done) {
+        // SECURITY: Copayer.xPubToCopayerId() (called from Copayer.create(), and separately
+        // from the TSS participant check below) hashes opts.xPubKey with sjcl directly. For the
+        // default coin ('btc'), hashing undefined throws inside sjcl; since that throw happens
+        // inside an async storage.fetchWallet callback that nothing awaits, it used to surface
+        // as an unhandled rejection instead of a clean ClientError response - crashing the whole
+        // process, not just failing the one request. Confirmed by direct execution against the
+        // pre-fix code before this test was written. xPubKey must be required unconditionally,
+        // before any of that code is reached, regardless of hardwareSourcePublicKey/
+        // clientDerivedPublicKey.
+        const copayerOpts: any = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        delete copayerOpts.xPubKey;
+        copayerOpts.hardwareSourcePublicKey = 'legit-hw-pubkey-no-xpub';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(result);
+          should.exist(err);
+          err.message.should.contain('xPubKey');
+          done();
+        });
+      });
+
+      it('should fail to join a full wallet with a valid signature and hardwareSourcePublicKey present', function(done) {
+        // walletId is m=1/n=2 (see beforeEach above); fill both slots with normal joins first
+        // so the third, hardware-flagged join hits WALLET_FULL rather than succeeding.
+        const firstCopayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'copayer 1',
+          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        server.joinWallet(firstCopayerOpts, function(err) {
+          should.not.exist(err);
+          const secondCopayerOpts = helpers.getSignedCopayerOpts({
+            walletId: walletId,
+            name: 'copayer 2',
+            xPubKey: TestData.copayers[1].xPubKey_44H_0H_0H,
+            requestPubKey: TestData.copayers[1].pubKey_1H_0,
+          });
+          server.joinWallet(secondCopayerOpts, function(err) {
+            should.not.exist(err);
+            const thirdCopayerOpts = helpers.getSignedCopayerOpts({
+              walletId: walletId,
+              name: 'copayer 3',
+              xPubKey: TestData.copayers[2].xPubKey_44H_0H_0H,
+              requestPubKey: TestData.copayers[2].pubKey_1H_0,
+            });
+            thirdCopayerOpts.hardwareSourcePublicKey = 'attacker-or-legit-hw-pubkey';
+            server.joinWallet(thirdCopayerOpts, function(err, result) {
+              should.not.exist(result);
+              should.exist(err);
+              err.should.be.instanceof(ClientError);
+              err.code.should.equal('WALLET_FULL');
+              server.getWallet({}, function(err, wallet) {
+                should.not.exist(err);
+                wallet.copayers.length.should.equal(2);
+                done();
+              });
+            });
+          });
+        });
+      });
+
       it('should set pkr and status = complete on last copayer joining (2-3)', function(done) {
         helpers.createAndJoinWallet(2, 3).then(function({ server }) {
           server.getWallet({}, function(err, wallet) {
@@ -1374,6 +1534,128 @@ describe('Wallet service', function() {
             done();
           });
         });
+      });
+    });
+
+    // SECURITY: this guards against a copayer joining a TSS wallet without ever being checked
+    // against the key generation session's participant list. A join carrying
+    // hardwareSourcePublicKey/clientDerivedPublicKey must never be able to add a copayer
+    // before joinWallet()'s TSS_NON_PARTICIPANT check has run - a gate that (incorrectly)
+    // keyed off an opts.tssKeyId the join request never actually carries, instead of the
+    // wallet's own persisted wallet.tssKeyId, previously let this slip through entirely. Keep
+    // this test paired with the plain-signature-bypass tests above; both guard the same
+    // control-flow mistake from two different angles.
+    describe('TSS wallets (non-participant bypass)', function() {
+      it('should reject a join from a copayer who is not a TSS keygen session participant, even with clientDerivedPublicKey supplied', async function() {
+        const server = new WalletService();
+
+        const legitXPubKey = TestData.copayers[0].xPubKey_44H_0H_0H;
+        const legitCopayerId = Model.Copayer.xPubToCopayerId('btc', legitXPubKey);
+
+        // A completed TSS key-gen session whose sole participant is the legit copayer above.
+        // NOTE: helpers.beforeEach()'s collection wipe-list doesn't include tss_keygen (it's
+        // marked // TODO in helpers.ts), so this collection isn't reset between test runs the
+        // way the rest of the suite's state is. Clear our fixture id explicitly so this test
+        // stays repeatable regardless of that pre-existing gap.
+        const session = TssKeyGenModel.create({
+          id: 'tss-non-participant-bypass-test-session',
+          message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
+          n: 1,
+          copayerId: legitCopayerId,
+        });
+        session.sharedPublicKey = 'dummy-shared-public-key';
+        await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });
+        await server.storage.storeTssKeyGenSession({ doc: session });
+
+        // createWallet forces m=n=1 for any wallet created against a tssKeyId.
+        const walletId = await util.promisify(server.createWallet).call(server, {
+          name: 'tss wallet',
+          m: 1,
+          n: 1,
+          pubKey: TestData.keyPair.pub,
+          coin: 'btc',
+          tssKeyId: session.id,
+        });
+        should.exist(walletId);
+
+        // Attacker knows the wallet's join secret (so they CAN produce a valid
+        // copayerSignature - e.g. they were handed the invite link/secret for this wallet)
+        // but their copayerId is NOT in session.participants: they never actually took part
+        // in the TSS key generation. A valid copayerSignature alone must not be enough to
+        // join a TSS wallet; only listed DKG participants may.
+        const copayerOpts: any = helpers.getSignedCopayerOpts({
+          walletId,
+          name: 'attacker',
+          xPubKey: TestData.copayers[1].xPubKey_44H_0H_0H,
+          clientDerivedPublicKey: 'attacker-controlled-client-derived-pubkey',
+          requestPubKey: TestData.copayers[1].pubKey_1H_0,
+        });
+
+        const { err, result } = await new Promise<{ err: any; result: any }>(resolve => {
+          server.joinWallet(copayerOpts, (err, result) => resolve({ err, result }));
+        });
+
+        should.not.exist(result);
+        should.exist(err);
+        err.code.should.equal('TSS_NON_PARTICIPANT');
+
+        // The rejected join must not have persisted the attacker as a copayer despite
+        // supplying a valid copayerSignature - a regression that returns TSS_NON_PARTICIPANT
+        // but still adds the copayer would pass the assertions above alone.
+        const wallet = await util.promisify(server.getWallet).call(server, {});
+        wallet.copayers.length.should.equal(0);
+      });
+
+      it('should cleanly reject a clientDerivedPublicKey join to a TSS wallet with no xPubKey at all, instead of crashing', async function() {
+        // SECURITY: this is the TSS-wallet counterpart to the plain-wallet
+        // "should cleanly reject a hardwareSourcePublicKey join with no xPubKey at all" test
+        // above. The TSS_NON_PARTICIPANT check computes
+        // Copayer.xPubToCopayerId(opts.chain, opts.xPubKey) directly from opts.xPubKey - a call
+        // this fix newly made reachable for hardware/client-derived joins (the old bypass used
+        // to intercept before it). Without the unconditional xPubKey requirement added above,
+        // a TSS join missing xPubKey entirely would hit this exact line and crash/hang instead
+        // of returning a clean error.
+        const server = new WalletService();
+
+        const legitXPubKey = TestData.copayers[0].xPubKey_44H_0H_0H;
+        const legitCopayerId = Model.Copayer.xPubToCopayerId('btc', legitXPubKey);
+
+        const session = TssKeyGenModel.create({
+          id: 'tss-no-xpubkey-crash-test-session',
+          message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
+          n: 1,
+          copayerId: legitCopayerId,
+        });
+        session.sharedPublicKey = 'dummy-shared-public-key';
+        await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });
+        await server.storage.storeTssKeyGenSession({ doc: session });
+
+        const walletId = await util.promisify(server.createWallet).call(server, {
+          name: 'tss wallet',
+          m: 1,
+          n: 1,
+          pubKey: TestData.keyPair.pub,
+          coin: 'btc',
+          tssKeyId: session.id,
+        });
+        should.exist(walletId);
+
+        const copayerOpts: any = helpers.getSignedCopayerOpts({
+          walletId,
+          name: 'me',
+          xPubKey: legitXPubKey,
+          clientDerivedPublicKey: 'legit-client-derived-pubkey-no-xpub',
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        delete copayerOpts.xPubKey;
+
+        const { err, result } = await new Promise<{ err: any; result: any }>(resolve => {
+          server.joinWallet(copayerOpts, (err, result) => resolve({ err, result }));
+        });
+
+        should.not.exist(result);
+        should.exist(err);
+        err.message.should.contain('xPubKey');
       });
     });
   });

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1259,6 +1259,35 @@ describe('Wallet service', function() {
         });
       });
 
+      // Table-driven rather than one near-identical 'it' per field: the point of each case is
+      // that this *particular* ancillary field must not stand in for xPubKey, so looping over
+      // the field name keeps that assertion identical across cases and makes it obvious if a
+      // future ancillary field (a third credential type) is added without a matching case here.
+      for (const ancillaryField of ['hardwareSourcePublicKey', 'clientDerivedPublicKey']) {
+        it(`should reject an xPubKey-less ${ancillaryField} join without persisting a copayer`, function(done) {
+          const copayerOpts: any = helpers.getSignedCopayerOpts({
+            walletId: walletId,
+            name: 'me',
+            requestPubKey: TestData.copayers[0].pubKey_1H_0,
+          });
+          should.not.exist(copayerOpts.xPubKey);
+          copayerOpts[ancillaryField] = 'legit-value-no-xpub';
+          server.joinWallet(copayerOpts, function(err, result) {
+            should.not.exist(result);
+            should.exist(err);
+            err.should.be.instanceof(ClientError);
+            // The join is rejected before WalletService.walletId is set, so an unauthenticated
+            // getWallet({}) cannot address the wallet; read persisted state at the storage level.
+            server.storage.fetchWallet(walletId, function(err, wallet) {
+              should.not.exist(err);
+              should.exist(wallet);
+              wallet.copayers.length.should.equal(0);
+              done();
+            });
+          });
+        });
+      }
+
       it('should fail to join with a malformed xPubKey even when hardwareSourcePublicKey is present', function(done) {
         const copayerOpts = helpers.getSignedCopayerOpts({
           walletId: walletId,

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1228,29 +1228,65 @@ describe('Wallet service', function() {
         });
       });
 
-      it('should cleanly reject a hardwareSourcePublicKey join with no xPubKey at all, instead of crashing', function(done) {
-        // SECURITY: Copayer.xPubToCopayerId() (called from Copayer.create(), and separately
-        // from the TSS participant check below) hashes opts.xPubKey with sjcl directly. For the
-        // default coin ('btc'), hashing undefined throws inside sjcl; since that throw happens
-        // inside an async storage.fetchWallet callback that nothing awaits, it used to surface
-        // as an unhandled rejection instead of a clean ClientError response - crashing the whole
-        // process, not just failing the one request. Confirmed by direct execution against the
-        // pre-fix code before this test was written. xPubKey must be required unconditionally,
-        // before any of that code is reached, regardless of hardwareSourcePublicKey/
-        // clientDerivedPublicKey.
+      it('should join with a valid signature and hardwareSourcePublicKey present when xPubKey is absent', function(done) {
+        // SECURITY: defensive coverage for a model contract (Copayer.create() has always
+        // tolerated an absent xPubKey when an alternate credential is present) that no client
+        // in this monorepo currently exercises - bitcore-wallet-client's only join path always
+        // sends a real xPubKey. The copayer ID must be derived from the effective identity
+        // credential (hardwareSourcePublicKey here), never from `undefined` (hashing which
+        // throws for the default coin and collides into one constant hash per chain for every
+        // other coin). The signature is created while xPubKey is genuinely absent - it covers
+        // [name, undefined, requestPubKey].join('|') === 'me||<requestPubKey>', exactly what
+        // the client would compute for the same omission, so this also proves that hash form
+        // verifies server-side.
         const copayerOpts: any = helpers.getSignedCopayerOpts({
           walletId: walletId,
           name: 'me',
-          xPubKey: TestData.copayers[0].xPubKey_44H_0H_0H,
           requestPubKey: TestData.copayers[0].pubKey_1H_0,
         });
-        delete copayerOpts.xPubKey;
-        copayerOpts.hardwareSourcePublicKey = 'legit-hw-pubkey-no-xpub';
+        should.not.exist(copayerOpts.xPubKey);
+        const legitHwPubkeyNoXpub = 'legit-hw-pubkey-no-xpub';
+        copayerOpts.hardwareSourcePublicKey = legitHwPubkeyNoXpub;
+        const expectedCopayerId = Model.Copayer.xPubToCopayerId('btc', legitHwPubkeyNoXpub);
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(err);
+          should.exist(result);
+          result.copayerId.should.equal(expectedCopayerId);
+          server.getWallet({}, function(err, wallet) {
+            should.not.exist(err);
+            wallet.copayers.length.should.equal(1);
+            const copayer = wallet.copayers[0];
+            copayer.id.should.equal(expectedCopayerId);
+            should.not.exist(copayer.xPubKey);
+            copayer.hardwareSourcePublicKey.should.equal(legitHwPubkeyNoXpub);
+            done();
+          });
+        });
+      });
+
+      it('should reject a join when xPubKey, hardwareSourcePublicKey and clientDerivedPublicKey are all missing or empty', function(done) {
+        const copayerOpts: any = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        should.not.exist(copayerOpts.xPubKey);
+        copayerOpts.hardwareSourcePublicKey = '';
+        copayerOpts.clientDerivedPublicKey = '';
         server.joinWallet(copayerOpts, function(err, result) {
           should.not.exist(result);
           should.exist(err);
-          err.message.should.contain('xPubKey');
-          done();
+          err.should.be.instanceof(ClientError);
+          // The rejected join must not have persisted a copayer. The join is rejected
+          // before WalletService.walletId is set, so an unauthenticated getWallet({})
+          // cannot address the wallet, and there is no copayerId to authenticate with;
+          // read persisted state at the storage level instead.
+          server.storage.fetchWallet(walletId, function(err, wallet) {
+            should.not.exist(err);
+            should.exist(wallet);
+            wallet.copayers.length.should.equal(0);
+            done();
+          });
         });
       });
 
@@ -1606,25 +1642,29 @@ describe('Wallet service', function() {
         wallet.copayers.length.should.equal(0);
       });
 
-      it('should cleanly reject a clientDerivedPublicKey join to a TSS wallet with no xPubKey at all, instead of crashing', async function() {
-        // SECURITY: this is the TSS-wallet counterpart to the plain-wallet
-        // "should cleanly reject a hardwareSourcePublicKey join with no xPubKey at all" test
-        // above. The TSS_NON_PARTICIPANT check computes
-        // Copayer.xPubToCopayerId(opts.chain, opts.xPubKey) directly from opts.xPubKey - a call
-        // this fix newly made reachable for hardware/client-derived joins (the old bypass used
-        // to intercept before it). Without the unconditional xPubKey requirement added above,
-        // a TSS join missing xPubKey entirely would hit this exact line and crash/hang instead
-        // of returning a clean error.
+      it('should join a TSS wallet with a valid signature and clientDerivedPublicKey present when xPubKey is absent, if the copayer is a keygen session participant', async function() {
+        // SECURITY: defensive coverage for a model contract (Copayer.create() has always
+        // tolerated an absent xPubKey when an alternate credential is present) that no client
+        // in this monorepo currently exercises - bitcore-wallet-client's only join path always
+        // sends a real xPubKey, and its TSS participants are registered under the ID derived
+        // from it. Here the session participant list carries the ID derived from
+        // clientDerivedPublicKey instead, so the TSS_NON_PARTICIPANT check must be fed the same
+        // effective identity credential that Copayer.create() will use when persisting - never
+        // `undefined` (hashing which throws for the default coin and collides into one constant
+        // hash per chain for every other coin). The signature is created while xPubKey is
+        // genuinely absent - it covers [name, undefined, requestPubKey].join('|') ===
+        // 'me||<requestPubKey>', exactly what the client would compute for the same omission,
+        // so this also proves that hash form verifies server-side on a TSS wallet.
         const server = new WalletService();
 
-        const legitXPubKey = TestData.copayers[0].xPubKey_44H_0H_0H;
-        const legitCopayerId = Model.Copayer.xPubToCopayerId('btc', legitXPubKey);
+        const clientDerivedPublicKey = 'legit-client-derived-pubkey-no-xpub';
+        const participantCopayerId = Model.Copayer.xPubToCopayerId('btc', clientDerivedPublicKey);
 
         const session = TssKeyGenModel.create({
           id: 'tss-no-xpubkey-crash-test-session',
           message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
           n: 1,
-          copayerId: legitCopayerId,
+          copayerId: participantCopayerId,
         });
         session.sharedPublicKey = 'dummy-shared-public-key';
         await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });
@@ -1643,19 +1683,27 @@ describe('Wallet service', function() {
         const copayerOpts: any = helpers.getSignedCopayerOpts({
           walletId,
           name: 'me',
-          xPubKey: legitXPubKey,
-          clientDerivedPublicKey: 'legit-client-derived-pubkey-no-xpub',
+          clientDerivedPublicKey,
           requestPubKey: TestData.copayers[0].pubKey_1H_0,
         });
-        delete copayerOpts.xPubKey;
+        should.not.exist(copayerOpts.xPubKey);
 
         const { err, result } = await new Promise<{ err: any; result: any }>(resolve => {
           server.joinWallet(copayerOpts, (err, result) => resolve({ err, result }));
         });
 
-        should.not.exist(result);
-        should.exist(err);
-        err.message.should.contain('xPubKey');
+        should.not.exist(err);
+        should.exist(result);
+        result.copayerId.should.equal(participantCopayerId);
+
+        // The join must have persisted the copayer with an ID derived from
+        // clientDerivedPublicKey and no xPubKey.
+        const wallet = await util.promisify(server.getWallet).call(server, {});
+        wallet.copayers.length.should.equal(1);
+        const copayer = wallet.copayers[0];
+        copayer.id.should.equal(participantCopayerId);
+        should.not.exist(copayer.xPubKey);
+        copayer.clientDerivedPublicKey.should.equal(clientDerivedPublicKey);
       });
     });
   });

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1228,37 +1228,78 @@ describe('Wallet service', function() {
         });
       });
 
-      it('should join with a valid signature and hardwareSourcePublicKey present when xPubKey is absent', function(done) {
-        // SECURITY: defensive coverage for a model contract (Copayer.create() has always
-        // tolerated an absent xPubKey when an alternate credential is present) that no client
-        // in this monorepo currently exercises - bitcore-wallet-client's only join path always
-        // sends a real xPubKey. The copayer ID must be derived from the effective identity
-        // credential (hardwareSourcePublicKey here), never from `undefined` (hashing which
-        // throws for the default coin and collides into one constant hash per chain for every
-        // other coin). The signature is created while xPubKey is genuinely absent - it covers
-        // [name, undefined, requestPubKey].join('|') === 'me||<requestPubKey>', exactly what
-        // the client would compute for the same omission, so this also proves that hash form
-        // verifies server-side.
+      it('should reject a join with hardwareSourcePublicKey present when xPubKey is absent', function(done) {
+        // xPubKey is the canonical copayer identity for every join; the ancillary
+        // hardwareSourcePublicKey field is metadata and must not stand in for it. The
+        // signature is created while xPubKey is genuinely absent - it covers
+        // [name, undefined, requestPubKey].join('|') === 'me||<requestPubKey>' - so the
+        // rejection below is attributable to the missing identity field, not to a
+        // signature invalidated by deleting an xpub after signing.
         const copayerOpts: any = helpers.getSignedCopayerOpts({
           walletId: walletId,
           name: 'me',
           requestPubKey: TestData.copayers[0].pubKey_1H_0,
         });
         should.not.exist(copayerOpts.xPubKey);
-        const legitHwPubkeyNoXpub = 'legit-hw-pubkey-no-xpub';
-        copayerOpts.hardwareSourcePublicKey = legitHwPubkeyNoXpub;
-        const expectedCopayerId = Model.Copayer.xPubToCopayerId('btc', legitHwPubkeyNoXpub);
+        copayerOpts.hardwareSourcePublicKey = 'legit-hw-pubkey-no-xpub';
         server.joinWallet(copayerOpts, function(err, result) {
-          should.not.exist(err);
-          should.exist(result);
-          result.copayerId.should.equal(expectedCopayerId);
-          server.getWallet({}, function(err, wallet) {
+          should.not.exist(result);
+          should.exist(err);
+          err.should.be.instanceof(ClientError);
+          // The rejected join must not have persisted a copayer. The join is rejected
+          // before WalletService.walletId is set, so an unauthenticated getWallet({})
+          // cannot address the wallet, and there is no copayerId to authenticate with;
+          // read persisted state at the storage level instead.
+          server.storage.fetchWallet(walletId, function(err, wallet) {
             should.not.exist(err);
-            wallet.copayers.length.should.equal(1);
-            const copayer = wallet.copayers[0];
-            copayer.id.should.equal(expectedCopayerId);
-            should.not.exist(copayer.xPubKey);
-            copayer.hardwareSourcePublicKey.should.equal(legitHwPubkeyNoXpub);
+            should.exist(wallet);
+            wallet.copayers.length.should.equal(0);
+            done();
+          });
+        });
+      });
+
+      it('should fail to join with a malformed xPubKey even when hardwareSourcePublicKey is present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: 'invalid',
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.hardwareSourcePublicKey = 'legit-hw-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(result);
+          should.exist(err);
+          err.should.be.instanceof(ClientError);
+          // The rejected join must not have persisted a copayer; read persisted state
+          // at the storage level (the join may be rejected before WalletService.walletId
+          // is set, in which case getWallet({}) cannot address the wallet).
+          server.storage.fetchWallet(walletId, function(err, wallet) {
+            should.not.exist(err);
+            should.exist(wallet);
+            wallet.copayers.length.should.equal(0);
+            done();
+          });
+        });
+      });
+
+      it('should fail to join with a malformed xPubKey even when clientDerivedPublicKey is present', function(done) {
+        const copayerOpts = helpers.getSignedCopayerOpts({
+          walletId: walletId,
+          name: 'me',
+          xPubKey: 'invalid',
+          requestPubKey: TestData.copayers[0].pubKey_1H_0,
+        });
+        copayerOpts.clientDerivedPublicKey = 'legit-client-derived-pubkey';
+        server.joinWallet(copayerOpts, function(err, result) {
+          should.not.exist(result);
+          should.exist(err);
+          err.should.be.instanceof(ClientError);
+          // Same persisted-state guard as the hardwareSourcePublicKey case above.
+          server.storage.fetchWallet(walletId, function(err, wallet) {
+            should.not.exist(err);
+            should.exist(wallet);
+            wallet.copayers.length.should.equal(0);
             done();
           });
         });
@@ -1642,29 +1683,26 @@ describe('Wallet service', function() {
         wallet.copayers.length.should.equal(0);
       });
 
-      it('should join a TSS wallet with a valid signature and clientDerivedPublicKey present when xPubKey is absent, if the copayer is a keygen session participant', async function() {
-        // SECURITY: defensive coverage for a model contract (Copayer.create() has always
-        // tolerated an absent xPubKey when an alternate credential is present) that no client
-        // in this monorepo currently exercises - bitcore-wallet-client's only join path always
-        // sends a real xPubKey, and its TSS participants are registered under the ID derived
-        // from it. Here the session participant list carries the ID derived from
-        // clientDerivedPublicKey instead, so the TSS_NON_PARTICIPANT check must be fed the same
-        // effective identity credential that Copayer.create() will use when persisting - never
-        // `undefined` (hashing which throws for the default coin and collides into one constant
-        // hash per chain for every other coin). The signature is created while xPubKey is
-        // genuinely absent - it covers [name, undefined, requestPubKey].join('|') ===
-        // 'me||<requestPubKey>', exactly what the client would compute for the same omission,
-        // so this also proves that hash form verifies server-side on a TSS wallet.
+      it('should reject a TSS join with clientDerivedPublicKey present when xPubKey is absent, even if the ancillary-derived ID is a keygen session participant', async function() {
+        // xPubKey is the canonical copayer identity for every join, including TSS ones;
+        // the ancillary clientDerivedPublicKey field must not stand in for it. The
+        // session participant list below carries the ID derived from
+        // clientDerivedPublicKey, so this proves the join is rejected for the missing
+        // identity field itself rather than by the TSS participant check. The signature
+        // is created while xPubKey is genuinely absent - it covers
+        // [name, undefined, requestPubKey].join('|') === 'me||<requestPubKey>' - so it is
+        // valid for the request as sent and the rejection is attributable to the missing
+        // xPubKey, not to an invalidated signature.
         const server = new WalletService();
 
         const clientDerivedPublicKey = 'legit-client-derived-pubkey-no-xpub';
-        const participantCopayerId = Model.Copayer.xPubToCopayerId('btc', clientDerivedPublicKey);
+        const ancillaryDerivedCopayerId = Model.Copayer.xPubToCopayerId('btc', clientDerivedPublicKey);
 
         const session = TssKeyGenModel.create({
-          id: 'tss-no-xpubkey-crash-test-session',
+          id: 'tss-no-xpubkey-rejected-test-session',
           message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
           n: 1,
-          copayerId: participantCopayerId,
+          copayerId: ancillaryDerivedCopayerId,
         });
         session.sharedPublicKey = 'dummy-shared-public-key';
         await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });
@@ -1692,18 +1730,16 @@ describe('Wallet service', function() {
           server.joinWallet(copayerOpts, (err, result) => resolve({ err, result }));
         });
 
-        should.not.exist(err);
-        should.exist(result);
-        result.copayerId.should.equal(participantCopayerId);
+        should.not.exist(result);
+        should.exist(err);
+        err.should.be.instanceof(ClientError);
 
-        // The join must have persisted the copayer with an ID derived from
-        // clientDerivedPublicKey and no xPubKey.
-        const wallet = await util.promisify(server.getWallet).call(server, {});
-        wallet.copayers.length.should.equal(1);
-        const copayer = wallet.copayers[0];
-        copayer.id.should.equal(participantCopayerId);
-        should.not.exist(copayer.xPubKey);
-        copayer.clientDerivedPublicKey.should.equal(clientDerivedPublicKey);
+        // The rejected join must not have persisted a copayer. The join is rejected
+        // before WalletService.walletId is set, so an unauthenticated getWallet({})
+        // cannot address the wallet; read persisted state at the storage level instead.
+        const wallet = await util.promisify(server.storage.fetchWallet).call(server.storage, walletId);
+        should.exist(wallet);
+        wallet.copayers.length.should.equal(0);
       });
     });
   });

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1615,13 +1615,7 @@ describe('Wallet service', function() {
     });
 
     // SECURITY: this guards against a copayer joining a TSS wallet without ever being checked
-    // against the key generation session's participant list. A join carrying
-    // hardwareSourcePublicKey/clientDerivedPublicKey must never be able to add a copayer
-    // before joinWallet()'s TSS_NON_PARTICIPANT check has run - a gate that (incorrectly)
-    // keyed off an opts.tssKeyId the join request never actually carries, instead of the
-    // wallet's own persisted wallet.tssKeyId, previously let this slip through entirely. Keep
-    // this test paired with the plain-signature-bypass tests above; both guard the same
-    // control-flow mistake from two different angles.
+    // against the key generation session's participant list.
     describe('TSS wallets (non-participant bypass)', function() {
       it('should reject a join from a copayer who is not a TSS keygen session participant, even with clientDerivedPublicKey supplied', async function() {
         const server = new WalletService();
@@ -1693,6 +1687,8 @@ describe('Wallet service', function() {
         // [name, undefined, requestPubKey].join('|') === 'me||<requestPubKey>' - so it is
         // valid for the request as sent and the rejection is attributable to the missing
         // xPubKey, not to an invalidated signature.
+
+        // 20 Aug '26: Support for joining a wallet without xPubKey will fast-follow
         const server = new WalletService();
 
         const clientDerivedPublicKey = 'legit-client-derived-pubkey-no-xpub';

--- a/packages/bitcore-wallet-service/test/model/copayer.test.ts
+++ b/packages/bitcore-wallet-service/test/model/copayer.test.ts
@@ -8,15 +8,13 @@ import { Copayer } from '../../src/lib/model/copayer';
 const should = chai.should();
 
 describe('Copayer', function() {
-  // SECURITY: copayer identity must be derived from exactly one effective credential,
-  // in a fixed precedence (xPubKey, then hardwareSourcePublicKey, then
-  // clientDerivedPublicKey), so that IDs stay stable for every xpub-bearing caller and
-  // never hash `undefined` (which throws for the default coin and collides into one
-  // constant hash per chain for every other coin).
-  describe('#create identity key selection', function() {
-    // SECURITY: `chain` is passed explicitly below because the service layer
+  // xPubKey is the canonical copayer identity: the ID is always derived from it, and
+  // hardwareSourcePublicKey / clientDerivedPublicKey are persisted ancillary metadata
+  // that never select identity.
+  describe('#create identity', function() {
+    // `chain` is passed explicitly below because the service layer
     // (joinWallet / _addCopayerToWallet) always supplies a resolved chain (backfilled
-    // from coin via Wallet.fromObj); these model tests encode the identity-key contract
+    // from coin via Wallet.fromObj); these model tests encode the identity contract
     // under that precondition rather than pinning a coin-only input shape.
     const baseOpts = {
       coin: 'btc',
@@ -54,50 +52,18 @@ describe('Copayer', function() {
       c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
     });
 
-    it('should fall back to hardwareSourcePublicKey when xPubKey is absent', function() {
-      const hardwareSourcePublicKey = 'hw-key';
-      const c = Copayer.create({ ...baseOpts, hardwareSourcePublicKey });
-      c.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey));
-    });
-
-    it('should fall back to clientDerivedPublicKey when xPubKey and hardwareSourcePublicKey are absent', function() {
-      const clientDerivedPublicKey = 'cdk-key';
-      const c = Copayer.create({ ...baseOpts, clientDerivedPublicKey: clientDerivedPublicKey });
-      c.id.should.equal(Copayer.xPubToCopayerId('btc', clientDerivedPublicKey));
-    });
-
-    it('should deterministically prefer hardwareSourcePublicKey over clientDerivedPublicKey when xPubKey is absent', function() {
-      const hardwareSourcePublicKey = 'hw-key';
-      const clientDerivedPublicKey = 'cdk-key';
-      const c = Copayer.create({ ...baseOpts, hardwareSourcePublicKey, clientDerivedPublicKey });
-      c.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey));
-    });
-
-    it('should assign distinct IDs to copayers with different hardwareSourcePublicKey values on btc', function() {
-      const hardwareSourcePublicKey_a = 'hw-key-a';
-      const hardwareSourcePublicKey_b = 'hw-key-b';
-
-      const a = Copayer.create({ ...baseOpts, hardwareSourcePublicKey: hardwareSourcePublicKey_a });
-      const b = Copayer.create({ ...baseOpts, hardwareSourcePublicKey: hardwareSourcePublicKey_b });
-      should.exist(a.id);
-      a.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey_a));
-      b.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey_b));
-      a.id.should.not.equal(b.id);
-    });
-
-    it('should assign distinct IDs to copayers with different hardwareSourcePublicKey values on a non-default chain', function() {
-      const hardwareSourcePublicKey_a = 'hw-key-a';
-      const hardwareSourcePublicKey_b = 'hw-key-b';
-
+    it('should derive the same xpub-based ID on a non-default chain', function() {
+      const xPubKey = 'xpub-abc';
       const opts = { ...baseOpts, coin: 'bch', chain: 'bch' };
-      const a = Copayer.create({ ...opts, hardwareSourcePublicKey: hardwareSourcePublicKey_a });
-      const b = Copayer.create({ ...opts, hardwareSourcePublicKey: hardwareSourcePublicKey_b });
-      a.id.should.equal(Copayer.xPubToCopayerId('bch', hardwareSourcePublicKey_a));
-      b.id.should.equal(Copayer.xPubToCopayerId('bch', hardwareSourcePublicKey_b));
-      a.id.should.not.equal(b.id);
+      const c = Copayer.create({ ...opts, xPubKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('bch', xPubKey));
     });
 
-    it('should persist the supplied credential fields and leave unsupplied ones absent', function() {
+    it('should reject creation without xPubKey and without ancillary fields', function() {
+      should.throw(() => Copayer.create({ ...baseOpts }));
+    });
+
+    it('should persist the supplied ancillary fields and leave unsupplied ones absent', function() {
       const xPubKey = 'xpub-abc';
       const hardwareSourcePublicKey = 'hw-key';
 
@@ -105,6 +71,18 @@ describe('Copayer', function() {
       c.xPubKey.should.equal(xPubKey);
       c.hardwareSourcePublicKey.should.equal(hardwareSourcePublicKey);
       should.not.exist(c.clientDerivedPublicKey);
+    });
+
+    it('should persist both ancillary fields without changing the xpub-derived ID', function() {
+      const xPubKey = 'xpub-abc';
+      const hardwareSourcePublicKey = 'hw-key';
+      const clientDerivedPublicKey = 'cdk-key';
+
+      const c = Copayer.create({ ...baseOpts, xPubKey, hardwareSourcePublicKey, clientDerivedPublicKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
+      c.xPubKey.should.equal(xPubKey);
+      c.hardwareSourcePublicKey.should.equal(hardwareSourcePublicKey);
+      c.clientDerivedPublicKey.should.equal(clientDerivedPublicKey);
     });
   });
 

--- a/packages/bitcore-wallet-service/test/model/copayer.test.ts
+++ b/packages/bitcore-wallet-service/test/model/copayer.test.ts
@@ -8,6 +8,106 @@ import { Copayer } from '../../src/lib/model/copayer';
 const should = chai.should();
 
 describe('Copayer', function() {
+  // SECURITY: copayer identity must be derived from exactly one effective credential,
+  // in a fixed precedence (xPubKey, then hardwareSourcePublicKey, then
+  // clientDerivedPublicKey), so that IDs stay stable for every xpub-bearing caller and
+  // never hash `undefined` (which throws for the default coin and collides into one
+  // constant hash per chain for every other coin).
+  describe('#create identity key selection', function() {
+    // SECURITY: `chain` is passed explicitly below because the service layer
+    // (joinWallet / _addCopayerToWallet) always supplies a resolved chain (backfilled
+    // from coin via Wallet.fromObj); these model tests encode the identity-key contract
+    // under that precondition rather than pinning a coin-only input shape.
+    const baseOpts = {
+      coin: 'btc',
+      chain: 'btc',
+      name: 'me',
+      requestPubKey: '03814ac7decf64321a3c6967bfb746112fdb5b583531cd512cc3787eaf578947dc',
+      signature: 'dummy-signature',
+    };
+
+    it('should derive the ID from xPubKey alone', function() {
+      const xPubKey = 'xpub-abc';
+      const c = Copayer.create({ ...baseOpts, xPubKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
+    });
+
+    it('should prefer xPubKey when hardwareSourcePublicKey is also present', function() {
+      const xPubKey = 'xpub-abc';
+      const hardwareSourcePublicKey = 'hw-key';
+
+      const c = Copayer.create({ ...baseOpts, xPubKey, hardwareSourcePublicKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
+    });
+
+    it('should prefer xPubKey when both alternate credentials are also present', function() {
+      const xPubKey = 'xpub-abc';
+      const hardwareSourcePublicKey = 'hw-key';
+      const clientDerivedPublicKey = 'cdk-key';
+
+      const c = Copayer.create({
+        ...baseOpts,
+        xPubKey,
+        hardwareSourcePublicKey,
+        clientDerivedPublicKey,
+      });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
+    });
+
+    it('should fall back to hardwareSourcePublicKey when xPubKey is absent', function() {
+      const hardwareSourcePublicKey = 'hw-key';
+      const c = Copayer.create({ ...baseOpts, hardwareSourcePublicKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey));
+    });
+
+    it('should fall back to clientDerivedPublicKey when xPubKey and hardwareSourcePublicKey are absent', function() {
+      const clientDerivedPublicKey = 'cdk-key';
+      const c = Copayer.create({ ...baseOpts, clientDerivedPublicKey: clientDerivedPublicKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', clientDerivedPublicKey));
+    });
+
+    it('should deterministically prefer hardwareSourcePublicKey over clientDerivedPublicKey when xPubKey is absent', function() {
+      const hardwareSourcePublicKey = 'hw-key';
+      const clientDerivedPublicKey = 'cdk-key';
+      const c = Copayer.create({ ...baseOpts, hardwareSourcePublicKey, clientDerivedPublicKey });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey));
+    });
+
+    it('should assign distinct IDs to copayers with different hardwareSourcePublicKey values on btc', function() {
+      const hardwareSourcePublicKey_a = 'hw-key-a';
+      const hardwareSourcePublicKey_b = 'hw-key-b';
+
+      const a = Copayer.create({ ...baseOpts, hardwareSourcePublicKey: hardwareSourcePublicKey_a });
+      const b = Copayer.create({ ...baseOpts, hardwareSourcePublicKey: hardwareSourcePublicKey_b });
+      should.exist(a.id);
+      a.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey_a));
+      b.id.should.equal(Copayer.xPubToCopayerId('btc', hardwareSourcePublicKey_b));
+      a.id.should.not.equal(b.id);
+    });
+
+    it('should assign distinct IDs to copayers with different hardwareSourcePublicKey values on a non-default chain', function() {
+      const hardwareSourcePublicKey_a = 'hw-key-a';
+      const hardwareSourcePublicKey_b = 'hw-key-b';
+
+      const opts = { ...baseOpts, coin: 'bch', chain: 'bch' };
+      const a = Copayer.create({ ...opts, hardwareSourcePublicKey: hardwareSourcePublicKey_a });
+      const b = Copayer.create({ ...opts, hardwareSourcePublicKey: hardwareSourcePublicKey_b });
+      a.id.should.equal(Copayer.xPubToCopayerId('bch', hardwareSourcePublicKey_a));
+      b.id.should.equal(Copayer.xPubToCopayerId('bch', hardwareSourcePublicKey_b));
+      a.id.should.not.equal(b.id);
+    });
+
+    it('should persist the supplied credential fields and leave unsupplied ones absent', function() {
+      const xPubKey = 'xpub-abc';
+      const hardwareSourcePublicKey = 'hw-key';
+
+      const c = Copayer.create({ ...baseOpts, xPubKey, hardwareSourcePublicKey });
+      c.xPubKey.should.equal(xPubKey);
+      c.hardwareSourcePublicKey.should.equal(hardwareSourcePublicKey);
+      should.not.exist(c.clientDerivedPublicKey);
+    });
+  });
+
   describe('#fromObj', function() {
     it('read a copayer', function() {
       const c = Copayer.fromObj(testWallet.copayers[0]);

--- a/packages/bitcore-wallet-service/test/model/copayer.test.ts
+++ b/packages/bitcore-wallet-service/test/model/copayer.test.ts
@@ -14,6 +14,30 @@ describe('Copayer', function() {
 
   // 20 Aug '26 - support for hardware wallets lacking xPubKey will
   // change the above statement and change the nature of these tests
+  describe('#xPubToCopayerId', function() {
+    it('should reject a missing xPubKey for the default coin', function() {
+      should.throw(() => Copayer.xPubToCopayerId('btc', undefined), 'Missing xPubKey for copayer id derivation');
+    });
+
+    it('should reject a missing xPubKey for a non-default coin instead of hashing "<coin>undefined"', function() {
+      should.throw(() => Copayer.xPubToCopayerId('bch', undefined), 'Missing xPubKey for copayer id derivation');
+    });
+
+    it('should reject null and empty xPubKey values', function() {
+      should.throw(() => Copayer.xPubToCopayerId('btc', null), 'Missing xPubKey for copayer id derivation');
+      should.throw(() => Copayer.xPubToCopayerId('btc', ''), 'Missing xPubKey for copayer id derivation');
+    });
+
+    it('should preserve existing copayer IDs for valid xPubKey inputs', function() {
+      const xPubKey = 'xpub661MyMwAqRbcFLRkhYzK8eQdoywNHJVsJCMQNDoMks5bZymuMcyDgYfnVQYq2Q9npnVmdTAthYGc3N3uxm5sEdnTpSqBc4YYTAhNnoSxCm9';
+      // Pinned hash so a change to the derivation (e.g. algorithm, encoding, or the
+      // coin == Defaults.COIN branch) would break existing wallets' copayer ids silently.
+      Copayer.xPubToCopayerId('btc', xPubKey).should.equal(
+        '77a8752fdddbe10fb9c290bd55ea8efbb1ad72adb4e68e8b57bf04adc3cc3ebb'
+      );
+    });
+  });
+
   describe('#create identity', function() {
     // `chain` is passed explicitly below because the service layer
     // (joinWallet / _addCopayerToWallet) always supplies a resolved chain (backfilled
@@ -64,6 +88,29 @@ describe('Copayer', function() {
 
     it('should reject creation without xPubKey and without ancillary fields', function() {
       should.throw(() => Copayer.create({ ...baseOpts }));
+    });
+
+    it('should reject an xPubKey-less copayer with hardwareSourcePublicKey until alternative ID derivation is implemented', function() {
+      // Copayer.create's own xPubKey guard is skipped when hardwareSourcePublicKey is present
+      // (that's the carve-out left for a future hardware-derived identity), but there is no
+      // alternative ID derivation yet, so the id assignment below falls through to
+      // xPubToCopayerId(chain, undefined), which still throws.
+      should.throw(() => Copayer.create({ ...baseOpts, hardwareSourcePublicKey: 'hw-key' }));
+    });
+
+    it('should reject an xPubKey-less copayer with clientDerivedPublicKey until alternative ID derivation is implemented', function() {
+      should.throw(() => Copayer.create({ ...baseOpts, clientDerivedPublicKey: 'cdk-key' }));
+    });
+
+    it('should continue deriving the copayer ID from xPubKey when ancillary public keys are also present', function() {
+      const xPubKey = 'xpub-abc';
+      const c = Copayer.create({
+        ...baseOpts,
+        xPubKey,
+        hardwareSourcePublicKey: 'hw-key',
+        clientDerivedPublicKey: 'cdk-key',
+      });
+      c.id.should.equal(Copayer.xPubToCopayerId('btc', xPubKey));
     });
 
     it('should persist the supplied ancillary fields and leave unsupplied ones absent', function() {

--- a/packages/bitcore-wallet-service/test/model/copayer.test.ts
+++ b/packages/bitcore-wallet-service/test/model/copayer.test.ts
@@ -11,6 +11,9 @@ describe('Copayer', function() {
   // xPubKey is the canonical copayer identity: the ID is always derived from it, and
   // hardwareSourcePublicKey / clientDerivedPublicKey are persisted ancillary metadata
   // that never select identity.
+
+  // 20 Aug '26 - support for hardware wallets lacking xPubKey will
+  // change the above statement and change the nature of these tests
   describe('#create identity', function() {
     // `chain` is passed explicitly below because the service layer
     // (joinWallet / _addCopayerToWallet) always supplies a resolved chain (backfilled


### PR DESCRIPTION
### Description

Closes IS-1391 — unauthorized wallet join via `hardwareSourcePublicKey` / `clientDerivedPublicKey`.

`WalletService.joinWallet()` (`POST /v2/wallets/:id/copayers/`) previously returned early into `_addCopayerToWallet()` when a join request included a truthy `hardwareSourcePublicKey` or `clientDerivedPublicKey` and no request-side `opts.tssKeyId`. Normal join requests do not carry `opts.tssKeyId`, so this branch ran before wallet-secret verification (`copayerSignature`) and bypassed the upgrade, chain, network, legacy-wallet, duplicate-copayer, wallet-full, and TSS-participant checks.

Anyone who knew the ID of a wallet with an available join slot could therefore add an attacker-controlled copayer and obtain a valid copayer ID and authenticated request key without proving knowledge of the wallet’s join secret.

This PR removes that early return. Every accepted join now requires a valid HD `xPubKey`, which is the canonical identity input for the service-layer join protocol. `hardwareSourcePublicKey` and `clientDerivedPublicKey` remain available as ancillary copayer data, but their presence cannot suppress `xPubKey` validation or bypass join authorization.

The PR also makes `addAccess()` fail closed when it encounters malformed historical copayer state.

#### Compatibility note (intentional protocol restriction)

Service-layer joins that provide only an alternate public key, or provide a raw, placeholder, or otherwise invalid HD value in `xPubKey`, are now rejected.

The repository’s generated-client join path (`_doJoinWallet`) supplies both a real `xPubKey` and a real `copayerSignature`, including when either ancillary field is present. No generated-client flow exercised by this repository depends on the removed shortcut.

Upstream or out-of-repository consumers that relied on xpub-less joins must be inventoried before this change is considered impact-free. Such clients should not be accommodated by restoring an authorization bypass; supporting a different canonical identity requires a versioned end-to-end protocol.

### Changelog

* Removed the authorization-free early return from `joinWallet()`. Alternate public-key fields no longer call `_addCopayerToWallet()` before authorization and wallet validation.
* Required and parsed `xPubKey` for every service-layer join. Ancillary fields can no longer suppress required-field, HD parsing, or network validation.
* Ensured joins carrying ancillary fields are subject to the normal upgrade, chain, network, legacy-wallet, wallet-secret, and duplicate-copayer checks. Non-TSS joins remain subject to the wallet-full check, while TSS joins must pass the TSS participant check.
* Ensured the existing TSS participant check is reached after authorization. That check uses the persisted `wallet.tssKeyId` and the corresponding key-generation session’s participant list; the removed shortcut was incorrectly conditioned on request-side `opts.tssKeyId`, which normal join requests do not carry.
* Eliminated two historical failure modes for an absent join-time `xPubKey`: an undefined-input hashing exception on the default chain and a colliding constant derived ID on non-default chains.
* Made `addAccess()` return `NOT_AUTHORIZED` when the target copayer is missing or its persisted `xPubKey` is absent or malformed, instead of allowing a property-access or HD-parsing exception to escape.
* Added regression coverage in `test/integration/server.test.ts` and `test/model/copayer.test.ts`.

### Testing Notes

Run from `packages/bitcore-wallet-service`:

```bash
npm test

# Or target the affected suites:
npm run compile && npx mocha 'ts_build/test/integration/server.test.js' 'ts_build/test/model/copayer.test.js'
```

New and relevant assertions reviewers should validate
- Wrong-signature joins with either ancillary field are rejected as Bad request, and the persisted wallet remains unchanged with no copayer added.
  Tests in test/integration/server.test.ts:
  - should fail to join with wrong signature even when hardwareSourcePublicKey is present
  - should fail to join with wrong signature even when clientDerivedPublicKey is present
- Valid-signature joins with ancillary data succeed, return the persisted copayer ID, and retain the supplied metadata.
  Tests in test/integration/server.test.ts:
  - should join existing wallet with a valid signature and hardwareSourcePublicKey present
  - should join existing wallet with a valid signature and clientDerivedPublicKey present
- Missing join-time xPubKey values are rejected even when an ancillary field is present, and no copayer is persisted.
  Tests in test/integration/server.test.ts:
  - should reject a join with hardwareSourcePublicKey present when xPubKey is absent
  - should reject a join when xPubKey, hardwareSourcePublicKey and clientDerivedPublicKey are all missing or empty
  - should reject a TSS join with clientDerivedPublicKey present when xPubKey is absent, even if the ancillary-derived ID is a keygen session participant
- Malformed join-time xPubKey values are rejected regardless of ancillary metadata, with no copayer persisted in the new ancillary-field cases.
  Tests in test/integration/server.test.ts:
  - should fail to join with invalid xPubKey
  - should fail to join with a malformed xPubKey even when hardwareSourcePublicKey is present
  - should fail to join with a malformed xPubKey even when clientDerivedPublicKey is present
- A join carrying ancillary metadata cannot bypass the wallet-full check. A third join into a full m=1, n=2 wallet returns WALLET_FULL, and the wallet remains at two copayers.
  Test in test/integration/server.test.ts:
  - should fail to join a full wallet with a valid signature and hardwareSourcePublicKey present
- A TSS joiner with a valid copayerSignature is rejected with TSS_NON_PARTICIPANT when its xpub-derived copayer ID is absent from the key-generation session, and no copayer is persisted.
  Test in test/integration/server.test.ts:
  - should reject a join from a copayer who is not a TSS keygen session participant, even with clientDerivedPublicKey supplied
- addAccess() returns NOT_AUTHORIZED and leaves wallet and copayer-lookup state unchanged when historical copayer state is missing or malformed.
  Tests under #add access with historical copayer state in test/integration/server.test.ts:
  - should return NOT_AUTHORIZED when the target copayer is missing from the wallet
  - should return NOT_AUTHORIZED when the target copayer has no xPubKey
  - should return NOT_AUTHORIZED when the target copayer has a malformed xPubKey
- When an xPubKey is supplied, the copayer ID is derived from it regardless of ancillary fields. Supplied ancillary fields are persisted without selecting or changing identity.
  Tests under #create identity in test/model/copayer.test.ts:
  - should derive the ID from xPubKey alone
  - should prefer xPubKey when hardwareSourcePublicKey is also present
  - should prefer xPubKey when both alternate credentials are also present
  - should derive the same xpub-based ID on a non-default chain
  - should persist the supplied ancillary fields and leave unsupplied ones absent
  - should persist both ancillary fields without changing the xpub-derived ID
- Existing default-chain model behavior rejects creation when neither xPubKey nor either ancillary field is supplied.
  Test in test/model/copayer.test.ts:
  - should reject creation without xPubKey and without ancillary fields

Control-flow points not covered by new alternate-field-specific regression tests should be reviewed directly: chain mismatch, xpub network mismatch, duplicate-copayer detection, upgrade gates, and legacy-wallet rejection. The removed early return previously bypassed all of these checks.

The TSS tests explicitly clear their `tss_keygen` fixture IDs because `helpers.beforeEach()` does not currently include `tss_keygen` in its collection wipe list. This keeps the tests repeatable despite that pre-existing cleanup gap.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.