### PR TITLE
[BWS] Chore: unnecessary simplexGetEvents endpoint removed

### DIFF
--- a/packages/bitcore-wallet-service/src/externalservices/simplex.ts
+++ b/packages/bitcore-wallet-service/src/externalservices/simplex.ts
@@ -248,34 +248,4 @@ export class SimplexService {
       );
     });
   }
-
-  simplexGetEvents(req): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (!config.simplex) return reject(new Error('Simplex missing credentials'));
-      if (!req.env || (req.env != 'sandbox' && req.env != 'production'))
-        return reject(new Error("Simplex's request wrong environment"));
-
-      const API = config.simplex[req.env].api;
-      const API_KEY = config.simplex[req.env].apiKey;
-      const headers = {
-        'Content-Type': 'application/json',
-        Authorization: 'ApiKey ' + API_KEY
-      };
-
-      this.request.get(
-        API + '/wallet/merchant/v2/events',
-        {
-          headers,
-          json: true
-        },
-        (err, data) => {
-          if (err) {
-            return reject(err.body ? err.body : null);
-          } else {
-            return resolve(data.body ? data.body : null);
-          }
-        }
-      );
-    });
-  }
 }

--- a/packages/bitcore-wallet-service/src/lib/routes/services.ts
+++ b/packages/bitcore-wallet-service/src/lib/routes/services.ts
@@ -65,7 +65,7 @@ function respondWithAuthServer(req, res, context: RouteContext, handler: RouteHa
 }
 
 export function registerServiceRoutes(router: express.Router, context: RouteContext) {
-  const { getServerWithAuth, setPublicCache, returnError } = context;
+  const { setPublicCache } = context;
 
   const transakCorsOptions = {
     origin: (origin, cb) => {
@@ -396,19 +396,6 @@ export function registerServiceRoutes(router: express.Router, context: RouteCont
   router.post('/v1/service/simplex/sellPaymentRequest', (req, res) => {
     respondWithAuthServer(req, res, context, server => {
       return server.externalServices.simplex.simplexSellPaymentRequest(req);
-    });
-  });
-
-  router.get('/v1/service/simplex/events', (req, res) => {
-    getServerWithAuth(req, res, server => {
-      Promise.resolve()
-        .then(() => server.externalServices.simplex.simplexGetEvents({ env: req.query.env }))
-        .then(response => {
-          res.json(response);
-        })
-        .catch(err => {
-          returnError(err ?? 'unknown', res, req);
-        });
     });
   });
 

--- a/packages/bitcore-wallet-service/test/integration/externalservices/simplex.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/externalservices/simplex.test.ts
@@ -363,22 +363,4 @@ describe('Simplex integration', () => {
       }
     });
   });
-
-  describe('#simplexGetEvents', () => {
-    beforeEach(() => {
-      req = {
-        env: 'production'
-      };
-
-      fakeRequest = {
-        get: (_url, _opts, _cb) => { return _cb(null, { body: {} }); },
-      };
-      server.externalServices.simplex.request = fakeRequest;
-    });
-
-    it('should work properly if req is OK', async () => {
-      const data = await server.externalServices.simplex.simplexGetEvents(req);
-      should.exist(data);
-    });
-  });
 });


### PR DESCRIPTION
### Description
Ticket reference: [RN-2874](https://bitpayprod.atlassian.net/browse/RN-2874)

The `simplexGetEvents` function and its BWS endpoint were removed, as they were not currently used by either the app or the web.

### Changelog

Only unnecessary code removed.