### PR TITLE
Fixes cross-wallet txp view

### DIFF
--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3139,7 +3139,12 @@ export class WalletService implements IWalletService {
    * @returns {Object} txProposal
    */
   getTxByHash(opts, cb) {
-    this.storage.fetchTxByHash(opts.txid, (err, txp) => {
+    // Scoped to this.walletId: the global storage.fetchTxByHash
+    // would return any wallet's TxProposal for a known txid, disclosing a
+    // foreign wallet's proposal data to any authenticated copayer. The
+    // internal global consumers (BlockchainMonitor, getWalletFromIdentifier)
+    // are unaffected; they keep calling storage.fetchTxByHash directly.
+    this.storage.fetchTxByHashForWallet(this.walletId, opts.txid, (err, txp) => {
       if (err) return cb(err);
       if (!txp) return cb(Errors.TX_NOT_FOUND);
 

--- a/packages/bitcore-wallet-service/src/lib/server.ts
+++ b/packages/bitcore-wallet-service/src/lib/server.ts
@@ -3139,6 +3139,8 @@ export class WalletService implements IWalletService {
    * @returns {Object} txProposal
    */
   getTxByHash(opts, cb) {
+    if (!checkRequired(opts, 'txid', cb)) return;
+
     // Scoped to this.walletId: the global storage.fetchTxByHash
     // would return any wallet's TxProposal for a known txid, disclosing a
     // foreign wallet's proposal data to any authenticated copayer. The

--- a/packages/bitcore-wallet-service/src/lib/storage.ts
+++ b/packages/bitcore-wallet-service/src/lib/storage.ts
@@ -360,6 +360,25 @@ export class Storage {
     );
   }
 
+  // Wallet-scoped counterpart to fetchTxByHash, used by the authenticated
+  // by-hash API read.
+  fetchTxByHashForWallet(walletId: string, hash, cb: (err?: any, tx?: TxProposal) => void) {
+    if (!this.db) return cb();
+
+    this.db.collection(collections.TXS).findOne(
+      {
+        walletId,
+        txid: hash
+      },
+      (err, result) => {
+        if (err) return cb(err);
+        if (!result) return cb();
+
+        return this._completeTxData(walletId, TxProposal.fromObj(result), cb);
+      }
+    );
+  }
+
   fetchLastTxs(walletId, creatorId, limit, cb) {
     this.db
       .collection(collections.TXS)

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -4,6 +4,8 @@ import * as chai from 'chai';
 import 'chai/register-should';
 import util from 'util';
 import sinon from 'sinon';
+import http from 'http';
+import request from 'request';
 import * as CWC from '@bitpay-labs/crypto-wallet-core';
 import { ChainService } from '../../src/lib/chain/index';
 import config from '../../src/config';
@@ -15,6 +17,7 @@ import { BCHAddressTranslator } from '../../src/lib/bchaddresstranslator';
 import * as TestData from '../testdata';
 import helpers from './helpers';
 import { ClientError } from '../../src/lib/errors/clienterror';
+import { ExpressApp } from '../../src/lib/expressapp';
 
 const should = chai.should();
 config.moralis = config.moralis ?? {
@@ -9030,8 +9033,217 @@ describe('Wallet service', function() {
     });
     
     it.skip('should get accepted/rejected transaction proposal', function(done) { });
-    
+
     it.skip('should get broadcasted transaction proposal', function(done) { });
+  });
+
+  describe('#getTxByHash', function() {
+    // Two unrelated wallets (the multi-wallet `{ offset: 1 }` pattern used
+    // elsewhere in this file, e.g. 'should delete a wallet, and only that
+    // wallet') so wallet B has no legitimate relationship to wallet A's
+    // TxProposal.
+    let serverA: WalletService;
+    let walletA: Model.Wallet;
+    let serverB: WalletService;
+    let txp;
+
+    beforeEach(async function() {
+      ({ server: serverA, wallet: walletA } = await helpers.createAndJoinWallet(1, 1));
+      await helpers.stubUtxos(serverA, walletA, 1);
+      const txOpts = {
+        outputs: [{
+          toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+          amount: 0.5e8
+        }],
+        feePerKb: 100e2,
+        message: 'some message',
+      };
+      txp = await helpers.createAndPublishTx(serverA, txOpts, TestData.copayers[0].privKey_1H_0);
+      should.exist(txp);
+      // Sign to accepted status, which is when TxProposal#sign populates
+      // `txid`/`raw` (Phase 1 finding); no broadcast is required. signTx's
+      // callback returns the updated txp, since the local `txp` reference
+      // above predates signing.
+      const signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      txp = await util.promisify(serverA.signTx).call(serverA, {
+        txProposalId: txp.id,
+        signatures,
+      });
+      should.exist(txp.txid);
+
+      ({ server: serverB } = await helpers.createAndJoinWallet(1, 1, { offset: 1 }));
+    });
+
+    it('should not disclose another wallet\'s transaction proposal by hash', function(done) {
+      serverB.getTxByHash({
+        txid: txp.txid
+      }, function(err, res) {
+        should.exist(err);
+        should.not.exist(res);
+        err.should.be.instanceof(ClientError);
+        err.code.should.equal('TX_NOT_FOUND');
+        err.message.should.equal('Transaction proposal not found');
+        // Belt-and-suspenders: confirm the error itself carries none of
+        // wallet A's data (no walletId/creatorId/raw leaking via the error).
+        JSON.stringify(err).should.not.include(walletA.id);
+        done();
+      });
+    });
+
+    it('should get own transaction proposal by hash, unchanged from before the fix', function(done) {
+      // Also covers the note: getTx's sibling reader attaches the caller's
+      // own note to the response, and that attachment is unconditional on
+      // ownership (it always used this.walletId) -- confirm the fix didn't
+      // disturb it.
+      serverA.editTxNote({
+        txid: txp.txid,
+        body: 'a note from wallet A'
+      }, function(err) {
+        should.not.exist(err);
+        serverA.getTxByHash({
+          txid: txp.txid
+        }, function(err, res) {
+          should.not.exist(err);
+          should.exist(res);
+          res.id.should.equal(txp.id);
+          res.walletId.should.equal(walletA.id);
+          res.txid.should.equal(txp.txid);
+          should.exist(res.raw);
+          should.exist(res.note);
+          res.note.body.should.equal('a note from wallet A');
+          done();
+        });
+      });
+    });
+
+    it('should return the identical not-found error for a foreign txid and an unknown txid', function(done) {
+      serverB.getTxByHash({
+        txid: txp.txid
+      }, function(errForeign, resForeign) {
+        should.exist(errForeign);
+        should.not.exist(resForeign);
+        serverB.getTxByHash({
+          txid: helpers.randomTXID()
+        }, function(errUnknown, resUnknown) {
+          should.exist(errUnknown);
+          should.not.exist(resUnknown);
+          errForeign.code.should.equal(errUnknown.code);
+          errForeign.message.should.equal(errUnknown.message);
+          errForeign.code.should.equal('TX_NOT_FOUND');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('GET /v1/txproposalsbyhash/:id/ (HTTP route)', function() {
+    // Exercises the real Express route (registerTransactionRoutes ->
+    // getServerWithAuth -> WalletService.getInstanceWithAuth), not just the
+    // service method, so route wiring, request-auth plumbing, and HTTP
+    // status/body serialization are covered, not only the underlying
+    // service logic already tested above. Only the cryptographic signature
+    // check is stubbed to return true (matching helpers.getAuthServer's
+    // established pattern) -- copayer/wallet lookup, ownership scoping, and
+    // JSON serialization all run for real, against the same real storage
+    // instance the rest of this file uses.
+    const testPort = 3240;
+    const testHost = 'http://127.0.0.1';
+    let httpServer;
+    let verifyStub;
+    let walletA: Model.Wallet;
+    let walletB: Model.Wallet;
+    let txp;
+
+    beforeEach(async function() {
+      let serverA: WalletService;
+      let serverB: WalletService;
+      ({ server: serverA, wallet: walletA } = await helpers.createAndJoinWallet(1, 1));
+      await helpers.stubUtxos(serverA, walletA, 1);
+      const txOpts = {
+        outputs: [{
+          toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+          amount: 0.5e8
+        }],
+        feePerKb: 100e2,
+        message: 'some message',
+      };
+      txp = await helpers.createAndPublishTx(serverA, txOpts, TestData.copayers[0].privKey_1H_0);
+      const signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
+      txp = await util.promisify(serverA.signTx).call(serverA, {
+        txProposalId: txp.id,
+        signatures,
+      });
+      should.exist(txp.txid);
+
+      ({ server: serverB, wallet: walletB } = await helpers.createAndJoinWallet(1, 1, { offset: 1 }));
+
+      // Bypass only the crypto signature check, same as helpers.getAuthServer;
+      // the real ExpressApp/WalletService/Storage stack does everything else,
+      // including the actual walletId scoping under test.
+      verifyStub = sinon.stub(WalletService.prototype, '_verifySignature').returns(true);
+
+      const app = new ExpressApp();
+      httpServer = new http.Server(app.app);
+      await util.promisify(app.start).call(app, {
+        storage: helpers.getStorage(),
+        blockchainExplorer: helpers.getBlockchainExplorer(),
+        request: sinon.stub(),
+        disableLogs: true,
+        basePath: config.basePath
+      });
+      httpServer.listen(testPort);
+    });
+
+    afterEach(function() {
+      verifyStub.restore();
+      httpServer.close();
+    });
+
+    function getByHash(copayerId, txid, cb) {
+      request({
+        method: 'GET',
+        url: testHost + ':' + testPort + config.basePath + '/v1/txproposalsbyhash/' + txid + '/',
+        headers: {
+          'x-identity': copayerId,
+          'x-signature': 'stubbed'
+        },
+        json: true
+      }, (err, res, body) => cb(err, res, body));
+    }
+
+    it('foreign wallet gets HTTP 400 TX_NOT_FOUND with no owner data in the body', function(done) {
+      getByHash(walletB.copayers[0].id, txp.txid, (err, res, body) => {
+        should.not.exist(err);
+        res.statusCode.should.equal(400);
+        body.code.should.equal('TX_NOT_FOUND');
+        JSON.stringify(body).should.not.include(walletA.id);
+        done();
+      });
+    });
+
+    it('owner wallet gets HTTP 200 with the full proposal, unchanged', function(done) {
+      getByHash(walletA.copayers[0].id, txp.txid, (err, res, body) => {
+        should.not.exist(err);
+        res.statusCode.should.equal(200);
+        body.walletId.should.equal(walletA.id);
+        body.txid.should.equal(txp.txid);
+        should.exist(body.raw);
+        done();
+      });
+    });
+
+    it('foreign and unknown txids produce an identical HTTP 400 TX_NOT_FOUND body', function(done) {
+      getByHash(walletB.copayers[0].id, txp.txid, (err, resForeign, bodyForeign) => {
+        should.not.exist(err);
+        getByHash(walletB.copayers[0].id, helpers.randomTXID(), (err, resUnknown, bodyUnknown) => {
+          should.not.exist(err);
+          resForeign.statusCode.should.equal(resUnknown.statusCode);
+          bodyForeign.code.should.equal(bodyUnknown.code);
+          bodyForeign.code.should.equal('TX_NOT_FOUND');
+          done();
+        });
+      });
+    });
   });
 
   describe('#getTxs', function() {

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -9038,10 +9038,6 @@ describe('Wallet service', function() {
   });
 
   describe('#getTxByHash', function() {
-    // Two unrelated wallets (the multi-wallet `{ offset: 1 }` pattern used
-    // elsewhere in this file, e.g. 'should delete a wallet, and only that
-    // wallet') so wallet B has no legitimate relationship to wallet A's
-    // TxProposal.
     let serverA: WalletService;
     let walletA: Model.Wallet;
     let serverB: WalletService;
@@ -9060,10 +9056,7 @@ describe('Wallet service', function() {
       };
       txp = await helpers.createAndPublishTx(serverA, txOpts, TestData.copayers[0].privKey_1H_0);
       should.exist(txp);
-      // Sign to accepted status, which is when TxProposal#sign populates
-      // `txid`/`raw` (Phase 1 finding); no broadcast is required. signTx's
-      // callback returns the updated txp, since the local `txp` reference
-      // above predates signing.
+
       const signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
       txp = await util.promisify(serverA.signTx).call(serverA, {
         txProposalId: txp.id,
@@ -9091,10 +9084,6 @@ describe('Wallet service', function() {
     });
 
     it('should get own transaction proposal by hash, unchanged from before the fix', function(done) {
-      // Also covers the note: getTx's sibling reader attaches the caller's
-      // own note to the response, and that attachment is unconditional on
-      // ownership (it always used this.walletId) -- confirm the fix didn't
-      // disturb it.
       serverA.editTxNote({
         txid: txp.txid,
         body: 'a note from wallet A'
@@ -9142,10 +9131,7 @@ describe('Wallet service', function() {
     // service method, so route wiring, request-auth plumbing, and HTTP
     // status/body serialization are covered, not only the underlying
     // service logic already tested above. Only the cryptographic signature
-    // check is stubbed to return true (matching helpers.getAuthServer's
-    // established pattern) -- copayer/wallet lookup, ownership scoping, and
-    // JSON serialization all run for real, against the same real storage
-    // instance the rest of this file uses.
+    // check is stubbed to return true
     const testPort = 3240;
     const testHost = 'http://127.0.0.1';
     let httpServer;
@@ -9177,9 +9163,6 @@ describe('Wallet service', function() {
 
       ({ server: serverB, wallet: walletB } = await helpers.createAndJoinWallet(1, 1, { offset: 1 }));
 
-      // Bypass only the crypto signature check, same as helpers.getAuthServer;
-      // the real ExpressApp/WalletService/Storage stack does everything else,
-      // including the actual walletId scoping under test.
       verifyStub = sinon.stub(WalletService.prototype, '_verifySignature').returns(true);
 
       const app = new ExpressApp();

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -9123,6 +9123,17 @@ describe('Wallet service', function() {
         });
       });
     });
+
+    it('should return a bad-request error when txid is missing', function(done) {
+      serverA.getTxByHash({}, function(err, res) {
+        should.exist(err);
+        should.not.exist(res);
+        err.should.be.instanceof(ClientError);
+        err.code.should.equal('BADREQUEST');
+        err.message.should.equal('Required argument: txid missing.');
+        done();
+      });
+    });
   });
 
   describe('GET /v1/txproposalsbyhash/:id/ (HTTP route)', function() {
@@ -9132,8 +9143,8 @@ describe('Wallet service', function() {
     // status/body serialization are covered, not only the underlying
     // service logic already tested above. Only the cryptographic signature
     // check is stubbed to return true
-    const testPort = 3240;
     const testHost = 'http://127.0.0.1';
+    let testPort: number;
     let httpServer;
     let verifyStub;
     let walletA: Model.Wallet;
@@ -9141,6 +9152,9 @@ describe('Wallet service', function() {
     let txp;
 
     beforeEach(async function() {
+      httpServer = undefined;
+      verifyStub = undefined;
+
       let serverA: WalletService;
       let serverB: WalletService;
       ({ server: serverA, wallet: walletA } = await helpers.createAndJoinWallet(1, 1));
@@ -9174,12 +9188,34 @@ describe('Wallet service', function() {
         disableLogs: true,
         basePath: config.basePath
       });
-      httpServer.listen(testPort);
+
+      await new Promise<void>((resolve, reject) => {
+        httpServer.once('error', reject);
+        httpServer.listen(0, '127.0.0.1', () => {
+          httpServer.off('error', reject);
+          const address = httpServer.address();
+          if (!address || typeof address === 'string') {
+            return reject(new Error('HTTP test server did not bind to a TCP port'));
+          }
+          testPort = address.port;
+          resolve();
+        });
+      });
     });
 
-    afterEach(function() {
-      verifyStub.restore();
-      httpServer.close();
+    afterEach(function(done) {
+      if (verifyStub) {
+        verifyStub.restore();
+        verifyStub = undefined;
+      }
+      if (!httpServer?.listening) {
+        httpServer = undefined;
+        return done();
+      }
+      httpServer.close(err => {
+        httpServer = undefined;
+        done(err);
+      });
     });
 
     function getByHash(copayerId, txid, cb) {

--- a/packages/bitcore-wallet-service/test/storage.test.ts
+++ b/packages/bitcore-wallet-service/test/storage.test.ts
@@ -200,6 +200,97 @@ describe('Storage', function() {
       });
     });
 
+    it('should fetch tx by hash scoped to wallet, disambiguating duplicate txids across wallets', async function() {
+      // A second, unrelated wallet with its own proposal reusing 'txid0'. The
+      // txid index is non-unique, so this can happen in production; the
+      // scoped method must still resolve deterministically per walletId
+      // while the legacy global fetchTxByHash contract stays unchanged.
+      const otherWallet = Model.Wallet.create({
+        id: '456',
+        name: 'other wallet',
+        m: 1,
+        n: 1,
+        coin: 'btc',
+        chain: 'btc',
+        network: 'livenet',
+        pubKey: '',
+        singleAddress: false,
+        derivationStrategy: 'BIP45',
+        addressType: 'P2SH',
+      });
+      const otherCopayer = Model.Copayer.create({
+        coin: 'btc',
+        name: 'other copayer',
+        xPubKey: 'other xPubKey',
+        requestPubKey: 'other requestPubKey',
+        signature: 'other signature',
+      });
+      otherWallet.addCopayer(otherCopayer);
+      await util.promisify(storage.storeWalletAndUpdateCopayersLookup).call(storage, otherWallet);
+
+      const otherTx = Model.TxProposal.create({
+        walletId: '456',
+        coin: 'btc',
+        network: 'livenet',
+        outputs: [{
+          toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+          amount: 999,
+        }],
+        feePerKb: 100e2,
+        creatorId: otherWallet.copayers[0].id,
+      });
+      otherTx.status = 'pending';
+      otherTx.txid = 'txid0';
+      await util.promisify(storage.storeTx).call(storage, '456', otherTx);
+
+      // Global lookup is unchanged: it still finds *a* proposal with this
+      // txid (which one is not guaranteed with duplicates), proving the
+      // existing internal-caller contract was not altered.
+      const globalTx = await util.promisify(storage.fetchTxByHash).call(storage, 'txid0');
+      should.exist(globalTx);
+      globalTx.txid.should.equal('txid0');
+
+      // The scoped method resolves the correct wallet's proposal regardless
+      // of the duplicate.
+      const txForWalletA = await util.promisify(storage.fetchTxByHashForWallet).call(storage, '123', 'txid0');
+      should.exist(txForWalletA);
+      txForWalletA.walletId.should.equal('123');
+      txForWalletA.id.should.equal(proposals[0].id);
+
+      const txForWalletB = await util.promisify(storage.fetchTxByHashForWallet).call(storage, '456', 'txid0');
+      should.exist(txForWalletB);
+      txForWalletB.walletId.should.equal('456');
+      txForWalletB.id.should.equal(otherTx.id);
+
+      // A wallet with no proposal for this txid gets nothing (not the other
+      // wallet's data) -- proving the query is scoped, not just filtered
+      // client-side.
+      const otherWallet2 = Model.Wallet.create({
+        id: '789',
+        name: 'third wallet',
+        m: 1,
+        n: 1,
+        coin: 'btc',
+        chain: 'btc',
+        network: 'livenet',
+        pubKey: '',
+        singleAddress: false,
+        derivationStrategy: 'BIP45',
+        addressType: 'P2SH',
+      });
+      const thirdCopayer = Model.Copayer.create({
+        coin: 'btc',
+        name: 'third copayer',
+        xPubKey: 'third xPubKey',
+        requestPubKey: 'third requestPubKey',
+        signature: 'third signature',
+      });
+      otherWallet2.addCopayer(thirdCopayer);
+      await util.promisify(storage.storeWalletAndUpdateCopayersLookup).call(storage, otherWallet2);
+      const noTx = await util.promisify(storage.fetchTxByHashForWallet).call(storage, '789', 'txid0');
+      should.not.exist(noTx);
+    });
+
     it('should fetch all pending txs', function(done) {
       storage.fetchPendingTxs('123', function(err, txs) {
         should.not.exist(err);


### PR DESCRIPTION
### Description

Fixes a cross-wallet transaction proposal disclosure in `GET /v1/txproposalsbyhash/:txid/`.

Previously, the endpoint looked up transaction proposals globally by txid. This allowed an authenticated copayer to retrieve another wallet’s proposal when its txid was known. The endpoint now scopes the database lookup to the authenticated wallet.

Foreign and unknown txids return the same existing HTTP 400 `TX_NOT_FOUND` response, while owner access and transaction-note behavior remain unchanged.

### Changelog

* Add a wallet-scoped `fetchTxByHashForWallet` storage method.
* Use the authenticated wallet ID when retrieving transaction proposals by hash.
* Preserve the global hash lookup used by internal wallet-identifier and blockchain-monitor consumers.
* Add service-level and HTTP-route regression coverage for owner, foreign-wallet, and unknown txids.
* Add storage coverage for duplicate txids across wallets and verify deterministic wallet-scoped results.

### Testing Notes

Requires MongoDB on `localhost:27017`.

* TypeScript compilation and changed-file ESLint checks pass.
* Transaction-by-hash service and HTTP-route tests: 6 passing.
* Storage suite: 18 passing.
* The HTTP tests verify:
  * foreign wallet → HTTP 400 `TX_NOT_FOUND` with no owner data;
  * owner wallet → HTTP 200 with the full proposal;
  * foreign and unknown txids → indistinguishable error responses.
* The owner service test verifies transaction notes remain available.
* Full package suite: 1469 passing, 21 pending, with 2 failures in the pre-existing race-sensitive `Locks` tests; neither failure intersects this diff.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.