### PR TITLE
Fix failing test due to TS compile issue

### DIFF
--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1662,8 +1662,7 @@ describe('Wallet service', function() {
           message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
           n: 1,
           copayerId: legitCopayerId,
-          // looking for CI failure due to lack of version below
-          // version: 1.1,
+          version: 1.1,
         });
         session.sharedPublicKey = 'dummy-shared-public-key';
         await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });

--- a/packages/bitcore-wallet-service/test/integration/server.test.ts
+++ b/packages/bitcore-wallet-service/test/integration/server.test.ts
@@ -1662,6 +1662,8 @@ describe('Wallet service', function() {
           message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
           n: 1,
           copayerId: legitCopayerId,
+          // looking for CI failure due to lack of version below
+          // version: 1.1,
         });
         session.sharedPublicKey = 'dummy-shared-public-key';
         await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });
@@ -1728,6 +1730,7 @@ describe('Wallet service', function() {
           message: { partyId: 0, broadcastMessages: [], p2pMessages: [], publicKey: 'dummy', round: 0 },
           n: 1,
           copayerId: ancillaryDerivedCopayerId,
+          version: 1.1,
         });
         session.sharedPublicKey = 'dummy-shared-public-key';
         await server.storage.db.collection('tss_keygen').deleteMany({ id: session.id });


### PR DESCRIPTION
### Description
bws server.test.ts file breaks compilation. This fixes it with the right value.

### Changelog

* Add missing `version` property to TssKeyGenModel.create() call

### Testing Notes
- Check out and run `npm ci` on the first commit - should fail with:
```
test/integration/server.test.ts(1660,47): error TS2345: Argument of type '{ id: string; message: { partyId: number; broadcastMessages: undefined[]; p2pMessages: undefined[]; publicKey: string; round: number; }; n: number; copayerId: any; }' is not assignable to parameter of type '{ id: string; message: ITssKeyMessageObject; n: number; copayerId: string; passwordHash?: string; version: number; timeLimit?: number; }'.
  Property 'version' is missing in type '{ id: string; message: { partyId: number; broadcastMessages: undefined[]; p2pMessages: undefined[]; publicKey: string; round: number; }; n: number; copayerId: any; }' but required in type '{ id: string; message: ITssKeyMessageObject; n: number; copayerId: string; passwordHash?: string; version: number; timeLimit?: number; }'.
lerna ERR! npm run compile exited 2 in '@bitpay-labs/bitcore-wallet-service'
```
- Check out and run `npm ci` on second commit - should pass.

<hr style="border-width:3px">

### Checklist
* [x] I have read [CONTRIBUTING.md](https://github.com/bitpay/bitcore/tree/master/CONTRIBUTING.md) and verified that this PR follows the guidelines and requirements outlined in it.